### PR TITLE
collect request needs a repository

### DIFF
--- a/contrib/abcl-asdf/abcl-asdf.lisp
+++ b/contrib/abcl-asdf/abcl-asdf.lisp
@@ -128,9 +128,12 @@ single entry denoting a remote binary artifact."
                                      "java.lang.ClassNotFoundException")
           (error "Unexpected Java exception~&~A.~&" e))))
     (if (find-mvn)
-        (resolve-dependencies group-id artifact-id
-                              :version version
-                              :repositories repositories)
+	(if repositories 
+	    (resolve-dependencies group-id artifact-id
+				  :version version
+				  :repositories repositories)
+	    (resolve-dependencies group-id artifact-id
+                              :version version))
         (if alternate-uri
             (values (pathname alternate-uri) alternate-uri) 
             (error "Failed to resolve MVN component name ~A." name)))))

--- a/contrib/abcl-asdf/mvn-module.lisp
+++ b/contrib/abcl-asdf/mvn-module.lisp
@@ -30,6 +30,7 @@
       (let ((collect-request (java:jnew (jss:find-java-class "CollectRequest")))
             (exclusions-collection (jss:new 'hashset) )
             (compile-scope (java:jfield (jss:find-java-class "JavaScopes") "COMPILE")))
+	(#"addRepository" collect-request (ensure-remote-repository))
         (loop for e  in exclusions
            for (groupid artifactid) = (abcl-build:split-string e #\:)
            ;; If i have scope be compile-scope it doesn't get excluded!!


### PR DESCRIPTION
See https://github.com/armedbear/abcl/issues/66 - this patches abcl-asdf:resolve-multiple-dependencies to add a repository to the collect request, and patches abcl-asdf:resolves to not call resolve-dependencies with :repositories nil if repositories is nil