### PR TITLE
Signaling a simple error would signal another error if the message happened to have a ~ in it

### DIFF
--- a/src/org/armedbear/lisp/ArithmeticError.java
+++ b/src/org/armedbear/lisp/ArithmeticError.java
@@ -72,7 +72,7 @@ public class ArithmeticError extends LispError
     public ArithmeticError(String message)
     {
         super(StandardClass.ARITHMETIC_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
         setOperation(NIL);
         setOperands(NIL);

--- a/src/org/armedbear/lisp/Condition.java
+++ b/src/org/armedbear/lisp/Condition.java
@@ -98,7 +98,7 @@ public class Condition extends StandardObject
   {
     super(StandardClass.CONDITION);
     Debug.assertTrue(slots.length == 2);
-    setFormatControl(message);
+    setFormatControl(message.replaceAll("~","~~"));
     setFormatArguments(NIL);
   }
 

--- a/src/org/armedbear/lisp/ControlError.java
+++ b/src/org/armedbear/lisp/ControlError.java
@@ -46,7 +46,7 @@ public final class ControlError extends LispError
     public ControlError(String message)
     {
         super(StandardClass.CONTROL_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 

--- a/src/org/armedbear/lisp/FileError.java
+++ b/src/org/armedbear/lisp/FileError.java
@@ -67,7 +67,7 @@ public final class FileError extends LispError
     public FileError(String message)
     {
         super(StandardClass.FILE_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
         setPathname(NIL);
     }
@@ -76,7 +76,7 @@ public final class FileError extends LispError
 
     {
         super(StandardClass.FILE_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
         setPathname(pathname);
     }

--- a/src/org/armedbear/lisp/IllegalMonitorState.java
+++ b/src/org/armedbear/lisp/IllegalMonitorState.java
@@ -43,7 +43,7 @@ public final class IllegalMonitorState extends ProgramError
         // This is really just an ordinary PROGRAM-ERROR, broken out into its
         // own Java class as a convenience for the implementation.
         super(StandardClass.PROGRAM_ERROR);
-        setFormatControl(getMessage());
+        setFormatControl(getMessage().replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 
@@ -55,7 +55,7 @@ public final class IllegalMonitorState extends ProgramError
         if (message != null) {
             this.message = message;
         } 
-        setFormatControl(getMessage());
+        setFormatControl(getMessage().replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
     

--- a/src/org/armedbear/lisp/ParseError.java
+++ b/src/org/armedbear/lisp/ParseError.java
@@ -40,7 +40,7 @@ public final class ParseError extends LispError
     public ParseError(String message)
     {
         super(StandardClass.PARSE_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 

--- a/src/org/armedbear/lisp/ProgramError.java
+++ b/src/org/armedbear/lisp/ProgramError.java
@@ -57,7 +57,7 @@ public class ProgramError extends LispError
     public ProgramError(String message)
     {
         super(StandardClass.PROGRAM_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 

--- a/src/org/armedbear/lisp/ReaderError.java
+++ b/src/org/armedbear/lisp/ReaderError.java
@@ -40,14 +40,14 @@ public final class ReaderError extends StreamError
     public ReaderError(String message)
     {
         super(StandardClass.READER_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 
     public ReaderError(String message, Stream stream)
     {
         super(StandardClass.READER_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
         setStream(stream);
     }

--- a/src/org/armedbear/lisp/SimpleError.java
+++ b/src/org/armedbear/lisp/SimpleError.java
@@ -54,7 +54,7 @@ public final class SimpleError extends LispError
     public SimpleError(String message)
     {
         super(StandardClass.SIMPLE_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 

--- a/src/org/armedbear/lisp/StreamError.java
+++ b/src/org/armedbear/lisp/StreamError.java
@@ -48,7 +48,7 @@ public class StreamError extends LispError
     public StreamError(String message)
     {
         super(StandardClass.STREAM_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
         setStream(NIL);
         cause = null;
@@ -64,7 +64,7 @@ public class StreamError extends LispError
     public StreamError(String message, Stream stream)
     {
         super(StandardClass.STREAM_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
         setStream(stream != null ? stream : NIL);
         cause = null;
@@ -95,7 +95,7 @@ public class StreamError extends LispError
     public StreamError(Stream stream, String message)
     {
         super(StandardClass.STREAM_ERROR);
-        setFormatControl(message);
+        setFormatControl(message.replaceAll("~","~~"));
         setFormatArguments(NIL);
         setStream(stream != null ? stream : NIL);
         cause = null;
@@ -106,7 +106,7 @@ public class StreamError extends LispError
         super(StandardClass.STREAM_ERROR);
         setStream(stream != null ? stream : NIL);
         String message = cause.getMessage();
-        setFormatControl(message != null ? message : cause.toString());
+        setFormatControl(message != null ? message.replaceAll("~","~~") : cause.toString().replaceAll("~","~~"));
         setFormatArguments(NIL);
         this.cause = cause;
     }

--- a/src/org/armedbear/lisp/WrongNumberOfArgumentsException.java
+++ b/src/org/armedbear/lisp/WrongNumberOfArgumentsException.java
@@ -56,7 +56,7 @@ public final class WrongNumberOfArgumentsException extends ProgramError
 	this.expectedMinArgs = expectedMin;
 	this.expectedMaxArgs = expectedMax;
         this.actualArgs = args;
-        setFormatControl(getMessage());
+        setFormatControl(getMessage().replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 
@@ -80,7 +80,7 @@ public final class WrongNumberOfArgumentsException extends ProgramError
 	    throw new NullPointerException("message can not be null");
 	}
 	this.message = message;
-        setFormatControl(getMessage());
+        setFormatControl(getMessage().replaceAll("~","~~"));
         setFormatArguments(NIL);
     }
 


### PR DESCRIPTION
since in simple cases there are no format args, but format is called with the message string. I searched for all cases in the source where there were calls to setFormatControl(x) followed by setFormatArguments(NIL). In such cases I changed setFormatControl(x) -> setFormatControl(x.replaceAll("~","~~")). An example that would trigger the double error was compiling (defun foo (x) ("This should be quoted ~a" x)).