### PR TITLE
Check for element type before filling vectors.

### DIFF
--- a/src/org/armedbear/lisp/BasicVector_UnsignedByte16.java
+++ b/src/org/armedbear/lisp/BasicVector_UnsignedByte16.java
@@ -200,7 +200,17 @@ public final class BasicVector_UnsignedByte16 extends AbstractVector
     @Override
     public void fill(LispObject obj)
     {
-        int n = Fixnum.getValue(obj);
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 65535) {
+            type_error(obj, UNSIGNED_BYTE_16);
+            // Not reached.
+            return;
+        }
         for (int i = capacity; i-- > 0;)
             elements[i] = n;
     }

--- a/src/org/armedbear/lisp/BasicVector_UnsignedByte32.java
+++ b/src/org/armedbear/lisp/BasicVector_UnsignedByte32.java
@@ -207,8 +207,17 @@ public final class BasicVector_UnsignedByte32 extends AbstractVector
   @Override
   public void fill(LispObject obj)
   {
+    if (!(obj instanceof LispInteger)) {
+      type_error(obj, Symbol.INTEGER);
+      // Not reached.
+      return;
+    }
+    if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(obj, UNSIGNED_BYTE_32);
+    }
+    long value = obj.longValue();
     for (int i = capacity; i-- > 0;)
-      elements[i] = obj.longValue();
+      elements[i] = value;
   }
 
   @Override

--- a/src/org/armedbear/lisp/BasicVector_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/BasicVector_UnsignedByte8.java
@@ -211,9 +211,19 @@ public final class BasicVector_UnsignedByte8 extends AbstractVector
   @Override
   public void fill(LispObject obj)
   {
-    byte b = coerceLispObjectToJavaByte(obj);
+    if (!(obj instanceof Fixnum)) {
+      type_error(obj, Symbol.FIXNUM);
+      // Not reached.
+      return;
+    }
+    int n = ((Fixnum) obj).value;
+    if (n < 0 || n > 255) {
+      type_error(obj, UNSIGNED_BYTE_8);
+      // Not reached.
+      return;
+    }
     for (int i = capacity; i-- > 0;)
-      elements[i] = b;
+      elements[i] = (byte) n;
   }
 
   @Override

--- a/src/org/armedbear/lisp/ComplexArray_UnsignedByte32.java
+++ b/src/org/armedbear/lisp/ComplexArray_UnsignedByte32.java
@@ -219,6 +219,14 @@ public final class ComplexArray_UnsignedByte32 extends AbstractArray
     @Override
     public void fill(LispObject obj)
     {
+        if (!(obj instanceof LispInteger)) {
+            type_error(obj, Symbol.INTEGER);
+            // Not reached.
+            return;
+        }
+        if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+            type_error(obj, UNSIGNED_BYTE_32);
+        }
         if (data != null) {
             for (int i = data.length; i-- > 0;)
                 data[i] = obj;

--- a/src/org/armedbear/lisp/ComplexArray_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/ComplexArray_UnsignedByte8.java
@@ -215,10 +215,20 @@ public final class ComplexArray_UnsignedByte8 extends AbstractArray
     @Override
     public void fill(LispObject obj)
     {
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 255) {
+            type_error(obj, UNSIGNED_BYTE_8);
+            // Not reached.
+            return;
+        }
         if (data != null) {
-            byte b = coerceLispObjectToJavaByte(obj);
             for (int i = data.length; i-- > 0;)
-                data[i] = b;
+                data[i] = (byte) n;
         } else {
             for (int i = totalSize; i-- > 0;)
                 aset(i, obj);

--- a/src/org/armedbear/lisp/ComplexVector_UnsignedByte32.java
+++ b/src/org/armedbear/lisp/ComplexVector_UnsignedByte32.java
@@ -231,6 +231,14 @@ public final class ComplexVector_UnsignedByte32 extends AbstractVector
     @Override
     public void fill(LispObject obj)
     {
+        if (!(obj instanceof LispInteger)) {
+            type_error(obj, Symbol.INTEGER);
+            // Not reached.
+            return;
+        }
+        if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+            type_error(obj, UNSIGNED_BYTE_32);
+        }
         for (int i = capacity; i-- > 0;)
             elements[i] = obj;
     }

--- a/src/org/armedbear/lisp/ComplexVector_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/ComplexVector_UnsignedByte8.java
@@ -243,9 +243,19 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
     @Override
     public void fill(LispObject obj)
     {
-        byte b = (byte) Fixnum.getValue(obj);
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 255) {
+            type_error(obj, UNSIGNED_BYTE_8);
+            // Not reached.
+            return;
+        }
         for (int i = capacity; i-- > 0;)
-            elements[i] = b;
+            elements[i] = (byte) n;
     }
 
     @Override

--- a/src/org/armedbear/lisp/SimpleArray_UnsignedByte16.java
+++ b/src/org/armedbear/lisp/SimpleArray_UnsignedByte16.java
@@ -285,7 +285,17 @@ public final class SimpleArray_UnsignedByte16 extends AbstractArray
     @Override
     public void fill(LispObject obj)
     {
-        int n = Fixnum.getValue(obj);
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 65535) {
+            type_error(obj, UNSIGNED_BYTE_16);
+            // Not reached.
+            return;
+        }
         for (int i = totalSize; i-- > 0;)
             data[i] = n;
     }

--- a/src/org/armedbear/lisp/SimpleArray_UnsignedByte32.java
+++ b/src/org/armedbear/lisp/SimpleArray_UnsignedByte32.java
@@ -276,6 +276,14 @@ public final class SimpleArray_UnsignedByte32 extends AbstractArray
     @Override
     public void fill(LispObject obj)
     {
+        if (!(obj instanceof LispInteger)) {
+            type_error(obj, Symbol.INTEGER);
+            // Not reached.
+            return;
+        }
+        if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+            type_error(obj, UNSIGNED_BYTE_32);
+        }
         for (int i = totalSize; i-- > 0;)
             data[i] = obj;
     }

--- a/src/org/armedbear/lisp/SimpleArray_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/SimpleArray_UnsignedByte8.java
@@ -272,9 +272,19 @@ public final class SimpleArray_UnsignedByte8 extends AbstractArray
     @Override
     public void fill(LispObject obj)
     {
-        byte b = coerceLispObjectToJavaByte(obj);
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 255) {
+            type_error(obj, UNSIGNED_BYTE_8);
+            // Not reached.
+            return;
+        }
         for (int i = totalSize; i-- > 0;)
-            data[i] = b;
+            data[i] = (byte) n;
     }
 
     @Override


### PR DESCRIPTION
Attempting to fix https://abcl.org/trac/ticket/297.

```
(make-array 5 :element-type '(unsigned-byte 8) :initial-element 300)
=>
  The value 300 is not of type (UNSIGNED-BYTE 8).
;; was #(44 44 44 44 44)

(make-array 5 :element-type '(unsigned-byte 16) :initial-element (+ 300 (expt 2 16)))
=>
  The value 65836 is not of type (UNSIGNED-BYTE 16).
;; #(65836 65836 65836 65836 65836)
```