### PR TITLE
minor: show function documentation in describe

### DIFF
--- a/src/org/armedbear/lisp/describe.lisp
+++ b/src/org/armedbear/lisp/describe.lisp
@@ -92,7 +92,15 @@
              (setf plist (cddr plist))))))
       (FUNCTION
        (%describe-object object stream)
-       (describe-arglist object stream))
+       (describe-arglist object stream)
+       (let ((function-symbol (nth-value 2 (function-lambda-expression object))))
+	 (if (and (consp function-symbol) (eq (car function-symbol) 'macro-function))
+	     (setq function-symbol (second function-symbol)))
+	 (when  function-symbol
+	   (let ((doc (documentation function-symbol 'function)))
+	     (when doc
+	       (format stream "Function documentation:~%  ~A~%" doc)))
+	   )))
       (INTEGER
        (%describe-object object stream)
        (format stream "~D.~%~


### PR DESCRIPTION
Forgot to submit a pull for this.