### PR TITLE
Figured out how to let arglist get saved during build. Record source …

### DIFF
--- a/src/org/armedbear/lisp/fdefinition.lisp
+++ b/src/org/armedbear/lisp/fdefinition.lisp
@@ -109,7 +109,6 @@ called early in build when many of the sequence functions aren't
 present.  Will probably just filter when presenting in slime.
 
 |#  
-  (unless SYS::*LOAD-TRUENAME-FASL*
     (unless source-pathname
       (setf source-pathname (or *source* :top-level)))
     (unless source-position
@@ -117,8 +116,12 @@ present.  Will probably just filter when presenting in slime.
     (let ((source (if source-position
 		      (list source-pathname source-position)
 		      (list source-pathname))))
-      (let ((sym (if (consp name) (second name) name)))
-	(put sym 'sys::source (cons `(,type ,(if (symbolp (car source)) (car source) (namestring (car source))) ,(second source)) (get sym  'sys::source nil)))))))
+      (let ((sym (if (consp name) (second name) name))
+            (new `(,type ,(if (symbolp (car source)) (car source) (namestring (car source))) ,(second source))))
+        (if (autoloadp 'delete)
+ 	 (put sym 'sys::source (cons new (get sym  'sys::source nil)))
+         (put sym 'sys::source (cons new (delete new (get sym  'sys::source nil) 
+               :test (lambda(a b) (and (equalp (car a) (car b)) (equalp (second a) (second b) ))))))))))
 
 ;; Redefined in trace.lisp.
 (defun trace-redefined-update (&rest args)

--- a/src/org/armedbear/lisp/fdefinition.lisp
+++ b/src/org/armedbear/lisp/fdefinition.lisp
@@ -132,6 +132,8 @@ present.  Will probably just filter when presenting in slime.
   (declare (ignore name))
   nil)
 
+(%defvar '*fset-hooks* nil)
+
 (defun fset (name function &optional source-position arglist documentation)
   (cond ((symbolp name)
          (check-redefinition name)
@@ -149,6 +151,7 @@ present.  Will probably just filter when presenting in slime.
          (require-type name '(or symbol (cons (eql setf) (cons symbol null))))))
   (when (functionp function) ; FIXME Is this test needed?
     (%set-lambda-name function name))
+  (dolist (hook *fset-hooks*) (ignore-errors (funcall hook name function)))
   (trace-redefined-update name function)
   function)
 

--- a/src/org/armedbear/lisp/precompiler.lisp
+++ b/src/org/armedbear/lisp/precompiler.lisp
@@ -1191,29 +1191,35 @@
                            ,@decls
                            ,@(when doc `(,doc))
                            (block ,block-name ,@body))))
-      (cond ((and (boundp 'jvm::*file-compilation*)
-                  ;; when JVM.lisp isn't loaded yet, this variable isn't bound
-                  ;; meaning that we're not trying to compile to a file:
-                  ;; Both COMPILE and COMPILE-FILE bind this variable.
-                  ;; This function is also triggered by MACROEXPAND, though
-                  jvm::*file-compilation*)
-             `(progn
-                (fset ',name ,lambda-expression)
-                ',name))
-            (t
-	     (when (and env (empty-environment-p env))
-               (setf env nil))
-             (when (null env)
-               (setf lambda-expression (precompiler:precompile-form lambda-expression nil)))
-	     (let ((sym (if (consp name) (second name) name)))
-	       `(prog1
-		    (%defun ',name ,lambda-expression)
-		  (record-source-information-for-type ',sym '(:function ,name))
-;		  (%set-arglist (fdefinition ',name) ,(format nil "~{~s~^ ~}" (third lambda-expression)))
+	(cond ((and (boundp 'jvm::*file-compilation*)
+		    ;; when JVM.lisp isn't loaded yet, this variable isn't bound
+		    ;; meaning that we're not trying to compile to a file:
+		    ;; Both COMPILE and COMPILE-FILE bind this variable.
+		    ;; This function is also triggered by MACROEXPAND, though
+		    jvm::*file-compilation*)
+	       `(progn
+		  (fset ',name ,lambda-expression)
+		  ;; the below matter, for example when loading a compiled defun that is inside some other form (e.g. flet)
+		  (record-source-information-for-type ',(if (consp name) (second name) name) '(:function ,name))
+		  (%set-arglist (fdefinition ',name) ',(third lambda-expression))
 		  ,@(when doc
 		      `((%set-documentation ',name 'function ,doc)))
-		  )))))))
-
+		  ',name))
+	      (t
+	       (when (and env (empty-environment-p env))
+		 (setf env nil))
+	       (when (null env)
+		 (setf lambda-expression (precompiler:precompile-form lambda-expression nil)))
+	       (let ((sym (if (consp name) (second name) name)))
+		 `(prog1
+		      (%defun ',name ,lambda-expression)
+		    (record-source-information-for-type ',sym '(:function ,name))
+		    (%set-arglist (fdefinition ',name) ',(third lambda-expression))
+		    ;; don't do this. building abcl fails autoloading stuff it shouldn't yet
+		    ;; (%set-arglist (symbol-function ',name) ,(format nil "~{~s~^ ~}" (third lambda-expression)))
+		    ,@(when doc
+			`((%set-documentation ',name 'function ,doc)))
+		    )))))))
 (export '(precompile))
 
 ;;(provide "PRECOMPILER")


### PR DESCRIPTION
…etc. for top-level closures. Also, once #'delete is available, don't allow duplicate source entries