### PR TITLE
Fix a couple of places where user should be able to control things

### DIFF
--- a/contrib/quicklisp/quicklisp-abcl.asd
+++ b/contrib/quicklisp/quicklisp-abcl.asd
@@ -8,9 +8,11 @@
     :version "0.4.0"
     :components nil)
 
+(defvar *quicklisp-parent-dir* (user-homedir-pathname))
+  
 (defmethod perform ((o load-op) (c (eql (find-system 'quicklisp-abcl))))
   (let* ((setup-base (merge-pathnames "quicklisp/setup" 
-                                      (user-homedir-pathname)))
+                                      *quicklisp-parent-dir*))
          (setup-source (probe-file (make-pathname :defaults setup-base
                                                   :type "lisp")))
          (setup-fasl (probe-file (make-pathname :defaults setup-base
@@ -37,7 +39,8 @@
                 (warn "Using insecure transport for remote installation of Quicklisp:~&~A~&." e)
                 (load "http://beta.quicklisp.org/quicklisp.lisp")))))
       (unless (find-package :quicklisp)
-        (funcall (intern "INSTALL" "QUICKLISP-QUICKSTART")))))
+        (funcall (intern "INSTALL" "QUICKLISP-QUICKSTART") :path
+		 (merge-pathnames "quicklisp/" *quicklisp-parent-dir*)))))
 
 
 

--- a/src/org/armedbear/lisp/abcl-contrib.lisp
+++ b/src/org/armedbear/lisp/abcl-contrib.lisp
@@ -69,7 +69,7 @@ Used to determine relative pathname to find 'abcl-contrib.jar'."
   "Pathname of the ABCL contrib.
 Initialized via SYSTEM:FIND-CONTRIB.")
 
-(defparameter *verbose* t)
+(defvar *verbose* t)
 
 ;;; FIXME: stop using the obsolete ASDF:*CENTRAL-REGISTRY*
 (defun add-contrib (abcl-contrib-jar)
@@ -85,7 +85,7 @@ Initialized via SYSTEM:FIND-CONTRIB.")
           (push asdf-directory asdf:*central-registry*)
           (format *verbose* "~&Added ~A to ASDF.~&" asdf-directory))))))
 
-(defun find-and-add-contrib (&key (verbose nil))
+(defun find-and-add-contrib (&key (verbose *verbose*))
   "Attempt to find the ABCL contrib jar and add its contents to ASDF.
 returns the pathname of the contrib if it can be found."
    (if *abcl-contrib*
@@ -169,5 +169,5 @@ returns the pathname of the contrib if it can be found."
           find-contrib
           *abcl-contrib*))
 
-(when (find-and-add-contrib :verbose t)
+(when (find-and-add-contrib :verbose *verbose*)
   (provide :abcl-contrib))


### PR DESCRIPTION
In quicklisp-abcl, quicklisp directory was defaulting to (user-homedir-pathname). Make this customizable by using variable asdf::*quicklisp-parent-dir*
in abcl-contrib.lisp there was defparameter *verbose*, which should be defvar, and which was ignored in two places where it shouldn't have been.