### PR TITLE
build: support abcl.properties creation openjdk{6,7,8,11,13,14}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ addons:
 env:
   - ABCL_JDK=openjdk8
   - ABCL_JDK=openjdk11
+  - ABCL_JDK=openjdk14
 
 install:
   - echo $(pwd)

--- a/README
+++ b/README
@@ -141,7 +141,17 @@ The build may be customized by copying <file:abcl.properties.in> to
 incrementally as well as optimizing the runtime for a contemporary
 64bit desktop/server machine running Java 8 or 11.  The file contains
 incomplete documentation on how it may be edited for subsequent
-customization.
+customization.  As an alternative to copying the prototype, if one has
+a version of bash locally, one may issue via Ant
+
+    ant abcl.properties.autoconfigure.openjdk.11
+
+or from the shell as
+
+    bash ci/create-abcl-properties.bash openjdk11
+
+Currently upported platforms are 'openjdk6', 'openjdk7', 'openjdk8',
+'openjdk11', 'openjdk13', and 'openjdk14'.
 
 
 Using NetBeans

--- a/abcl.properties.in
+++ b/abcl.properties.in
@@ -26,9 +26,14 @@ java.options=-XshowSettings:vm -Dfile.encoding=UTF-8
 ## will NOT work.  Instead one has to "manually" create lines
 
 #<>
+# <java/runtime> ( openjdk11, openjdk13, openjdk14 ) ;
+#
+#java.options=-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx<size> -Xlog:gc
+
+#<>
 #  <java/runtime> openjdk11 ;
 #  rdfs:seeAlso <https://blog.gceasy.io/2020/03/18/7-jvm-arguments-of-highly-effective-applications/> ;
-#java.options=-XX:+UseZGC
+#java.options=-XX:CompileThreshold=10
 
 #<>
 #  <java/runtime> openjdk8 ;

--- a/build.xml
+++ b/build.xml
@@ -1244,6 +1244,15 @@ JVM System Properties
             tofile="${dist.dir}/asdf.pdf"/>
     </target>
 
+    <target name="abcl.properties.autoconfigure.openjdk.11">
+      <exec executable="/usr/bin/env">
+        <arg value="bash"/>
+        <arg value="ci/create-abcl-properties.bash"/>
+        
+        <arg value="openjdk11"/>
+      </exec>
+    </target>
+          
     <import file="etc/ant/netbeans-build.xml"
             optional="true"/> 
     <import file="etc/ant/build-snapshot.xml"

--- a/ci/create-abcl-properties.bash
+++ b/ci/create-abcl-properties.bash
@@ -1,18 +1,47 @@
 #!/usr/bin/env bash
+DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 jdk=$1
 if [[ -z $jdk ]]; then
     jdk=openjdk8
 fi
 
+root="${DIR}/.."
+prop_in="${root}/abcl.properties.in"
+prop_out="${root}/abcl.properties"
+echo "Configuring for $jdk from <${prop_in}>."
+
+# Unused
+# zgc="-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -Xmx<size> -Xlog:gc"
+
+abcl_javac_source=1.8
 case $jdk in
-    openjdk8)
+    6|openjdk6)
+        options="-d64 -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1g -XX:+UseConcMarkSweepGC"
+        abcl_javac_source=1.6
+        ;;
+    7|openjdk7)
+	options="-d64 -XX:+UseG1GC"
+        abcl_javac_source=1.7
+	;;
+    8|openjdk8)
         options="-XX:+UseG1GC -XX:+AggressiveOpts -XX:CompileThreshold=10"
         ;;
-    openjdk11)
+    11|openjdk11)
         options="-XX:CompileThreshold=10"
+        ;;
+    # untested: weakly unsupported 
+    12|openjdk12)
+        options="-XX:CompileThreshold=10"
+        ;;
+    13|openjdk13)
+        options="-XX:CompileThreshold=10"
+        ;;
+    14|openjdk14)
+        options="-XX:CompileThreshold=10 ${zgc}"
         ;;
 esac
 
-cat abcl.properties.in | awk -F = -v options="$options" '/^java.options/ {print $0 " " options; next}; {print $0}' > abcl.properties
+cat ${root}/abcl.properties.in | awk -F = -v options="$options" -v source="$abcl_javac_source" '/^java.options/ {print $0 " " options; next}; /^abcl.javac.source/ {print "abcl.javac.source=" source; next}; {print $0}' > ${root}/abcl.properties
 
+echo "Finished configuring for $jdk into <${prop_out}>."

--- a/ci/install-adoptjdk.bash
+++ b/ci/install-adoptjdk.bash
@@ -24,6 +24,10 @@ function determine_adoptjdk() {
                     topdir=jdk-11.0.6+10
                     dist="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.6_10.tar.gz"
                     ;;
+                openjdk14)
+                    topdir=jdk-14.0.1+7
+                    dist="https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_x64_mac_hotspot_14.0.1_7.tar.gz"
+                    ;;
             esac
             ;;
         Linux)
@@ -35,6 +39,10 @@ function determine_adoptjdk() {
                 openjdk11)
                     topdir=jdk-11.0.6+10
                     dist="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz"
+                    ;;
+                openjdk14)
+                    topdir=jdk-14.0.1+7
+                    dist="https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_x64_linux_hotspot_14.0.1_7.tar.gz"
                     ;;
             esac
             ;;


### PR DESCRIPTION
Additionally add test for openjdk14 to the Travis-CI build.

Improve script for creating build properties, which may be invoked
like:

    bash ci/create-abcl-properties.bash openjdk8

Currently this script has baked-in "knowledge" of options for various
platforms for now, but will eventually directly transcribe from the
"facts" in <file:abcl.rdf>.