### PR TITLE
ABCL Introspect - Support for new slime debugger functionality

### DIFF
--- a/contrib/abcl-introspect.lisp
+++ b/contrib/abcl-introspect.lisp
@@ -1,0 +1,348 @@
+(in-package :system)
+
+;; Author: Alan Ruttenberg December 2016
+
+;; This code is released under Creative Common CC0 declaration
+;; (https://wiki.creativecommons.org/wiki/CC0) and as such is intended
+;; to be in the public domain.
+
+
+;; A compiled function is an instance of a class - This class has
+;; multiple instances if it represents a closure, or a single instance if
+;; it represents a non-closed-over function.
+
+;; The ABCL compiler stores constants that are used in function execution
+;; as private java fields. This includes symbols used to invoke function,
+;; locally-defined functions (such as via labels or flet) and string and
+;; other literal constants.
+
+;; This file provides access to those internal values, and uses them in
+;; at least two ways. First, to annotate locally defined functions with
+;; the top-level function they are defined within, and second to search
+;; for callers of a give function(*). This may yield some false
+;; positives, such as when a symbol that names a function is also used
+;; for some other purpose. It can also have false negatives, as when a
+;; function is inlined. Still, it's pretty useful. The second use to to
+;; find source locations for frames in the debugger. If the source
+;; location for a local function is asked for the location of its 'owner'
+;; is instead returns.
+
+;; (*) Since java functions are strings, local fields also have these
+;; strings. In the context of looking for callers of a function you can
+;; also give a string that names a java method. Same caveat re: false
+;; positives.
+
+;; In order to record information about local functions, ABCL defines a
+;; function-plist, which is for the most part unused, but is used here
+;; with set of keys indicating where the local function was defined and
+;; in what manner, i.e. as normal local function, as a method function,
+;; or as an initarg function. There may be other places functions are
+;; stashed away (defstructs come to mind) and this file should be added
+;; to to take them into account as they are discovered.
+
+;; This file does not depend on jss, but provides a bit of
+;; jss-specific functionality if jss *is* loaded.
+
+(defun function-internal-fields (f)
+  "return a list of values of fields declared in the class implementing the function"
+  (if (symbolp f) 
+      (setq f (symbol-function f)))
+  ;; think about other fields
+  (let ((fields (java::jcall "getDeclaredFields" (java::jcall "getClass" f))))
+    (loop for field across fields
+	  do (java::jcall "setAccessible" field t)
+	  collect
+	  (java::jcall "get" field f))))
+
+(defun function-internals (f)
+  "internal fields + closed-over values"
+  (append (function-internal-fields f)
+	  (and (java::jcall "isInstance" (java::jclass "org.armedbear.lisp.CompiledClosure") f)
+	       (compiled-closure-context f))))
+
+(defun compiled-closure-context (f)
+  "For compiled closures, the values closed over"
+  (let ((context (java::jcall "get" (load-time-value (java::jclass-field "org.armedbear.lisp.CompiledClosure" "ctx")) f)))
+    (loop for binding across context
+	  collect 
+	  (java::jcall "get" (load-time-value (java::jclass-field "org.armedbear.lisp.ClosureBinding" "value")) binding))))
+   
+(defun foreach-internal-field (fn-fn not-fn-fn &optional (fns :all) (definer nil))
+  "fn-n gets called with top, internal function, not-fn-fn gets called with top anything-but"
+  (declare (optimize (speed 3) (safety 0)))
+  (macrolet ((fields (c) `(java::jcall ,(java::jmethod "java.lang.Class" "getDeclaredFields") ,c))
+	     (get (f i) `(java::jcall ,(java::jmethod "java.lang.reflect.Field" "get" "java.lang.Object") ,f ,i))
+	     (access (f b) `(java::jcall ,(java::jmethod "java.lang.reflect.AccessibleObject" "setAccessible" "boolean") ,f ,b))
+	     (getclass (o) `(java::jcall ,(java::jmethod "java.lang.Object" "getClass") ,o)))
+    (labels ((function-internal-fields (f)
+	       (if (symbolp f) 
+		   (setq f (symbol-function f)))
+	       (let ((fields (fields (getclass f))))
+		 (loop for field across fields
+		       do (access field t)
+		       collect
+		       (get field f))))
+	     (check (f top seen)
+	       (declare (optimize (speed 3) (safety 0)))
+	       (dolist (el (function-internal-fields f))
+		 (if (functionp el)
+		     (let ((name? (third (multiple-value-list (function-lambda-expression el)))))
+		       (if (or (consp name?) (and name? (fboundp name?) (eq el (symbol-function name?))) )
+			   (progn
+			     (when not-fn-fn (funcall not-fn-fn top name?))
+			     (when (not (member el seen :test #'eq))
+			       (push el seen)
+			       (check el top seen)))
+			   (when (not (member el seen :test #'eq))
+			     (when fn-fn (funcall fn-fn top el))
+			     (push el seen)
+			     (check el top seen))))
+		     (when not-fn-fn 
+		       (funcall not-fn-fn top el)
+		       )))))
+      (if (eq fns :all)
+	  (progn
+	    (dolist (p (list-all-packages))
+	    (do-symbols (s p)
+	      (when (fboundp s)
+		(check (symbol-function s) s nil))))
+	    (each-non-symbol-compiled-function (lambda (definer f) (check f definer nil))))
+	  (dolist (f fns) 
+	    (check (if (not (symbolp f)) f  (symbol-function f)) (or definer f) nil))
+	  ))))
+
+(defun callers (thing &aux them)
+  (foreach-internal-field
+   nil
+   (lambda(top el)
+     (when (equal el thing)
+       (pushnew top them)
+       )))
+  them)
+
+(defun annotate-internal-functions (&optional (fns :all) definer)
+  "Iterate over functions reachable from arg fns (all functions
+   if :all). When not a top-level function add
+   key: :internal-to-function value top-level thing in which the
+   function is defined. definers are the top-level functions, This
+   gets called after fset"
+  (foreach-internal-field
+   (lambda(top internal)
+     (unless (eq (if (symbolp top) (symbol-function top) top) internal)
+       (setf (getf (function-plist internal) :internal-to-function) (or definer top))
+       ))
+   nil
+   fns
+   definer))
+
+(defun annotate-clos-methods (&optional (which :all))
+  "Iterate over all clos methods, marking method-functions and
+method-fast-functions with the function plist
+indicator :method-function or :method-fast-function, value the method
+object. This gets called once."
+  (flet ((annotate (method)
+	   (let ((method-function (mop::std-method-function method))
+		 (fast-function  (mop::std-method-fast-function method)))
+	     (when (and method-function (compiled-function-p method-function)) 
+	       (setf (getf (function-plist method-function) :method-function) method)
+	       (annotate-internal-functions (list method-function) method))
+	     (when (and fast-function (compiled-function-p fast-function))
+	       (setf (getf (function-plist fast-function) :method-fast-function) method)
+	       (annotate-internal-functions (list fast-function) method)))))
+      (if (eq which :all)
+	  (loop for q = (list (find-class t)) then q
+		for focus = (pop q)
+		while focus
+		do (setq q (append q (mop::class-direct-subclasses  focus)))
+		   (loop for method in (mop::class-direct-methods focus)
+			 do (annotate method)))
+
+	  (dolist (f which)
+	    (annotate f)
+	    ))))
+
+(defun annotate-clos-slots (&optional (which :all))
+  "Iterate over all clos slots, marking compile-initarg functions as :initfunction value slot"
+  (flet ((annotate (slot)
+	   (let ((initfunction (and (slot-boundp slot 'initfunction)
+				    (slot-value slot 'initfunction))))
+	     (when initfunction
+	       (setf (getf (function-plist initfunction) :initfunction) slot)
+	       (annotate-internal-functions (list initfunction) slot)))))
+    (if (eq which :all)
+	(loop for q = (list (find-class t)) then q
+	      for focus = (pop q)
+	      while focus
+	      do (setq q (append q (mop::class-direct-subclasses  focus)))
+		 (loop for slot in (mop::class-direct-slots focus)
+		       do (annotate slot)))
+	(dolist (f which)
+	  (annotate f)
+	  ))))
+
+(defun method-spec-list (method)
+  "Given a method object, translate it into specification (name qualifiers specializers)"
+  `(,(mop::generic-function-name  (mop::method-generic-function method))
+    ,(mop::method-qualifiers method) 
+    ,(mapcar #'(lambda (c)
+		 (if (typep c 'mop:eql-specializer)
+		     `(eql ,(mop:eql-specializer-object c))
+		     (class-name c)))
+	     (mop:method-specializers method))))
+
+;; function names for printing, inspection and in the debugger
+
+(defun any-function-name (function &aux it)
+  "Compute function name based on the actual function name, if it is a
+named function or the values on the function-plist that functions
+above have used annotate local functions"
+  (maybe-jss-function function)
+  (let ((plist (sys::function-plist function)))
+    (cond ((setq it (getf plist :internal-to-function))
+	   `(:local-function ,@(if (java::jcall "getLambdaName" function) 
+				   (list (java::jcall "getLambdaName" function))
+				   (if (getf plist :jss-function)
+				       (list (concatenate 'string "#\"" (getf plist :jss-function) "\"")))
+				   )
+			     :in ,@(if (typep it 'mop::standard-method)
+				       (cons :method (method-spec-list it))
+				       (list it))))
+	  ((setq it (getf plist :method-function))
+	   (cons :method-function (sys::method-spec-list it)))	   
+	  ((setq it (getf plist :method-fast-function))
+	   (cons :method-fast-function (sys::method-spec-list it)))
+	  ((setq it (getf plist :initfunction))
+	   (let ((class (and (slot-boundp it 'allocation-class) (slot-value it 'allocation-class))))
+	     (list :slot-initfunction (slot-value it 'name ) :for (if class (class-name class) '??))))
+	  (t (or (nth-value 2 (function-lambda-expression function))
+		 (and (not (compiled-function-p function))
+		      `(:anonymous-interpreted-function))
+		 (function-name-by-where-loaded-from function))))))
+
+(defun function-name-by-where-loaded-from (function)
+  "name of last resource - used the loaded-from field from the function to construct the name"
+  (let* ((class (java::jcall "getClass" function))
+	 (loaded-from (sys::get-loaded-from function))
+	 (name (java::jcall "replace" (java::jcall "getName" class) "org.armedbear.lisp." ""))
+	 (where (and loaded-from (concatenate 'string (pathname-name loaded-from) "." (pathname-type loaded-from)))))
+    `(:anonymous-function ,name ,@(if (sys::arglist function)  (sys::arglist function)) 
+			  ,@(if where (list (list :from where))))))
+  
+(defun maybe-jss-function (f)
+  "Determing if function is something list #"foo" called as a
+  function. If so add to function internal plist :jss-function and the
+  name of the java methods"
+  (and (find-package :jss)
+       (or (getf (sys::function-plist f) :jss-function)
+	   (let ((internals (function-internal-fields f)))
+	     (and (= (length internals) 2)
+		  (eq (second internals) (intern "INVOKE-RESTARGS" :jss))
+		  (stringp (first internals))
+		  (setf (getf (sys::function-plist f) :jss-function) (first internals)))))))
+	 
+(defun local-function-p (function)
+  "Helper function. Tests whether a function wasn't defined at top
+  level based on function-plist annotations"
+  (and (functionp function)
+       (let ((plist  (sys::function-plist function)))
+	 (or (getf plist :internal-to-function)
+	     (getf plist :method-function)
+	     (getf plist :method-fast-function)
+	     (getf plist :slot-initfunction)))))
+
+(defun local-function-owner (function)
+  "For local function, return the 'owner' typically the top-level function or clos method"
+  (local-function-p function))
+
+(defmethod print-object ((f function) stream)
+  "Print a function using any-function-name. Requires a patch to
+  system::output-ugly-object in order to prevent the function being
+  printed by a java primitive"
+  (print-unreadable-object (f stream :identity t)
+    (let ((name (any-function-name  f)))
+       (if (consp name)
+           (format stream "~{~a~^ ~}" name)
+           (princ name stream)))))
+
+(defun each-non-symbol-compiled-function (f)
+  (loop for q = (list (find-class t)) then q
+	for focus = (pop q)
+	while focus
+	do (setq q (append q (mop::class-direct-subclasses  focus)))
+	   (loop for method in (mop::class-direct-methods focus)
+		 do (when (compiled-function-p (mop::method-function method)) (funcall f method (mop::method-function method))))
+	   (loop for slot in (mop::class-direct-slots focus)
+		 for initfunction = (and (slot-boundp slot 'initfunction) (slot-value slot 'initfunction))
+		 do (and initfunction (compiled-function-p initfunction) (funcall f slot initfunction)))))
+                                
+;; hooks into defining 
+ 
+(defvar *fset-hooks* nil "functions on this list get called with name and function *after* the symbol-function is set")
+
+(defvar *annotate-function-backlog?* t "true before this file has been loaded and function annotations are placed")
+
+(defun fset-hook-annotate-internal-function (name function)
+  "Called at the end of fset. If function annotations have not yet
+  been added, add local function annotations to all functions. If not,
+  just add annotations to function specified in the arglist"
+  (declare (ignore function))
+  (when *annotate-function-backlog?* 
+    (setq *annotate-function-backlog?* nil)
+    (annotate-internal-functions)
+    (annotate-clos-methods)
+    (annotate-clos-slots)
+    )
+  (annotate-internal-functions (list name)))
+
+;; Here we hook into clos in order to have method and slot functions
+;; annotated when they are defined.
+
+(defmethod mop::add-direct-method :after (class method)
+  (annotate-clos-methods (list method)))
+
+(defmethod mop::ensure-class-using-class :after (class name  &key direct-slots
+                                             direct-default-initargs 
+                                             &allow-other-keys)
+  (annotate-clos-slots (mop::class-direct-slots (find-class name))))
+
+;; needs to be the last thing. Some interaction with the fasl loader
+(pushnew 'fset-hook-annotate-internal-function sys::*fset-hooks*)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+		 
+(defun get-pid ()
+  "Get the process identifier of this lisp process. Used to be in
+  slime but generally useful, so now back in abcl proper."
+  (handler-case
+      (let* ((runtime
+              (java::jstatic "getRuntime" "java.lang.Runtime"))
+             (command
+              (java::jnew-array-from-array
+               "java.lang.String" #("sh" "-c" "echo $PPID")))
+             (runtime-exec-jmethod
+              ;; Complicated because java.lang.Runtime.exec() is
+              ;; overloaded on a non-primitive type (array of
+              ;; java.lang.String), so we have to use the actual
+              ;; parameter instance to get java.lang.Class
+              (java::jmethod "java.lang.Runtime" "exec"
+                            (java::jcall
+                             (java::jmethod "java.lang.Object" "getClass")
+                             command)))
+             (process
+              (java::jcall runtime-exec-jmethod runtime command))
+             (output
+              (java::jcall (java::jmethod "java.lang.Process" "getInputStream")
+                          process)))
+         (java::jcall (java::jmethod "java.lang.Process" "waitFor")
+                     process)
+	 (loop :with b :do
+	    (setq b
+		  (java::jcall (java::jmethod "java.io.InputStream" "read")
+			      output))
+	    :until (member b '(-1 #x0a))	; Either EOF or LF
+	    :collecting (code-char b) :into result
+	    :finally (return
+		       (parse-integer (coerce result 'string)))))
+    (t () 0)))
+
+(provide :abcl-introspect)

--- a/contrib/abcl-introspect/abcl-introspect.asd
+++ b/contrib/abcl-introspect/abcl-introspect.asd
@@ -1,0 +1,11 @@
+;;;; -*- Mode: LISP -*-
+(in-package :cl-user)
+
+(asdf:defsystem :abcl-introspect
+  :author "Alan Ruttenberg"
+  :version "1.0.0"
+  :description "Introspection on compiled function to aid source location other debugging functions.ñ"
+  :depends-on ()
+  :components 
+  ((:file "abcl-introspect"))
+  )

--- a/contrib/abcl-introspect/abcl-introspect.lisp
+++ b/contrib/abcl-introspect/abcl-introspect.lisp
@@ -1,0 +1,349 @@
+(in-package :system)
+
+;; Author: Alan Ruttenberg December 2016
+
+;; This code is released under Creative Common CC0 declaration
+;; (https://wiki.creativecommons.org/wiki/CC0) and as such is intended
+;; to be in the public domain.
+
+
+;; A compiled function is an instance of a class - This class has
+;; multiple instances if it represents a closure, or a single instance if
+;; it represents a non-closed-over function.
+
+;; The ABCL compiler stores constants that are used in function execution
+;; as private java fields. This includes symbols used to invoke function,
+;; locally-defined functions (such as via labels or flet) and string and
+;; other literal constants.
+
+;; This file provides access to those internal values, and uses them in
+;; at least two ways. First, to annotate locally defined functions with
+;; the top-level function they are defined within, and second to search
+;; for callers of a give function(*). This may yield some false
+;; positives, such as when a symbol that names a function is also used
+;; for some other purpose. It can also have false negatives, as when a
+;; function is inlined. Still, it's pretty useful. The second use to to
+;; find source locations for frames in the debugger. If the source
+;; location for a local function is asked for the location of its 'owner'
+;; is instead returns.
+
+;; (*) Since java functions are strings, local fields also have these
+;; strings. In the context of looking for callers of a function you can
+;; also give a string that names a java method. Same caveat re: false
+;; positives.
+
+;; In order to record information about local functions, ABCL defines a
+;; function-plist, which is for the most part unused, but is used here
+;; with set of keys indicating where the local function was defined and
+;; in what manner, i.e. as normal local function, as a method function,
+;; or as an initarg function. There may be other places functions are
+;; stashed away (defstructs come to mind) and this file should be added
+;; to to take them into account as they are discovered.
+
+;; This file does not depend on jss, but provides a bit of
+;; jss-specific functionality if jss *is* loaded.
+
+(defun function-internal-fields (f)
+  "return a list of values of fields declared in the class implementing the function"
+  (if (symbolp f) 
+      (setq f (symbol-function f)))
+  ;; think about other fields
+  (let ((fields (java::jcall "getDeclaredFields" (java::jcall "getClass" f))))
+    (loop for field across fields
+	  do (java::jcall "setAccessible" field t)
+	  collect
+	  (java::jcall "get" field f))))
+
+(defun function-internals (f)
+  "internal fields + closed-over values"
+  (append (function-internal-fields f)
+	  (and (java::jcall "isInstance" (java::jclass "org.armedbear.lisp.CompiledClosure") f)
+	       (compiled-closure-context f))))
+
+(defun compiled-closure-context (f)
+  "For compiled closures, the values closed over"
+  (let ((context (java::jcall "get" (load-time-value (java::jclass-field "org.armedbear.lisp.CompiledClosure" "ctx")) f)))
+    (loop for binding across context
+	  collect 
+	  (java::jcall "get" (load-time-value (java::jclass-field "org.armedbear.lisp.ClosureBinding" "value")) binding))))
+   
+(defun foreach-internal-field (fn-fn not-fn-fn &optional (fns :all) (definer nil))
+  "fn-n gets called with top, internal function, not-fn-fn gets called with top anything-but"
+  (declare (optimize (speed 3) (safety 0)))
+  (macrolet ((fields (c) `(java::jcall (setq @ ,(java::jmethod "java.lang.Class" "getDeclaredFields")) ,c))
+	     (get (f i) `(java::jcall (setq @ ,(java::jmethod "java.lang.reflect.Field" "get" "java.lang.Object")) ,f ,i))
+	     (access (f b) `(java::jcall (setq @ ,(java::jmethod "java.lang.reflect.AccessibleObject" "setAccessible" "boolean")) ,f ,b))
+	     (getclass (o) `(java::jcall (setq @ ,(java::jmethod "java.lang.Object" "getClass")) ,o))
+	     (name (o) `(java::jcall (setq @ ,(java::jmethod "org.armedbear.lisp.Operator" "getLambdaName")) ,o)))
+    (labels ((function-internal-fields (f)
+	       (if (symbolp f) 
+		   (setq f (symbol-function f)))
+	       (let ((fields (fields (getclass f))))
+		 (loop for field across fields
+		       do (access field t)
+		       collect
+		       (get field f))))
+	     (check (f top seen)
+	       (declare (optimize (speed 3) (safety 0)))
+	       (dolist (el (function-internal-fields f))
+		 (if (functionp el)
+		     (let ((name? (name el)))
+		       (if (or (consp name?) (and name? (fboundp name?) (eq el (symbol-function name?))) )
+			   (progn
+			     (when not-fn-fn (funcall not-fn-fn top name?))
+			     (when (not (member el seen :test #'eq))
+			       (push el seen)
+			       (check el top seen)))
+			   (when (not (member el seen :test #'eq))
+			     (when fn-fn (funcall fn-fn top el))
+			     (push el seen)
+			     (check el top seen))))
+		     (when not-fn-fn 
+		       (funcall not-fn-fn top el)
+		       )))))
+      (if (eq fns :all)
+	  (progn
+	    (dolist (p (list-all-packages))
+	    (do-symbols (s p)
+	      (when (fboundp s)
+		(check (symbol-function s) s nil))))
+	    (each-non-symbol-compiled-function (lambda (definer f) (check f definer nil))))
+	  (dolist (f fns) 
+	    (check (if (not (symbolp f)) f  (symbol-function f)) (or definer f) nil))
+	  ))))
+
+(defun callers (thing &aux them)
+  (foreach-internal-field
+   nil
+   (lambda(top el)
+     (when (equal el thing)
+       (pushnew top them)
+       )))
+  them)
+
+(defun annotate-internal-functions (&optional (fns :all) definer)
+  "Iterate over functions reachable from arg fns (all functions
+   if :all). When not a top-level function add
+   key: :internal-to-function value top-level thing in which the
+   function is defined. definers are the top-level functions, This
+   gets called after fset"
+  (foreach-internal-field
+   (lambda(top internal)
+     (unless (eq (if (symbolp top) (symbol-function top) top) internal)
+       (setf (getf (function-plist internal) :internal-to-function) (or definer top))
+       ))
+   nil
+   fns
+   definer))
+
+(defun annotate-clos-methods (&optional (which :all))
+  "Iterate over all clos methods, marking method-functions and
+method-fast-functions with the function plist
+indicator :method-function or :method-fast-function, value the method
+object. This gets called once."
+  (flet ((annotate (method)
+	   (let ((method-function (mop::std-method-function method))
+		 (fast-function  (mop::std-method-fast-function method)))
+	     (when (and method-function (compiled-function-p method-function)) 
+	       (setf (getf (function-plist method-function) :method-function) method)
+	       (annotate-internal-functions (list method-function) method))
+	     (when (and fast-function (compiled-function-p fast-function))
+	       (setf (getf (function-plist fast-function) :method-fast-function) method)
+	       (annotate-internal-functions (list fast-function) method)))))
+      (if (eq which :all)
+	  (loop for q = (list (find-class t)) then q
+		for focus = (pop q)
+		while focus
+		do (setq q (append q (mop::class-direct-subclasses  focus)))
+		   (loop for method in (mop::class-direct-methods focus)
+			 do (annotate method)))
+
+	  (dolist (f which)
+	    (annotate f)
+	    ))))
+
+(defun annotate-clos-slots (&optional (which :all))
+  "Iterate over all clos slots, marking compile-initarg functions as :initfunction value slot"
+  (flet ((annotate (slot)
+	   (let ((initfunction (and (slot-boundp slot 'initfunction)
+				    (slot-value slot 'initfunction))))
+	     (when initfunction
+	       (setf (getf (function-plist initfunction) :initfunction) slot)
+	       (annotate-internal-functions (list initfunction) slot)))))
+    (if (eq which :all)
+	(loop for q = (list (find-class t)) then q
+	      for focus = (pop q)
+	      while focus
+	      do (setq q (append q (mop::class-direct-subclasses  focus)))
+		 (loop for slot in (mop::class-direct-slots focus)
+		       do (annotate slot)))
+	(dolist (f which)
+	  (annotate f)
+	  ))))
+
+(defun method-spec-list (method)
+  "Given a method object, translate it into specification (name qualifiers specializers)"
+  `(,(mop::generic-function-name  (mop::method-generic-function method))
+    ,(mop::method-qualifiers method) 
+    ,(mapcar #'(lambda (c)
+		 (if (typep c 'mop:eql-specializer)
+		     `(eql ,(mop:eql-specializer-object c))
+		     (class-name c)))
+	     (mop:method-specializers method))))
+
+;; function names for printing, inspection and in the debugger
+
+(defun any-function-name (function &aux it)
+  "Compute function name based on the actual function name, if it is a
+named function or the values on the function-plist that functions
+above have used annotate local functions"
+  (maybe-jss-function function)
+  (let ((plist (sys::function-plist function)))
+    (cond ((setq it (getf plist :internal-to-function))
+	   `(:local-function ,@(if (java::jcall "getLambdaName" function) 
+				   (list (java::jcall "getLambdaName" function))
+				   (if (getf plist :jss-function)
+				       (list (concatenate 'string "#\"" (getf plist :jss-function) "\"")))
+				   )
+			     :in ,@(if (typep it 'mop::standard-method)
+				       (cons :method (method-spec-list it))
+				       (list it))))
+	  ((setq it (getf plist :method-function))
+	   (cons :method-function (sys::method-spec-list it)))	   
+	  ((setq it (getf plist :method-fast-function))
+	   (cons :method-fast-function (sys::method-spec-list it)))
+	  ((setq it (getf plist :initfunction))
+	   (let ((class (and (slot-boundp it 'allocation-class) (slot-value it 'allocation-class))))
+	     (list :slot-initfunction (slot-value it 'name ) :for (if class (class-name class) '??))))
+	  (t (or (nth-value 2 (function-lambda-expression function))
+		 (and (not (compiled-function-p function))
+		      `(:anonymous-interpreted-function))
+		 (function-name-by-where-loaded-from function))))))
+
+(defun function-name-by-where-loaded-from (function)
+  "name of last resource - used the loaded-from field from the function to construct the name"
+  (let* ((class (java::jcall "getClass" function))
+	 (loaded-from (sys::get-loaded-from function))
+	 (name (java::jcall "replace" (java::jcall "getName" class) "org.armedbear.lisp." ""))
+	 (where (and loaded-from (concatenate 'string (pathname-name loaded-from) "." (pathname-type loaded-from)))))
+    `(:anonymous-function ,name ,@(if (sys::arglist function)  (sys::arglist function)) 
+			  ,@(if where (list (list :from where))))))
+  
+(defun maybe-jss-function (f)
+  "Determing if function is something list #"foo" called as a
+  function. If so add to function internal plist :jss-function and the
+  name of the java methods"
+  (and (find-package :jss)
+       (or (getf (sys::function-plist f) :jss-function)
+	   (let ((internals (function-internal-fields f)))
+	     (and (= (length internals) 2)
+		  (eq (second internals) (intern "INVOKE-RESTARGS" :jss))
+		  (stringp (first internals))
+		  (setf (getf (sys::function-plist f) :jss-function) (first internals)))))))
+	 
+(defun local-function-p (function)
+  "Helper function. Tests whether a function wasn't defined at top
+  level based on function-plist annotations"
+  (and (functionp function)
+       (let ((plist  (sys::function-plist function)))
+	 (or (getf plist :internal-to-function)
+	     (getf plist :method-function)
+	     (getf plist :method-fast-function)
+	     (getf plist :slot-initfunction)))))
+
+(defun local-function-owner (function)
+  "For local function, return the 'owner' typically the top-level function or clos method"
+  (local-function-p function))
+
+(defmethod print-object ((f function) stream)
+  "Print a function using any-function-name. Requires a patch to
+  system::output-ugly-object in order to prevent the function being
+  printed by a java primitive"
+  (print-unreadable-object (f stream :identity t)
+    (let ((name (any-function-name  f)))
+       (if (consp name)
+           (format stream "~{~a~^ ~}" name)
+           (princ name stream)))))
+
+(defun each-non-symbol-compiled-function (f)
+  (loop for q = (list (find-class t)) then q
+	for focus = (pop q)
+	while focus
+	do (setq q (append q (mop::class-direct-subclasses  focus)))
+	   (loop for method in (mop::class-direct-methods focus)
+		 do (when (compiled-function-p (mop::method-function method)) (funcall f method (mop::method-function method))))
+	   (loop for slot in (mop::class-direct-slots focus)
+		 for initfunction = (and (slot-boundp slot 'initfunction) (slot-value slot 'initfunction))
+		 do (and initfunction (compiled-function-p initfunction) (funcall f slot initfunction)))))
+                                
+;; hooks into defining 
+ 
+(defvar *fset-hooks* nil "functions on this list get called with name and function *after* the symbol-function is set")
+
+(defvar *annotate-function-backlog?* t "true before this file has been loaded and function annotations are placed")
+
+(defun fset-hook-annotate-internal-function (name function)
+  "Called at the end of fset. If function annotations have not yet
+  been added, add local function annotations to all functions. If not,
+  just add annotations to function specified in the arglist"
+  (declare (ignore function))
+  (when *annotate-function-backlog?* 
+    (setq *annotate-function-backlog?* nil)
+    (annotate-internal-functions)
+    (annotate-clos-methods)
+    (annotate-clos-slots)
+    )
+  (annotate-internal-functions (list name)))
+
+;; Here we hook into clos in order to have method and slot functions
+;; annotated when they are defined.
+
+(defmethod mop::add-direct-method :after (class method)
+  (annotate-clos-methods (list method)))
+
+(defmethod mop::ensure-class-using-class :after (class name  &key direct-slots
+                                             direct-default-initargs 
+                                             &allow-other-keys)
+  (annotate-clos-slots (mop::class-direct-slots (find-class name))))
+
+;; needs to be the last thing. Some interaction with the fasl loader
+(pushnew 'fset-hook-annotate-internal-function sys::*fset-hooks*)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+		 
+(defun get-pid ()
+  "Get the process identifier of this lisp process. Used to be in
+  slime but generally useful, so now back in abcl proper."
+  (handler-case
+      (let* ((runtime
+              (java::jstatic "getRuntime" "java.lang.Runtime"))
+             (command
+              (java::jnew-array-from-array
+               "java.lang.String" #("sh" "-c" "echo $PPID")))
+             (runtime-exec-jmethod
+              ;; Complicated because java.lang.Runtime.exec() is
+              ;; overloaded on a non-primitive type (array of
+              ;; java.lang.String), so we have to use the actual
+              ;; parameter instance to get java.lang.Class
+              (java::jmethod "java.lang.Runtime" "exec"
+                            (java::jcall
+                             (java::jmethod "java.lang.Object" "getClass")
+                             command)))
+             (process
+              (java::jcall runtime-exec-jmethod runtime command))
+             (output
+              (java::jcall (java::jmethod "java.lang.Process" "getInputStream")
+                          process)))
+         (java::jcall (java::jmethod "java.lang.Process" "waitFor")
+                     process)
+	 (loop :with b :do
+	    (setq b
+		  (java::jcall (java::jmethod "java.io.InputStream" "read")
+			      output))
+	    :until (member b '(-1 #x0a))	; Either EOF or LF
+	    :collecting (code-char b) :into result
+	    :finally (return
+		       (parse-integer (coerce result 'string)))))
+    (t () 0)))
+
+(provide :abcl-introspect)

--- a/contrib/jss/collections.lisp
+++ b/contrib/jss/collections.lisp
@@ -1,0 +1,130 @@
+(in-package :jss)
+
+;; ****************************************************************
+;; Already defined in jss
+
+(defun set-to-list (set)
+  (declare (optimize (speed 3) (safety 0)))
+  (with-constant-signature ((iterator "iterator" t) (hasnext "hasNext") (next "next"))
+    (loop with iterator = (iterator set)
+       while (hasNext iterator)
+       for item = (next iterator)
+       collect item)))
+
+(defun jlist-to-list (list)
+  "Convert a LIST implementing java.util.List to a Lisp list."
+  (declare (optimize (speed 3) (safety 0)))
+  (loop :for i :from 0 :below (jcall "size" list)
+     :collecting (jcall "get" list i)))
+
+(defun jarray-to-list (jarray)
+  "Convert the Java array named by JARRARY into a Lisp list."
+  (declare (optimize (speed 3) (safety 0)))
+  (loop :for i :from 0 :below (jarray-length jarray)
+     :collecting (jarray-ref jarray i)))
+
+;;; Deprecated 
+;;; 
+;;; XXX unclear what sort of list this would actually work on, as it
+;;; certainly doesn't seem to be any of the Java collection types
+;;; (what implements getNext())?
+(defun list-to-list (list)
+  (declare (optimize (speed 3) (safety 0)))
+  (with-constant-signature ((isEmpty "isEmpty") (getfirst "getFirst")
+                            (getNext "getNext"))
+    (loop until (isEmpty list)
+       collect (getFirst list)
+       do (setq list (getNext list)))))
+
+;; Contribution of Luke Hope. (Thanks!)
+
+(defun iterable-to-list (iterable)
+  "Return the items contained the java.lang.Iterable ITERABLE as a list."
+  (declare (optimize (speed 3) (safety 0)))
+  (let ((it (#"iterator" iterable)))
+    (with-constant-signature ((has-next "hasNext")
+                              (next "next"))
+      (loop :while (has-next it)
+         :collect (next it)))))
+
+(defun vector-to-list (vector)
+  "Return the elements of java.lang.Vector VECTOR as a list."
+  (declare (optimize (speed 3) (safety 0)))
+  (with-constant-signature ((has-more "hasMoreElements")
+                            (next "nextElement"))
+    (let ((elements (#"elements" vector)))
+      (loop :while (has-more elements)
+         :collect (next elements)))))
+
+(defun hashmap-to-hashtable (hashmap &rest rest &key (keyfun #'identity) (valfun #'identity) (invert? nil)
+                                                  table 
+                             &allow-other-keys )
+  "Converts the a HASHMAP reference to a java.util.HashMap object to a Lisp hashtable.
+
+The REST paramter specifies arguments to the underlying MAKE-HASH-TABLE call.
+
+KEYFUN and VALFUN specifies functions to be run on the keys and values
+of the HASHMAP right before they are placed in the hashtable.
+
+If INVERT? is non-nil than reverse the keys and values in the resulting hashtable."
+  (let ((keyset (#"keySet" hashmap))
+        (table (or table (apply 'make-hash-table
+                                (loop for (key value) on rest by #'cddr
+                                   unless (member key '(:invert? :valfun :keyfun :table)) 
+                                   collect key and collect value)))))
+    (with-constant-signature ((iterator "iterator" t) (hasnext "hasNext") (next "next"))
+      (loop with iterator = (iterator keyset)
+         while (hasNext iterator)
+         for item = (next iterator)
+         do (if invert?
+                (setf (gethash (funcall valfun (#"get" hashmap item)) table) (funcall keyfun item))
+                (setf (gethash (funcall keyfun item) table) (funcall valfun (#"get" hashmap item)))))
+      table)))
+
+;; ****************************************************************
+;; But needing to remember is annoying
+
+;; Here's a summary I gleaned:
+
+;; java.util.Dictionary -> #"elements" yields java.util.Collections$3
+;; java.util.AbstractCollection -> #"iterator" yields java.util.Iterator?
+;; org.apache.felix.framework.util.CompoundEnumeration  -> implements java.util.Enumeration
+;; java.util.Collections -> doc says #"iterator" yields java.util.Iterator
+;; java.util.Collections$1) -> implements java.util.Iterator
+;; java.util.Collections$2) -> implements java.util.Spliterator (#"iterator" (#"stream" 'StreamSupport <a spliterator>)) -> java.util.Iterator
+;; java.util.Collections$3) -> implements java.util.Enumeration
+;; java.util.Iterator
+;;   ("next" "hasNext")
+;; java.util.Enumeration)
+;;   ("nextElement" "hasMoreElements")
+
+
+(defun j2list (thing)
+  (declare (optimize (speed 3) (safety 0)))
+  (flet ((iterator-collect (iterator)
+	   (with-constant-signature ((has-next "hasNext")
+				     (next "next"))
+	     (loop :while (has-next iterator)
+		   :collect (next iterator))))
+	 (enumeration-collect (enumeration)
+	   (with-constant-signature ((has-next "hasMoreElements")
+				     (next "nextElement"))
+	     (loop :while (has-next enumeration)
+		   :collect (next enumeration))))
+	 (map-collect (map)
+	   (with-constant-signature ((has-next "hasMoreElements")
+				     (next "nextElement"))
+	     (let ((keyiterator (#"iterator" (#"keyset" map))))
+	       (loop :while (has-next keyiterator)
+		     :for key = (next keyiterator)
+		     :collect (cons key (#"get" map key)))))))
+    (let ((isinstance (load-time-value (jmethod  "java.lang.Class" "isInstance" "java.lang.Object"))))
+      (cond ((jcall isinstance (load-time-value (jclass "java.util.AbstractCollection")) thing) (iterator-collect (#"iterator" thing)))
+	    ((jcall isinstance (load-time-value (jclass "java.util.Iterator")) thing)  (iterator-collect thing))
+	    ((jcall isinstance (load-time-value (jclass "java.util.Enumeration")) thing) (enumeration-collect thing))
+	    ((jcall isinstance (load-time-value (jclass "java.util.AbstractMap")) thing) (map-collect thing))
+	    ((jcall isinstance (load-time-value (jclass "java.util.Collections")) thing) (iterator-collect (#"iterator" thing)))
+	    ((jcall isinstance (load-time-value (jclass "java.util.Spliterator")) thing) (iterator-collect (#"iterator" (#"stream" 'StreamSupport thing))))
+	    ((jcall isinstance (load-time-value (jclass "java.util.Dictionary")) thing) (iterator-collect (#"elements" thing)))
+	    ((ignore-errors (#"toArray" thing)) (coerce (#"toArray" thing) 'list))
+	    (t (error "yet another iteration type - fix it: ~a" (jclass-name (jobject-class thing))))))))

--- a/src/org/armedbear/lisp/print.lisp
+++ b/src/org/armedbear/lisp/print.lisp
@@ -147,8 +147,11 @@
         ((xp::xp-structure-p stream)
          (let ((s (sys::%write-to-string object)))
            (xp::write-string++ s stream 0 (length s))))
+	((functionp object)
+	  (print-object object stream))
         (t
          (%output-object object stream))))
+
 
 ;;;; circularity detection stuff
 


### PR DESCRIPTION
The ABCL compiler stores constants that are used in function execution
as private java fields. This includes symbols used to invoke function,
locally-defined functions (such as via labels or flet) and string and
other literal constants.

This file provides access to those internal values, and uses them in
at least two ways. First, to annotate locally defined functions with
the top-level function they are defined within, and second to search
for callers of a give function(*). This may yield some false
positives, such as when a symbol that names a function is also used
for some other purpose. It can also have false negatives, as when a
function is inlined. Still, it's pretty useful. The second use to to
find source locations for frames in the debugger. If the source
location for a local function is asked for the location of its 'owner'
is instead returns.

(*) Since java functions are strings, local fields also have these
strings. In the context of looking for callers of a function you can
also give a string that names a java method. Same caveat re: false
positives.

In order to record information about local functions, ABCL defines a
function-plist, which is for the most part unused, but is used here
with set of keys indicating where the local function was defined and
in what manner, i.e. as normal local function, as a method function,
or as an initarg function. There may be other places functions are
stashed away (defstructs come to mind) and this file should be added
to to take them into account as they are discovered.

This file does not depend on jss, but provides a bit of
jss-specific functionality if jss *is* loaded.

This commit also sneaks in a new file to jss, for functions that translate from collections to lisp lists