### PR TITLE
build: make target JVM and source compatiblity developer configurable

### DIFF
--- a/abcl.properties.in
+++ b/abcl.properties.in
@@ -8,6 +8,12 @@
 # Attempt to perform incremental compilation? 
 abcl.build.incremental=true
 
+## javac compiler options for ABCL build
+# generate class files for this target JVM
+abcl.javac.target=1.8
+# specify Java source compatiblity level
+abcl.javac.source=1.6
+
 # Additional site specific startup code to be merged in 'system.lisp' at build time
 #abcl.startup.file=${basedir}/startup.lisp
 

--- a/build.xml
+++ b/build.xml
@@ -193,15 +193,20 @@ For help on the automatic tests available, use the Ant target 'help.test'.
       </echo>
     </target>
 
+    <!-- For compiling beyond openjdk11, one needs to increment these values in <file:abcl.properties> -->
+    <property name="abcl.javac.target"
+              value="1.6"/>
+    <property name="abcl.javac.source"
+              value="1.6"/>
+
     <target name="abcl.compile.java" 
             depends="abcl.init,abcl.java.warning">
       <mkdir dir="${build.dir}"/>
       <mkdir dir="${build.classes.dir}"/>
-      <!-- Stock build for Java 1.6 (aka Java 2) container -->
       <javac destdir="${build.classes.dir}"
              debug="true"
-             target="1.6"
-             source="1.6"
+             target="${abcl.javac.target}"
+             source="${abcl.javac.source}"
              includeantruntime="false"
              failonerror="true">
         <src path="${src.dir}"/>


### PR DESCRIPTION
For compiling beyond openjdk11, one needs to increment the values of
'abcl.javac.target' and 'abcl.javac.source' in <file:abcl.properties>.