### PR TITLE
build: can now use Maven to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project
    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-   xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-
-  <!-- NOT USABLE FOR BUILDS, only for installing into a repository! -->
+   xmlns="http://maven.apache.org/POM/4.0.0"
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -57,5 +56,65 @@
       <email>rudi (at) constantly (dot) at</email>
     </developer>
   </developers>
-  <dependencies />
+  <dependencies/>
+  <build>
+    <directory>${project.basedir}/build</directory>
+    <sourceDirectory>${project.basedir}/src</sourceDirectory>
+    <plugins>
+      <plugin>
+	<artifactId>maven-antrun-plugin</artifactId>
+	<version>3.0.0</version>
+	<!-- <https://stackoverflow.com/questions/34713222/wrapping-ant-in-maven-java-home-points-to-the-jre-but-works-with-just-ant> -->
+	<!-- Since tools.jar doesn't exist post-openjdk8, this isn't
+	     gonna work everywhere -->
+	<dependencies>
+	  <dependency>
+	    <groupId>com.sun</groupId>
+	    <artifactId>tools</artifactId>
+	    <version>1.5.0</version>
+	    <scope>system</scope>
+	    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+	  </dependency>
+	</dependencies>
+	<executions>
+	  <execution>
+	    <id>clean</id>
+	    <phase>clean</phase>
+	    <configuration>
+	      <target>
+		<ant antfile="build.xml" target="abcl.clean"/>
+	      </target>
+	    </configuration>
+	    <goals>
+	      <goal>run</goal>
+	    </goals>      
+	  </execution>
+	  <execution>
+	    <id>compile</id>
+	    <phase>compile</phase>
+	    <configuration>
+	      <target>
+		<ant antfile="build.xml" target="abcl.compile"/>
+	      </target>
+	    </configuration>
+	    <goals>
+	      <goal>run</goal>
+	    </goals>      
+	  </execution>
+	  <execution>
+	    <id>package</id>
+	    <phase>package</phase>
+	    <configuration>
+	      <target>
+		<ant antfile="build.xml" target="abcl.jar"/>
+	      </target>
+	    </configuration>
+	    <goals>
+	      <goal>run</goal>
+	    </goals>      
+	  </execution>
+	</executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
The basic assembly of <file:dist/abcl.jar> now works, although these
aren't completely hooked up to Maven's notion of output artifacts.

TODO:

We aren't really intercepting maven-jar-plugin default-jar goal
correctly, so the resulting <file:build/abcl-1.6.x-SNAPSHOT.jar>
artifact doesn't contain all artifacts.  We probably need to correctly
define our resources to Maven, but they are currently expressed as
various Ant properties, so we need to slave the Maven goals to
appropiate Ant tasks?

Maven really wants to create all output under a single directory,
while the Ant recipe puts intermediate artifacts under <file:build/>
and final results in <file:dist/>.

Need to somehow encapsulate the existence of
<file:dist/abcl-contrib.jar> within the <file:contrib/pom.xml> Maven
description, even though its build is part of the Ant `abcl.jar` task.