### PR TITLE
ReaderError: Don't evaluate format control string when signaling the error

### DIFF
--- a/src/org/armedbear/lisp/ReaderError.java
+++ b/src/org/armedbear/lisp/ReaderError.java
@@ -52,6 +52,14 @@ public final class ReaderError extends StreamError
         setStream(stream);
     }
 
+  public ReaderError(String message, Stream stream, LispObject arg1, LispObject arg2)
+  {
+        super(StandardClass.READER_ERROR);
+        setFormatControl(message);
+        setFormatArguments(list(arg1, arg2));
+        setStream(stream);
+  }
+
     public ReaderError(LispObject initArgs)
     {
         super(StandardClass.READER_ERROR);

--- a/src/org/armedbear/lisp/Stream.java
+++ b/src/org/armedbear/lisp/Stream.java
@@ -1190,16 +1190,17 @@ public class Stream extends StructureObject {
                     return symbol;
 
                 // Error!
-                if (pkg.findInternalSymbol(symbolName) != null)
-                    return error(new ReaderError("The symbol \"" + symbolName +
-                                                 "\" is not external in package " +
-                                                 packageName + '.',
-                                                 this));
-                else
-                    return error(new ReaderError("The symbol \"" + symbolName +
-                                                 "\" was not found in package " +
-                                                 packageName + '.',
-                                                 this));
+                if (pkg.findInternalSymbol(symbolName) != null) {
+                    return error(new ReaderError("The symbol \"~A\" is not external in package ~A.",
+                                                 this,
+                                                 new SimpleString(symbolName),
+                                                 new SimpleString(packageName)));
+                } else {
+                    return error(new ReaderError("The symbol \"~A\" was not found in package ~A.",
+                                                 this,
+                                                 new SimpleString(symbolName),
+                                                 new SimpleString(packageName)));
+                }
             }
         } else {                // token.length == 0
             Package pkg = (Package)Symbol._PACKAGE_.symbolValue(thread);


### PR DESCRIPTION
This PR is taking a stab at fixing #85.

What I've done is add a new constructor to Reader Error with a new constructor that takes two extra arguments  that are passed to the format control string. This is not an ideal solution as I'm only handling a two arguments for the format control string case. Not even checking the number of arguments needed by the format control string.

Another thing I'm wondering is whether we should we look up the package so we can referrer to it by its name. With the code as is submitted if the package was being referred to by a nickname that is how it is going to show up in the ReaderError Condition. As data points, SBCL uses the string "COMMON-LISP" and CCL uses the package object itself.