### PR TITLE
Add ability to optimize function calls with lambda in function position. Use it to optimize jss. <http://abcl.org/trac/ticket/420>

### DIFF
--- a/contrib/jss/invoke.lisp
+++ b/contrib/jss/invoke.lisp
@@ -286,8 +286,8 @@ want to avoid the overhead of the dynamic dispatch."
                               (group "group"))
       (loop while (hasmore entries)
          for name =  (getname (next entries))
-         with class-pattern = (#"compile" '|java.util.regex.Pattern| ".*\\.class$")
-         with name-pattern = (#"compile" '|java.util.regex.Pattern| ".*?([^.]*)$")
+         with class-pattern = (jstatic "compile" "java.util.regex.Pattern" ".*\\.class$")
+         with name-pattern = (jstatic "compile" "java.util.regex.Pattern" ".*?([^.]*)$")
          when (matches (matcher class-pattern name))
          collect
            (let* ((fullname (substring (jreplace name #\/ #\.) 0 (- (jlength name) 6)))

--- a/contrib/jss/invoke.lisp
+++ b/contrib/jss/invoke.lisp
@@ -123,6 +123,8 @@
   (defvar *do-auto-imports* t 
     "Whether to automatically introspect all Java classes on the classpath when JSS is loaded."))
 
+(defvar *muffle-warnings* t) 
+
 (defvar *imports-resolved-classes* (make-hash-table :test 'equalp))
 
 (defun find-java-class (name)
@@ -241,7 +243,7 @@ want to avoid the overhead of the dynamic dispatch."
                (with-constant-signature ,(cdr fname-jname-pairs)
                  ,@body)))))))
 
-(defun lookup-class-name (name)
+(defun lookup-class-name (name &key (muffle *muffle-warnings*))
   (setq name (string name))
   (let* (;; cant (last-name-pattern (#"compile" '|java.util.regex.Pattern| ".*?([^.]*)$"))
          ;; reason: bootstrap - the class name would have to be looked up...
@@ -263,7 +265,7 @@ want to avoid the overhead of the dynamic dispatch."
                  (ambiguous (choices)
                    (error "Ambiguous class name: ~a can be ~{~a~^, ~}" name choices)))
             (if (zerop bucket-length)
-		(progn (warn "can't find class named ~a" name) nil)
+		(progn (unless muffle (warn "can't find class named ~a" name)) nil)
                 (let ((matches (loop for el in bucket when (matches-end name el 'char=) collect el)))
                   (if (= (length matches) 1)
                       (car matches)
@@ -272,7 +274,7 @@ want to avoid the overhead of the dynamic dispatch."
                             (if (= (length matches) 1)
                                 (car matches)
                                 (if (= (length matches) 0)
-				    (progn (warn "can't find class named ~a" name) nil)
+				    (progn (unless muffle (warn "can't find class named ~a" name)) nil)
                                     (ambiguous matches))))
                           (ambiguous matches))))))))))
 

--- a/contrib/jss/jss.asd
+++ b/contrib/jss/jss.asd
@@ -1,16 +1,14 @@
 ;;;; -*- Mode: LISP -*-
 (asdf:defsystem :jss
   :author "Alan Ruttenberg, Mark Evenson"
-  :version "3.1.0" 
-  :description "<> asdf:defsystem <urn:abcl.org/release/1.5.0/contrib/jss#3.1.0>"
+  :version "3.1.1" 
+  :description "<> asdf:defsystem <urn:abcl.org/release/1.5.0/contrib/jss#3.1.1>"
   :components ((:module base 
                         :pathname "" :serial t 
                         :components ((:file "packages")
                                      (:file "invoke")
-				     (:file "optimize-java-call")
                                      (:file "classpath")
-                                     (:file "compat")
-				     ))))
+                                     (:file "compat")))))
 
 #+nil FIXME
 (asdf:defsystem :jss-tests

--- a/contrib/jss/jss.asd
+++ b/contrib/jss/jss.asd
@@ -7,8 +7,10 @@
                         :pathname "" :serial t 
                         :components ((:file "packages")
                                      (:file "invoke")
+				     (:file "optimize-java-call")
                                      (:file "classpath")
-                                     (:file "compat")))))
+                                     (:file "compat")
+				     ))))
 
 #+nil FIXME
 (asdf:defsystem :jss-tests

--- a/contrib/jss/optimize-java-call.lisp
+++ b/contrib/jss/optimize-java-call.lisp
@@ -1,0 +1,36 @@
+(in-package :jss)
+
+(defvar *inhibit-jss-optimization* nil)
+
+;; https://mailman.common-lisp.net/pipermail/armedbear-devel/2016-October/003726.html
+
+(precompiler::define-function-position-lambda-transform jss::invoke-restargs (arglist form args)
+  (declare (ignore arglist))
+  (unless *inhibit-jss-optimization*
+    (precompiler::precompile-function-call 
+     `(jss::invoke-restargs-macro
+	  ,(second form)
+	  ,(car args) (list ,@(cdr args)) ,(fifth form)))))
+
+(defmacro invoke-restargs-macro ( method object args &optional (raw? nil))
+  (assert (eq (car args) 'list))
+  (setq args (cdr args))
+  (if (and (consp object) (eq (car object) 'quote))
+      (let ((object (eval object)))
+	(let* ((object-as-class-name
+		 (if (symbolp object)
+		     (jss::maybe-resolve-class-against-imports object)
+		     ))
+	       (object-as-class
+		 (if object-as-class-name (find-java-class object-as-class-name))))
+	  (if raw?
+	      `(jstatic-raw ,method ,object-as-class ,@args)
+	      `(jstatic ,method ,object-as-class ,@args))))
+      (if raw?
+	  `(if (symbolp ,object)
+	       (jstatic-raw ,method (find-java-class ,object) ,@args)
+	       (jcall-raw ,method ,object ,@args))
+	  `(if (symbolp ,object)
+	       (jstatic ,method (find-java-class ,object) ,@args)
+	       (jcall ,method ,object ,@args)))))
+

--- a/contrib/jss/optimize-java-call.lisp
+++ b/contrib/jss/optimize-java-call.lisp
@@ -17,12 +17,9 @@
   (setq args (cdr args))
   (if (and (consp object) (eq (car object) 'quote))
       (let ((object (eval object)))
-	(let* ((object-as-class-name
-		 (if (symbolp object)
-		     (jss::maybe-resolve-class-against-imports object)
-		     ))
-	       (object-as-class
-		 (if object-as-class-name (find-java-class object-as-class-name))))
+	(let* ((object-as-class
+		 (or (ignore-errors (let ((*muffle-warnings* t)) (find-java-class object)))
+		     `(find-java-class ',object))))
 	  (if raw?
 	      `(jstatic-raw ,method ,object-as-class ,@args)
 	      `(jstatic ,method ,object-as-class ,@args))))
@@ -33,4 +30,6 @@
 	  `(if (symbolp ,object)
 	       (jstatic ,method (find-java-class ,object) ,@args)
 	       (jcall ,method ,object ,@args)))))
+
+
 

--- a/contrib/jss/packages.lisp
+++ b/contrib/jss/packages.lisp
@@ -5,6 +5,7 @@
    #:*inhibit-add-to-classpath*
    #:*added-to-classpath*
    #:*do-auto-imports*
+   #:*muffle-warnings*
 
    #:invoke-restargs
    #:with-constant-signature

--- a/contrib/jss/test-optimize-java-call.lisp
+++ b/contrib/jss/test-optimize-java-call.lisp
@@ -2,14 +2,14 @@
 
 (format t "~%~%")
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (setq *inhibit-jss-optimization* nil)
   (format t "With optimization: ~s~%" (macroexpand (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t))))
 
 (defun optimized-jss (count)
   (loop repeat count do (#"compile" 'regex.Pattern ".*")))
 
-(eval-when (:compile-toplevel :load-toplevel)
+(eval-when (:compile-toplevel :load-toplevel :execute)
   (setq *inhibit-jss-optimization* t)
   (format t "Without optimization: ~s~%" (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t)))
 

--- a/contrib/jss/test-optimize-java-call.lisp
+++ b/contrib/jss/test-optimize-java-call.lisp
@@ -1,0 +1,44 @@
+(in-package :jss)
+
+(format t "~%~%")
+
+(eval-when (:compile-toplevel :load-toplevel)
+  (setq *inhibit-jss-optimization* nil)
+  (format t "With optimization: ~s~%" (macroexpand (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t))))
+
+(defun optimized-jss (count)
+  (loop repeat count do (#"compile" 'regex.Pattern ".*")))
+
+(eval-when (:compile-toplevel :load-toplevel)
+  (setq *inhibit-jss-optimization* t)
+  (format t "Without optimization: ~s~%" (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t)))
+
+(defun unoptimized-jss (count)
+  (loop repeat count do (#"compile" 'regex.Pattern ".*")))
+
+(defun just-loop (count)
+  (loop repeat count))
+
+(print 'just-loop)
+(time (just-loop 10000))
+(print 'first)
+(time (optimized-jss 10000))
+(print 'second)
+(time (unoptimized-jss 10000))
+
+#|
+With optimization: (INVOKE-RESTARGS-MACRO "compile" (QUOTE REGEX.PATTERN) (LIST ".*") NIL T)
+Without optimization: ((LAMBDA (#:G85648 &REST #:G85649) (INVOKE-RESTARGS "compile" #:G85648 #:G85649 NIL)) (QUOTE REGEX.PATTERN) ".*")
+
+JUST-LOOP 
+0.0 seconds real time
+0 cons cells
+
+OPTIMIZED-JSS
+0.011 seconds real time
+0 cons cells
+
+UNOPTIMIZED-JSS
+0.325 seconds real time
+800156 cons cells
+|#

--- a/src/org/armedbear/lisp/precompiler.lisp
+++ b/src/org/armedbear/lisp/precompiler.lisp
@@ -414,13 +414,13 @@
 		;; simplest case - we have a simple arglist with as many
 		;; arguments as call args. Transform to let.
 		(return-from precompile-function-position-lambda
-		  `((let* ,(append
+		  `(let* ,(append
 			    (loop for arg-name in arglist
 				  for arg in (mapcar #'precompile1 args)
 				  until (eq arg-name '&aux)
 				  collect (list arg-name arg))
 			    (subseq arglist (1+ arglist-length)))
-		      ,@body)))
+		      ,@body))
 		(error "Argument mismatch for lambda in function position: ~a applied to ~a" `(lambda ,arglist body) args)))))))
 
 (defmacro define-function-position-lambda-transform (body-function-name (arglist form args) &body body)

--- a/src/org/armedbear/lisp/precompiler.lisp
+++ b/src/org/armedbear/lisp/precompiler.lisp
@@ -382,8 +382,9 @@
   (let ((op (car form)))
     (when (and (consp op) (eq (%car op) 'LAMBDA))
       (return-from precompile-function-call
-                   (cons (precompile-lambda op)
-                         (mapcar #'precompile1 (cdr form)))))
+	(or (precompile-function-position-lambda op (cdr form))
+	    (cons (precompile-lambda op)
+		  (mapcar #'precompile1 (cdr form))))))
     (when (or (not *in-jvm-compile*) (notinline-p op))
       (return-from precompile-function-call (precompile-cons form)))
     (when (source-transform op)
@@ -398,6 +399,34 @@
               (format t ";   inlining call to ~S~%" op)))
           (return-from precompile-function-call (precompile1 (expand-inline form expansion))))))
     (cons op (mapcar #'precompile1 (cdr form)))))
+
+(defun precompile-function-position-lambda (lambda args)
+  (let* ((arglist (second lambda))
+	 (body (cddr lambda))
+	 (simple-arglist? (not (or (memq '&KEY arglist) (memq '&OPTIONAL arglist) (memq '&REST arglist)))))
+    (or
+     ;;give a chance for someone to transform single-form function bodies
+     (and (= (length body) 1) (consp (car body)) (get (caar body) 'sys::function-position-lambda-transform)
+	  (funcall (get (caar body) 'sys::function-position-lambda-transform) (caar body) (car body) (mapcar #'precompile1 args)))
+     (and simple-arglist?
+	  (let ((arglist-length (if (memq '&aux arglist) (position '&aux arglist) (length arglist))))
+	    (if (= (length args) arglist-length)
+		;; simplest case - we have a simple arglist with as many
+		;; arguments as call args. Transform to let.
+		(return-from precompile-function-position-lambda
+		  `((let* ,(append
+			    (loop for arg-name in arglist
+				  for arg in (mapcar #'precompile1 args)
+				  until (eq arg-name '&aux)
+				  collect (list arg-name arg))
+			    (subseq arglist (1+ arglist-length)))
+		      ,@body)))
+		(error "Argument mismatch for lambda in function position: ~a applied to ~a" `(lambda ,arglist body) args)))))))
+
+(defmacro define-function-position-lambda-transform (body-function-name (arglist form args) &body body)
+  `(put ',body-function-name 'sys::function-position-lambda-transform 
+	#'(lambda(,arglist ,form ,args)
+	    ,@body)))
 
 (defun precompile-locally (form)
   (let ((*inline-declarations* *inline-declarations*))


### PR DESCRIPTION
Precompiler: When compiling a form with a lambda in the function
position, possibly optimize it

Case 1: If the lambda has a single form in it, let someone define a
transform using:

define-function-position-lambda-transform (body-function-name (arglist form args) &body body)

body-function-name is the car of the single form in the lambda
arglist is the arglist of the lambda
form is the single form within the lambda
args are the arguments to which the lambda will be defined.

The function should check whether it can do a transform, and do it if
so, otherwise return nil signalling it couldn't

Case 2: If case 1 is not successful then if the arglist is a simple
one (no &key, &rest, &optional) then do a standard beta-reduction
binding the args to arglist using let (https://wiki.haskell.org/Beta_reduction)

If not, return and do the usual thing.

An example is in contrib/jss/optimize-java-call.lisp

To see benefits, (compile-file contrib/jss/test-optimize-java-call.lisp)
and then load the compiled file. You should see something like the below
which reports the timings for the optimized and unoptimized version of
10000 calls of (#"compile" 'regex.pattern ".*")

--

With optimization: (INVOKE-RESTARGS-MACRO "compile" (QUOTE REGEX.PATTERN) (LIST ".*") NIL T)
Without optimization: ((LAMBDA (#:G85648 &REST #:G85649) (INVOKE-RESTARGS "compile" #:G85648 #:G85649 NIL)) (QUOTE REGEX.PATTERN) ".*")

JUST-LOOP
0.0 seconds real time
0 cons cells

OPTIMIZED-JSS
0.011 seconds real time
0 cons cells

UNOPTIMIZED-JSS
0.325 seconds real time
800156 cons cells

See:
https://mailman.common-lisp.net/pipermail/armedbear-devel/2016-October/003726.html
https://mailman.common-lisp.net/pipermail/armedbear-devel/2016-November/003733.html