### PR TITLE
More fixes.

### DIFF
--- a/contrib/jss/jss-tests.asd
+++ b/contrib/jss/jss-tests.asd
@@ -1,0 +1,13 @@
+(require :asdf)
+(in-package :cl-user)
+
+(asdf:defsystem jss-tests
+  :defsystem-depends-on (quicklisp-abcl
+                         prove-asdf)
+  :depends-on (jss
+               prove)
+  :components ((:module tests
+                        :pathname "" 
+                        :components ((:test-file "jss-tests"))))
+  :perform (asdf:test-op (op c)
+                         (uiop:symbol-call :prove-asdf 'run-test-system c)))

--- a/contrib/jss/jss-tests.lisp
+++ b/contrib/jss/jss-tests.lisp
@@ -41,18 +41,18 @@
     (- (#"currentTimeMillis" 'system) start)))
 
 
-(is-type (let ((just-loop (cl-user::print-db (timeit (just-loop 10000)))))
+(is-type (let ((just-loop (timeit (just-loop 10000))))
 	   (+ 0.0 
 	      (print (/ (-  (timeit (optimized-jss 10000)) just-loop)
 			(-  (timeit (unoptimized-jss 10000)) just-loop)))))
 	 '(float 0 0.1))
 
-(is (let* ((jss::*inhibit-jss-optimization* nil)
-	   (optimized-jss (macroexpand (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t))))
-      (let* ((jss::*inhibit-jss-optimization* t)
-	     (unoptimized-jss (macroexpand (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t))))
-	(and (eq (car optimized-jss) 'jstatic)
-	     (eq (caar unoptimized-jss) 'lambda)))))
+(let* ((jss::*inhibit-jss-optimization* nil)
+       (optimized-jss (macroexpand (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t))))
+  (let* ((jss::*inhibit-jss-optimization* t)
+         (unoptimized-jss (macroexpand (precompiler::precompile-form '(#"compile" 'regex.Pattern ".*") t))))
+    (is (car optimized-jss) 'java:jstatic)
+    (is (caar unoptimized-jss) 'lambda)))
 
 (finalize)
 

--- a/contrib/jss/jss.asd
+++ b/contrib/jss/jss.asd
@@ -15,27 +15,4 @@
 				     (:file "transform-to-field")
                                      (:file "compat"))))
   :perform (asdf:test-op (op c)
-                         (asdf:test-system :jss/tests)))
-
-
-(asdf:defsystem jss/tests
-  :defsystem-depends-on (quicklisp-abcl
-                         prove-asdf)
-  :depends-on (jss
-               prove)
-  :components ((:module tests
-                        :pathname "" 
-                        :components ((:test-file "jss-tests"))))
-  :perform (asdf:test-op (op c)
-                         (uiop:symbol-call :prove-asdf 'run-test-system c)))
-
-
-
-
-
-
-
-
-   
-
-
+                         (asdf:test-system :jss-tests)))

--- a/src/org/armedbear/lisp/clos.lisp
+++ b/src/org/armedbear/lisp/clos.lisp
@@ -3694,12 +3694,12 @@ or T when any keyword is acceptable due to presence of
       (multiple-value-bind (init-key init-value foundp)
           (get-properties all-keys (slot-definition-initargs slot))
         (if foundp
-            (setf (std-slot-value instance slot-name) init-value)
-            (unless (std-slot-boundp instance slot-name)
+            (setf (slot-value instance slot-name) init-value)
+            (unless (slot-boundp instance slot-name)
               (let ((initfunction (slot-definition-initfunction slot)))
                 (when (and initfunction (or (eq slot-names t)
                                             (memq slot-name slot-names)))
-                  (setf (std-slot-value instance slot-name)
+                  (setf (slot-value instance slot-name)
                         (funcall initfunction)))))))))
   instance)
 

--- a/src/org/armedbear/lisp/clos.lisp
+++ b/src/org/armedbear/lisp/clos.lisp
@@ -4313,16 +4313,18 @@ or T when any keyword is acceptable due to presence of
 
 (defmethod shared-initialize :after ((instance standard-generic-function)
                                      slot-names
-                                     &key lambda-list argument-precedence-order
+                                     &key (lambda-list nil lambda-list-p)
+                                       (argument-precedence-order nil a-p-o-p)
                                        (method-combination '(standard))
                                      &allow-other-keys)
-  (let* ((plist (analyze-lambda-list lambda-list))
-         (required-args (getf plist ':required-args)))
-    (setf (std-slot-value instance 'sys::required-args) required-args)
-    (setf (std-slot-value instance 'sys::optional-args)
-          (getf plist :optional-args)) 
-    (setf (std-slot-value instance 'sys::argument-precedence-order)
-          (or argument-precedence-order required-args)))
+  (when lambda-list-p
+    (let* ((plist (analyze-lambda-list lambda-list))
+           (required-args (getf plist ':required-args)))
+      (setf (std-slot-value instance 'sys::required-args) required-args)
+      (setf (std-slot-value instance 'sys::optional-args)
+            (getf plist :optional-args))
+      (setf (std-slot-value instance 'sys::argument-precedence-order)
+            (or (and a-p-o-p argument-precedence-order) required-args))))
   (unless (typep (generic-function-method-combination instance)
                  'method-combination)
     ;; this fixes (make-instance 'standard-generic-function) -- the

--- a/src/org/armedbear/lisp/compiler-error.lisp
+++ b/src/org/armedbear/lisp/compiler-error.lisp
@@ -40,9 +40,9 @@
 
 (defvar *compiler-error-context* nil)
 
-(define-condition compiler-error (error))
-(define-condition internal-compiler-error (compiler-error))
-(define-condition compiler-unsupported-feature-error (compiler-error))
+(define-condition compiler-error (error) ())
+(define-condition internal-compiler-error (compiler-error) ())
+(define-condition compiler-unsupported-feature-error (compiler-error) ())
 
 (defun compiler-style-warn (format-control &rest format-arguments)
   (warn 'style-warning

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -216,7 +216,7 @@
 (defmethod gray-streamp ((s fundamental-stream))
   s)
 
-(defclass fundamental-input-stream (fundamental-stream))
+(defclass fundamental-input-stream (fundamental-stream) ())
 
 (defmethod gray-input-character-stream-p (s)  ;; # fb 1.01
   (and (gray-input-stream-p s)
@@ -226,7 +226,7 @@
   (declare (ignore s))
   t)
 
-(defclass fundamental-output-stream (fundamental-stream))
+(defclass fundamental-output-stream (fundamental-stream) ())
 
 (defmethod gray-input-stream-p ((s fundamental-output-stream))
   (typep s 'fundamental-input-stream))
@@ -238,19 +238,19 @@
 (defmethod gray-output-stream-p ((s fundamental-input-stream))
   (typep s 'fundamental-output-stream))
 
-(defclass fundamental-character-stream (fundamental-stream))
+(defclass fundamental-character-stream (fundamental-stream) ())
 
 (defmethod gray-stream-element-type ((s fundamental-character-stream))
   (declare (ignore s))
   'character)
 
-(defclass fundamental-binary-stream (fundamental-stream))
+(defclass fundamental-binary-stream (fundamental-stream) ())
 
 (defgeneric stream-read-byte (stream))
 (defgeneric stream-write-byte (stream integer))
 
 (defclass fundamental-character-input-stream
-  (fundamental-input-stream fundamental-character-stream))
+  (fundamental-input-stream fundamental-character-stream) ())
 
 (defgeneric stream-read-char (stream))
 (defgeneric stream-unread-char (stream character))
@@ -292,7 +292,7 @@
   nil)
 
 (defclass fundamental-character-output-stream
-  (fundamental-output-stream fundamental-character-stream))
+  (fundamental-output-stream fundamental-character-stream) ())
 
 (defgeneric stream-write-char (stream character))
 (defgeneric stream-line-column (stream))
@@ -386,10 +386,10 @@
                         'character #'stream-write-char))
 
 (defclass fundamental-binary-input-stream
-  (fundamental-input-stream fundamental-binary-stream))
+  (fundamental-input-stream fundamental-binary-stream) ())
 
 (defclass fundamental-binary-output-stream
-  (fundamental-output-stream fundamental-binary-stream))
+  (fundamental-output-stream fundamental-binary-stream) ())
 
 (defmethod stream-read-sequence ((stream fundamental-binary-input-stream)
                                  sequence &optional (start 0) end)

--- a/test/lisp/abcl/misc-tests.lisp
+++ b/test/lisp/abcl/misc-tests.lisp
@@ -118,3 +118,15 @@
                (write-string "Goodbye, World!" stream)
                (get-output-stream-string stream)))
   T)
+
+(deftest destructuring-bind.1
+  (signals-error (destructuring-bind (a b &rest c) '(1) (list a b)) 'program-error)
+  T)
+
+(deftest destructuring-bind.2
+  (signals-error (destructuring-bind (a . b) '() (list a b)) 'program-error)
+  T)
+
+(deftest destructuring-bind.3
+  (destructuring-bind (a . b) '(1) (list a b))
+  (1 NIL))

--- a/test/lisp/abcl/mop-tests-setup.lisp
+++ b/test/lisp/abcl/mop-tests-setup.lisp
@@ -80,3 +80,28 @@
 (defun find-quux (&rest specializers)
   (find-method #'mop-test.quux nil
 	       (mapcar #'find-class specializers)))
+
+(defclass foo-meta-class (standard-class)
+  ())
+
+(defclass foo-direct-slot-definition (mop:standard-direct-slot-definition)
+  ())
+
+(defclass foo-effective-slot-definition (mop:standard-effective-slot-definition)
+  ())
+
+(defmethod mop:direct-slot-definition-class ((class foo-meta-class) &rest initargs)
+  (find-class 'foo-direct-slot-definition))
+
+(defmethod mop:effective-slot-definition ((class foo-meta-class) &rest initargs)
+  (find-class 'foo-effective-slot-definition))
+
+(defmethod mop:compute-effective-slot-definition ((class foo-meta-class) name direct-slots)
+  (car direct-slots))
+
+(defclass bar-class ()
+  ((x :initform T))
+  (:metaclass foo-meta-class))
+
+(defmethod mop:slot-boundp-using-class ((class foo-meta-class) object slot)
+  (error "foo"))

--- a/test/lisp/abcl/mop-tests.lisp
+++ b/test/lisp/abcl/mop-tests.lisp
@@ -309,3 +309,10 @@
         (error (error)
           (return (equal (princ-to-string error) "foo")))))
   t)
+
+;; ensure-generic-function shouldn't kill existing definition
+(deftest ensure-generic-function.1
+    (progn
+      (ensure-generic-function 'mop-test.foo)
+      (not (null (mop:generic-function-argument-precedence-order #'mop-test.foo))))
+  t)

--- a/test/lisp/abcl/mop-tests.lisp
+++ b/test/lisp/abcl/mop-tests.lisp
@@ -302,4 +302,10 @@
       #'mop-test.quux (find-classes 'fixnum  'simple-base-string)))
   t)
 
-
+;; creating the instance should already call our meta class methods
+(deftest shared-initialize.1
+    (block NIL
+      (handler-case (make-instance 'bar-class)
+        (error (error)
+          (return (equal (princ-to-string error) "foo")))))
+  t)


### PR DESCRIPTION
Some more fixes. With this I can get the demo from CL-CFFI-GTK to run, even with some more complicated JNA/CFFI things.

The `SHARED-INITIALIZE` change is something that at least SBCL/CCL do this way, but I'm not sure this is the right way to fix it.