### PR TITLE
Provisional hacks for running under openjdk-11

### DIFF
--- a/abcl.properties.in
+++ b/abcl.properties.in
@@ -15,8 +15,11 @@ abcl.build.incremental=true
 
 ## java.options sets the Java options in the abcl wrapper scripts
 
+# Java 11
+java.options=-XshowSettings:vm -Dfile.encoding=UTF-8
+
 # Maximum safe performance on JDK8
-java.options=-d64  -XX:+UseG1GC -XshowSettings:vm -Dfile.encoding=UTF-8 -XX:+AggressiveOpts -XX:CompileThreshold=10
+#java.options=-d64  -XX:+UseG1GC -XshowSettings:vm -Dfile.encoding=UTF-8 -XX:+AggressiveOpts -XX:CompileThreshold=10
 
 # Reasonable defaults for Java 8
 #java.options=-d64 -XshowSettings:vm -XX:+UseG1GC 

--- a/contrib/jss/invoke.lisp
+++ b/contrib/jss/invoke.lisp
@@ -464,9 +464,12 @@ associated is used to look up the static FIELD."
               'cons))
            (do-imports (cp)
              (import-classpath (expand-paths (split-classpath cp)))))
-    (do-imports (jcall "getClassPath" (jstatic "getRuntimeMXBean" '|java.lang.management.ManagementFactory|)))
-    (do-imports (jcall "getBootClassPath" (jstatic "getRuntimeMXBean" '|java.lang.management.ManagementFactory|)))))
 
+    (let ((mx-bean (jstatic "getRuntimeMXBean"
+                            '|java.lang.management.ManagementFactory|)))
+      (do-imports (jcall "getClassPath" mx-bean)))))
+
+#+(or)
 (eval-when (:load-toplevel :execute)
   (when *do-auto-imports* 
     (do-auto-imports)))


### PR DESCRIPTION
Surprisingly, the compiler seems to work fine, so the implementation
is certainly not intolerably slow under Java 11. JSS certainly does
not work but the ABCL-CONTRIB works for implementations with access to
a filesystem on which CL:DIRECTORY can work.

This patch reworks ABCL-CONTRIB strategy to introspect the value of
the the Java system property "java.class.path".  This may not be
sufficient to find the contribs under all possible ways that the
implementation may be hosted.

To provide some background to the issues here, ABCL-CONTRIB is
deliberately packaged separately from the contents of `abcl.jar` in
order to:

1. Keep the base ANSI implementation plus the included ASDF version in
   a single artifact with no other dependencies.

2. Push the decision to potentially infringe on licenses explicitly to
   the user.

The knowledgable User may use the build-time option for the inclusion
of code in system.lisp and the AIO packaging mechanism to create an
unified "All-in-one" artifact.

Since ASDF is always included as part of the base `abcl.jar`, we may
rely on its presence to find additional artifacts to add as additional
code to abcl, aka. "the abcl contribs".  Currently, this is achieved
by the following strategies, tried sequentially until one is found to
be successful:

1.  Introspecting for an implementation of "org.abcl-contrib" as
    declared in the system jar manifest.

2.  Attempting to locate a jar file named `abcl-contrib{MUMBLE}.jar`
    on the filesystem by searching directories referenced on the class
    path.

3.  Replacing the occurance of 'abcl' with 'abcl-contrib' in the the
    name of the system jar pathname, and then introspecting the
    contents.

It would probably be helpful to add the following strategies to find
members of ABCL-CONTRIB:

4.  Locating an `abcl-contrib.asd` artifact via the usual ASDF
    conventions.

5.  Retrieving the contents of ABCL-CONTRIB from the network via a
    "cool URI".

6.  (Java 11) Appropiate use of Java modules to describe graphs of
    loadable ABCL artifacts.