### PR TITLE
stacktrace bugfix

### DIFF
--- a/contrib/abcl-introspect/stacktrace.lisp
+++ b/contrib/abcl-introspect/stacktrace.lisp
@@ -56,7 +56,8 @@
 		  ;; hack! really I mean anything with a function plist
 		  ((eq (type-of el) 'compiled-function)
 		   (let ((owner (getf (function-plist  el) :internal-to-function)))
-		     (if (symbolp owner)
+		     (if (and (symbolp owner)
+			      (symbol-package owner))
 			 (package-name 
 			  (symbol-package owner))
 			 "")))


### PR DESCRIPTION
thought this was in, but not. Fixes a case where stacktrace uses a package name when there isn't a package.