### PR TITLE
Doc fixes

### DIFF
--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -14,12 +14,16 @@ ABCL	= ../../abcl
 
 # XXX TODO 1) use more compact iterated form, 2) pare down to using --noinit
 grovel:
-	$(ABCL) --batch --noinform --load "grovel.lisp" \
-	  --eval '(grovel-docstrings-as-tex (find-package :java)' \
-	  --eval  '(grovel-docstrings-as-tex (find-package :extensions))' \
-	--eval  '(grovel-docstrings-as-tex (find-package :threads))' \
-	--eval  '(grovel-docstrings-as-tex (find-package :system))' \
-	--eval '(progn (require :abcl-contrib) (require :jss) (grovel-docstrings-as-tex (find-package :jss)))'
+	$(ABCL) --batch --noinform \
+	--eval '(require :abcl-contrib)' \
+	--eval '(require :jss)' \
+	--eval '(asdf:load-system :abcl/documentation)' \
+	--eval '(in-package :abcl/documentation)' \
+	--eval '(grovel-docstrings-as-tex :package :java)' \
+	--eval '(grovel-docstrings-as-tex :package :extensions)' \
+	--eval '(grovel-docstrings-as-tex :package :threads)' \
+	--eval '(grovel-docstrings-as-tex :package :system)' \
+	--eval '(grovel-docstrings-as-tex :package :jss)'
 
 clean:
 	rm -f *.aux *.bbl *.blg *.idx *.ilg *.ind *.log *.out *.toc abcl.pdf

--- a/doc/manual/abcl.tex
+++ b/doc/manual/abcl.tex
@@ -1,6 +1,8 @@
 % -*- mode: latex; -*-
 % http://en.wikibooks.org/wiki/LaTeX/
 \documentclass[10pt]{book}
+% also need to have cm-super installed for high quality rendering
+\usepackage[T1]{fontenc}
 \usepackage{abcl}
 
 \usepackage{hyperref} % Put this one last, it redefines lots of internals

--- a/doc/manual/extensions.tex
+++ b/doc/manual/extensions.tex
@@ -107,6 +107,15 @@ not-documented
 \end{adjustwidth}
 
 \paragraph{}
+\label{EXTENSIONS:*GUI-BACKEND*}
+\index{*GUI-BACKEND*}
+--- Variable: \textbf{*gui-backend*} [\textbf{extensions}] \textit{}
+
+\begin{adjustwidth}{5em}{5em}
+not-documented
+\end{adjustwidth}
+
+\paragraph{}
 \label{EXTENSIONS:*INSPECTOR-HOOK*}
 \index{*INSPECTOR-HOOK*}
 --- Variable: \textbf{*inspector-hook*} [\textbf{extensions}] \textit{}
@@ -310,24 +319,7 @@ not-documented
 --- Function: \textbf{classp} [\textbf{extensions}] \textit{}
 
 \begin{adjustwidth}{5em}{5em}
-Collect ({(Name [Initial-Value] [Function])}*) {Form}*
-  Collect some values somehow.  Each of the collections specifies a bunch of
-  things which collected during the evaluation of the body of the form.  The
-  name of the collection is used to define a local macro, a la MACROLET.
-  Within the body, this macro will evaluate each of its arguments and collect
-  the result, returning the current value after the collection is done.  The
-  body is evaluated as a PROGN; to get the final values when you are done, just
-  call the collection macro with no arguments.
-
-  Initial-Value is the value that the collection starts out with, which
-  defaults to NIL.  Function is the function which does the collection.  It is
-  a function which will accept two arguments: the value to be collected and the
-  current collection.  The result of the function is made the new value for the
-  collection.  As a totally magical special-case, the Function may be Collect,
-  which tells us to build a list in forward order; this is the default.  If an
-  Initial-Value is supplied for Collect, the stuff will be rplacd'd onto the
-  end.  Note that Function may be anything that can appear in the functional
-  position, including macros and lambdas.
+not-documented
 \end{adjustwidth}
 
 \paragraph{}
@@ -467,17 +459,6 @@ Used to be in SLIME but generally useful, so now back in ABCL proper.
 \end{adjustwidth}
 
 \paragraph{}
-\label{EXTENSIONS:GET-PID}
-\index{GET-PID}
---- Function: \textbf{get-pid} [\textbf{extensions}] \textit{}
-
-\begin{adjustwidth}{5em}{5em}
-Get the process identifier of this lisp process. 
-
-Used to be in SLIME but generally useful, so now back in ABCL proper.
-\end{adjustwidth}
-
-\paragraph{}
 \label{EXTENSIONS:GET-SOCKET-STREAM}
 \index{GET-SOCKET-STREAM}
 --- Function: \textbf{get-socket-stream} [\textbf{extensions}] \textit{socket \&key (element-type (quote character)) (external-format default)}
@@ -520,7 +501,7 @@ Returns all environment variables as an alist containing (name . value)
 --- Function: \textbf{init-gui} [\textbf{extensions}] \textit{}
 
 \begin{adjustwidth}{5em}{5em}
-not-documented
+Dummy function used to autoload this file
 \end{adjustwidth}
 
 \paragraph{}
@@ -628,7 +609,7 @@ Create and return the pathname of a previously non-existent file.
 --- Function: \textbf{make-weak-reference} [\textbf{extensions}] \textit{obj}
 
 \begin{adjustwidth}{5em}{5em}
-not-documented
+Creates a weak reference to 'obj'.
 \end{adjustwidth}
 
 \paragraph{}
@@ -809,7 +790,7 @@ Returns either the function or NIL if no resolution was possible.
 --- Function: \textbf{run-shell-command} [\textbf{extensions}] \textit{command \&key directory (output *standard-output*)}
 
 \begin{adjustwidth}{5em}{5em}
-not-documented
+Deprecated.  Use SYS:RUN-PROGRAM.
 \end{adjustwidth}
 
 \paragraph{}

--- a/doc/manual/jss.tex
+++ b/doc/manual/jss.tex
@@ -26,15 +26,6 @@ not-documented
 \end{adjustwidth}
 
 \paragraph{}
-\label{JSS:*MUFFLE-WARNINGS*}
-\index{*MUFFLE-WARNINGS*}
---- Variable: \textbf{*muffle-warnings*} [\textbf{jss}] \textit{}
-
-\begin{adjustwidth}{5em}{5em}
-not-documented
-\end{adjustwidth}
-
-\paragraph{}
 \label{JSS:CLASSFILES-IMPORT}
 \index{CLASSFILES-IMPORT}
 --- Function: \textbf{classfiles-import} [\textbf{jss}] \textit{directory}

--- a/doc/manual/system.tex
+++ b/doc/manual/system.tex
@@ -2038,12 +2038,21 @@ not-documented
 \end{adjustwidth}
 
 \paragraph{}
+\label{SYSTEM:PROCESS}
+\index{PROCESS}
+--- Class: \textbf{process} [\textbf{system}] \textit{}
+
+\begin{adjustwidth}{5em}{5em}
+not-documented
+\end{adjustwidth}
+
+\paragraph{}
 \label{SYSTEM:PROCESS-ALIVE-P}
 \index{PROCESS-ALIVE-P}
 --- Function: \textbf{process-alive-p} [\textbf{system}] \textit{process}
 
 \begin{adjustwidth}{5em}{5em}
-not-documented
+Return t if process is still alive, nil otherwise.
 \end{adjustwidth}
 
 \paragraph{}
@@ -2436,7 +2445,7 @@ not-documented
 --- Function: \textbf{sha256} [\textbf{system}] \textit{\&rest paths-or-strings}
 
 \begin{adjustwidth}{5em}{5em}
-not-documented
+Returned ASCIIfied representation of SHA256 digest of byte-based resource at PATHS-OR-STRINGs.
 \end{adjustwidth}
 
 \paragraph{}
@@ -2652,7 +2661,8 @@ not-documented
 --- Function: \textbf{unzip} [\textbf{system}] \textit{pathname \&optional directory => unzipped\_pathnames}
 
 \begin{adjustwidth}{5em}{5em}
-not-documented
+Unpack zip archive at PATHNAME returning a list of extracted pathnames.
+If the optional DIRECTORY is specified, root the abstraction in that directory, otherwise use the current value of *DEFAULT-PATHNAME-DEFAULTS*.
 \end{adjustwidth}
 
 \paragraph{}


### PR DESCRIPTION
Three things:

- Updates the Makefile to make it the same usable sequence from the README file.
- Fixes one case of wrong rendering in LaTeX due to the `<` and `>` characters. [See this for an explanation](https://tex.stackexchange.com/questions/2369/why-do-the-less-than-symbol-and-the-greater-than-symbol-appear-wrong-as).
- Lastly regenerates the LaTeX sources with the former in place; the big removal there is actually correct - in `master` that block is duplicated!

Example output is http://macrolet.net/data/abcl.pdf - note that I also [installed the `cm-super` package](https://tex.stackexchange.com/questions/7185/how-to-make-the-pdf-output-of-better-print-quality/7188#7188), so perhaps a different font as explained there, `lmodern`, might be better in the long term.