### PR TITLE
Add jtypecase form, fix print-object of null pointer

### DIFF
--- a/contrib/jss/jss.asd
+++ b/contrib/jss/jss.asd
@@ -11,6 +11,7 @@
 				     (:file "optimize-java-call")
                                      (:file "classpath")
 				     (:file "transform-to-field")
-                                     (:file "compat"))))
+                                     (:file "compat")
+				     (:file "jtypecase"))))
   :perform (asdf:test-op (op c)
                          (asdf:test-system :jss-tests)))

--- a/contrib/jss/jtypecase.lisp
+++ b/contrib/jss/jtypecase.lisp
@@ -1,0 +1,8 @@
+(in-package :jss)
+
+(defmacro jtypecase (keyform &body cases)
+  "JTYPECASE Keyform {(Type Form*)}*
+  Evaluates the Forms in the first clause for which Type names a class that Keyform #"isInstance" of
+  is true."
+  (sys::case-body 'jtypecase keyform cases t `(lambda(i c) (jcall "isInstance" (find-java-class c) i))  nil nil nil))
+

--- a/contrib/jss/jtypecase.lisp
+++ b/contrib/jss/jtypecase.lisp
@@ -1,8 +1,18 @@
 (in-package :jss)
 
+(defvar *jtypecache* (make-hash-table :test 'eq))
+
+(defun jtypep (object type)
+  (declare (optimize (speed 3) (safety 0)))
+  (let ((class (or (gethash type *jtypecache*)
+		   (ignore-errors (setf (gethash type *jtypecache*) (find-java-class type)))))
+	(method (load-time-value (jmethod "java.lang.Class" "isInstance" "java.lang.Object"))))
+    (and class 
+	 (jcall method class object))))
+    
 (defmacro jtypecase (keyform &body cases)
   "JTYPECASE Keyform {(Type Form*)}*
-  Evaluates the Forms in the first clause for which Type names a class that Keyform #"isInstance" of
+  Evaluates the Forms in the first clause for which Type names a class that Keyform isInstance of
   is true."
-  (sys::case-body 'jtypecase keyform cases t `(lambda(i c) (jcall "isInstance" (find-java-class c) i))  nil nil nil))
+  (sys::case-body 'jtypecase keyform cases t 'jtypep nil nil nil))
 

--- a/src/org/armedbear/lisp/java.lisp
+++ b/src/org/armedbear/lisp/java.lisp
@@ -458,7 +458,7 @@ is equivalent to the following Java code:
 
 (defmethod print-object ((obj java:java-object) stream)
   (if (jnull-ref-p obj)
-      (write-string "#<NullPointer>" stream)
+      (write-string "#<null>" stream)
       (print-java-object-by-class (intern (jclass-name (jobject-class obj)) 'keyword) obj stream)))
 
 ;;define extensions by eql methods on class name interned in keyword package

--- a/src/org/armedbear/lisp/java.lisp
+++ b/src/org/armedbear/lisp/java.lisp
@@ -457,7 +457,9 @@ is equivalent to the following Java code:
 ;;; print-object
 
 (defmethod print-object ((obj java:java-object) stream)
-  (print-java-object-by-class (intern (jclass-name (jobject-class obj)) 'keyword) obj stream))
+  (if (jnull-ref-p obj)
+      (write-string "#<NullPointer>" stream)
+      (print-java-object-by-class (intern (jclass-name (jobject-class obj)) 'keyword) obj stream)))
 
 ;;define extensions by eql methods on class name interned in keyword package
 ;;e.g. (defmethod java::print-java-object-by-class ((class (eql ':|uk.ac.manchester.cs.owl.owlapi.concurrent.ConcurrentOWLOntologyImpl|)) obj stream) 


### PR DESCRIPTION
Like typecase except the check is whether the form is an instance of one of the classes, which are lookup up using find-java-class. 

Also included: a minor fix to print-java-object-by-class - it was getting an error while printing a null pointer.