### PR TITLE
abcl-introspect: start collecting various dissassemblers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ install:
 # TODO: figure out how to add abcl to our path
 
 script:
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-introspect.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cffi.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cl+ssl.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl.lisp

--- a/ci/test-abcl-introspect.lisp
+++ b/ci/test-abcl-introspect.lisp
@@ -1,2 +1,6 @@
 (ql:quickload :abcl-introspect)
+;;; shouldn't be necessary…
+(ql:quickload :prove)
+(ql:quickload :prove-asdf)
+(ql:quickload :abcl-introspect-tests)
 (asdf:test-system :abcl-introspect)

--- a/ci/test-abcl-introspect.lisp
+++ b/ci/test-abcl-introspect.lisp
@@ -1,0 +1,2 @@
+(ql:quickload :abcl-introspect)
+(asdf:test-system :abcl-introspect)

--- a/contrib/abcl-introspect/jad.asd
+++ b/contrib/abcl-introspect/jad.asd
@@ -1,0 +1,5 @@
+(defsystem jad
+  :description "Introspect runtime architecture, install appropiate JAD binary, use it."
+  :depends-on (abcl-build)
+  :components ((:file "jad")))
+

--- a/contrib/abcl-introspect/jad.lisp
+++ b/contrib/abcl-introspect/jad.lisp
@@ -17,21 +17,28 @@
    ((uiop/os:os-macosx-p)
     "http://www.javadecompilers.com/jad/Jad%201.5.8g%20for%20Mac%20OS%20X%2010.4.6%20on%20Intel%20platform.zip")))
 
-(defvar *working-jad-path* nil)
+(defvar *working-jad-executable* nil)
   
 (defun ensure-jad ()
-  (if (null *working-jad-path*)
-      (let ((jad-path (abcl-build:introspect-path-for "jad")))
-        (if (and jad-path
-                 (handler-case
-                     (uiop:run-program jad-path)
-                   (uiop/run-program:subprocess-error (e) nil)))
-            (setf *working-jad-path* jad-path))
-        (progn
-          (abcl-build:xdg/install (introspect-jad-uri) :type :unzip)
-          (setf *working-jad-path* nil)))
-      *working-jad-path*))
-
+  (flet
+      ((install-jad-returning-path (uri)
+         (abcl-build:xdg/install (pathname uri) :type :unzip))
+       (working-jad-p (jad-path)
+         (handler-case
+             (uiop:run-program jad-path)
+           (uiop/run-program:subprocess-error (e) nil))))
+      (if (null *working-jad-executable*)
+          (let ((jad-path (abcl-build:introspect-path-for "jad")))
+            (if (and jad-path
+                     (working-jad-p jad-path))
+                (setf *working-jad-executable* jad-path)
+                (progn
+                  (install-jad-returning-path (introspect-jad-uri))
+                  (setf *working-jad-executable* jad-path))))
+          (unless (working-jad-p)
+            (setf *working-jad-executable*
+                  (install-jad-returning-path (introspect-jad-uri)))))))
+          
 (defun disassemble-class-bytes (object)
   (ensure-jad)
   (let ((sys:::*disassembler*

--- a/contrib/abcl-introspect/jad.lisp
+++ b/contrib/abcl-introspect/jad.lisp
@@ -41,6 +41,6 @@
           
 (defun disassemble-class-bytes (object)
   (ensure-jad)
-  (let ((sys:::*disassembler*
-          (format nil "~s -a -p" *working-jad-path*)))
+  (let ((sys::*disassembler*
+          (format nil "~s -a -p" *working-jad-executable*)))
     (cl:disassemble object)))

--- a/contrib/abcl-introspect/jad.lisp
+++ b/contrib/abcl-introspect/jad.lisp
@@ -1,8 +1,39 @@
+(defpackage :abcl-introspect/jvm/tools/jad
+  (:use #:cl)
+  (:nicknames #:jvm/tools/jad #:jad)
+  (:export
+   #:disassemble-class-bytes))
+
 #|
 
 <http://www.javadecompilers.com/jad/Jad%201.5.8g%20for%20Mac%20OS%20X%2010.4.6%20on%20Intel%20platform.zip>
 
 |#
 
+(in-package :abcl-introspect/jvm/tools/jad)
 
+(defun introspect-jad-uri ()
+  (uiop:os-cond
+   ((uiop/os:os-macosx-p)
+    "http://www.javadecompilers.com/jad/Jad%201.5.8g%20for%20Mac%20OS%20X%2010.4.6%20on%20Intel%20platform.zip")))
 
+(defvar *working-jad-path* nil)
+  
+(defun ensure-jad ()
+  (if (null *working-jad-path*)
+      (let ((jad-path (abcl-build:introspect-path-for "jad")))
+        (if (and jad-path
+                 (handler-case
+                     (uiop:run-program jad-path)
+                   (uiop/run-program:subprocess-error (e) nil)))
+            (setf *working-jad-path* jad-path))
+        (progn
+          (abcl-build:xdg/install (introspect-jad-uri) :type :unzip)
+          (setf *working-jad-path* nil)))
+      *working-jad-path*))
+
+(defun disassemble-class-bytes (object)
+  (ensure-jad)
+  (let ((sys:::*disassembler*
+          (format nil "~s -a -p" *working-jad-path*)))
+    (cl:disassemble object)))

--- a/contrib/abcl-introspect/jad.lisp
+++ b/contrib/abcl-introspect/jad.lisp
@@ -43,4 +43,5 @@
   (ensure-jad)
   (let ((sys::*disassembler*
           (format nil "~s -a -p" *working-jad-executable*)))
-    (cl:disassemble object)))
+    (sys:disassemble-class-bytes object)))
+

--- a/contrib/abcl-introspect/jad.lisp
+++ b/contrib/abcl-introspect/jad.lisp
@@ -35,7 +35,7 @@
                 (progn
                   (install-jad-returning-path (introspect-jad-uri))
                   (setf *working-jad-executable* jad-path))))
-          (unless (working-jad-p)
+          (unless (working-jad-p *working-jad-executable*)
             (setf *working-jad-executable*
                   (install-jad-returning-path (introspect-jad-uri)))))))
           

--- a/contrib/abcl-introspect/jad.lisp
+++ b/contrib/abcl-introspect/jad.lisp
@@ -1,0 +1,8 @@
+#|
+
+<http://www.javadecompilers.com/jad/Jad%201.5.8g%20for%20Mac%20OS%20X%2010.4.6%20on%20Intel%20platform.zip>
+
+|#
+
+
+

--- a/contrib/abcl-introspect/javap.asd
+++ b/contrib/abcl-introspect/javap.asd
@@ -1,0 +1,4 @@
+(defsystem javap
+  :description "Utilization of the javap command line dissassembler"
+  :components ((:file "javap")))
+

--- a/contrib/abcl-introspect/javap.lisp
+++ b/contrib/abcl-introspect/javap.lisp
@@ -1,23 +1,25 @@
+(defpackage :abcl-introspect/jvm/tools/javap
+  (:use #:cl)
+  (:export
+   #:disassemble-class-bytes))
+
 ;; use javap
 #|
 (let ((sys::*disassembler* "javap -c -verbose"))
   (disassemble 'cons))
 |#
 
-(in-package :cl-user)
-(defpackage :abcl/build/jvm/tools/javap
-  (:use :cl)
-  (:export
-   #:disassemble-class-bytes))
 
-(in-package :abcl/build/jvm/tools/javap)
+(in-package :abcl-introspect/jvm/tools/javap)
+
 
 (defun disassemble-class-bytes (object)
   (let ((sys::*disassembler* "javap -c -verbose"))
     (disassemble object)))
 
+
 (eval-when (:load-toplevel :execute)
-  (pushnew `(:javap . abcl/build/jvm/tools/javap::disassemble-class-bytes)
+  (pushnew `(:javap . abcl-introspect/jvm/tools/javap::disassemble-class-bytes)
            sys::*disassemblers*)
   (format cl:*load-verbose* "~&; ~a ; Successfully added javap disassembler.~%" *package*))
 

--- a/contrib/abcl-introspect/javap.lisp
+++ b/contrib/abcl-introspect/javap.lisp
@@ -1,0 +1,29 @@
+;; use javap
+#|
+(let ((sys::*disassembler* "javap -c -verbose"))
+  (disassemble 'cons))
+|#
+
+(in-package :cl-user)
+(defpackage :abcl/build/jvm/tools/javap
+  (:use :cl)
+  (:export
+   #:disassemble-class-bytes))
+
+(in-package :abcl/build/jvm/tools/javap)
+
+(defun disassemble-class-bytes (object)
+  (let ((sys::*disassembler* "javap -c -verbose"))
+    (disassemble object)))
+
+(eval-when (:load-toplevel :execute)
+  (pushnew `(:javap . abcl/build/jvm/tools/javap::disassemble-class-bytes)
+           sys::*disassemblers*)
+  (format cl:*load-verbose* "~&; ~a ; Successfully added javap disassembler.~%" *package*))
+
+
+
+
+
+
+

--- a/contrib/abcl-introspect/javap.lisp
+++ b/contrib/abcl-introspect/javap.lisp
@@ -3,20 +3,17 @@
   (:export
    #:disassemble-class-bytes))
 
-;; use javap
+;;;; JDK javap <https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javap.html>
 #|
 (let ((sys::*disassembler* "javap -c -verbose"))
   (disassemble 'cons))
 |#
 
-
 (in-package :abcl-introspect/jvm/tools/javap)
-
 
 (defun disassemble-class-bytes (object)
   (let ((sys::*disassembler* "javap -c -verbose"))
-    (disassemble object)))
-
+    (sys:disassemble-class-bytes object)))
 
 (eval-when (:load-toplevel :execute)
   (pushnew `(:javap . abcl-introspect/jvm/tools/javap::disassemble-class-bytes)

--- a/contrib/abcl-introspect/objectweb.lisp
+++ b/contrib/abcl-introspect/objectweb.lisp
@@ -1,9 +1,8 @@
-(in-package :cl-user)
-(defpackage :abcl/build/jvm/tools/objectweb
+(defpackage :abcl-introspect/jvm/tools/objectweb
   (:use :cl)
   (:export
    #:disassemble-class-bytes))
-(in-package :abcl/build/jvm/tools/objectweb)
+(in-package :abcl-introspect/jvm/tools/objectweb)
 
 (defun disassemble-class-bytes (object)
   (let* ((reader (java:jnew "org.objectweb.asm.ClassReader" object))
@@ -16,7 +15,7 @@
     (java:jcall "toString" writer)))
 
 (eval-when (:load-toplevel :execute)
-  (pushnew `(:objectweb . abcl/build/jvm/tools/objectweb::disassemble-class-bytes)
+  (pushnew `(:objectweb . abcl-introspect/jvm/tools/objectweb::disassemble-class-bytes)
            sys::*disassemblers*)
   (format cl:*load-verbose* "~&; ~a ; Successfully added Objectweb disassembler.~%" *package*))
 

--- a/contrib/abcl-introspect/procyon.asd
+++ b/contrib/abcl-introspect/procyon.asd
@@ -1,0 +1,7 @@
+(defsystem procyon
+    :homepage https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler
+    ((:module maven
+              :components
+              ((:mvn "org.jboss.windup.decompiler/decompile-procyon/4.3.1.Final")))))
+
+

--- a/contrib/abcl-introspect/procyon.asd
+++ b/contrib/abcl-introspect/procyon.asd
@@ -1,7 +1,15 @@
 (defsystem procyon
-    :homepage https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler
-    ((:module maven
-              :components
-              ((:mvn "org.jboss.windup.decompiler/decompile-procyon/4.3.1.Final")))))
+  :version "4.3.1"
+  :homepage "https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler"
+  :components
+  ((:module mvn-libs
+    :components
+    ((:mvn "org.jboss.windup.decompiler/decompile-procyon/4.3.1.Final")))
+   (:module source
+    :depends-on (mvn-libs))
+   :components
+   ((:file "procyon")))))
+
+
 
 

--- a/contrib/abcl-introspect/procyon.asd
+++ b/contrib/abcl-introspect/procyon.asd
@@ -1,14 +1,14 @@
 (defsystem procyon
   :version "4.3.1"
   :homepage "https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler"
-  :components
-  ((:module mvn-libs
-    :components
-    ((:mvn "org.jboss.windup.decompiler/decompile-procyon/4.3.1.Final")))
+  :depends-on (alexandria) :components
+  ((:module mvn-libs :components
+            ((:mvn "org.jboss.windup.decompiler/decompile-procyon/4.3.1.Final")))
    (:module source
-    :depends-on (mvn-libs))
-   :components
-   ((:file "procyon")))))
+    :depends-on (mvn-libs) :components
+    ((:file "procyon")))))
+
+
 
 
 

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -23,7 +23,8 @@ catch (final IOException e) {
     // handle error
 }
 
-|# 
+|#
+(in-package :abcl-introspect/jvm/tools/procyon)
 
 (in-package :abcl-introspect/jvm/tools/procyon)
 (defun disassemble-class-bytes (object)

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -1,5 +1,5 @@
 (in-package :cl-user)
-(defpackage :abcl/build/jvm/tools/procyon
+(defpackage :abcl-introspect/jvm/tools/procyon
     (:use :cl)
     (:export
      #:disassemble-class-bytes))

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -4,7 +4,10 @@
     (:export
      #:disassemble-class-bytes))
 
-#|
+(in-package :abcl-introspect/jvm/tools/procyon)
+
+(defun disassemble-class-bytes (object)
+  #|
   
   <https://bitbucket.org/mstrobel/procyon/wiki/Decompiler%20API> 
 
@@ -23,9 +26,21 @@ catch (final IOException e) {
     // handle error
 }
 
-|#
-(in-package :abcl-introspect/jvm/tools/procyon)
+  |#
+  (with-temp-file (p)
+    (alexandria:with-output-to-file (o p)
+      (write (get-bytes object) :stream o)
+    (let* ((settings
+             (#"javaDefaults" 'DecompilerSettings))
+           (stream
+             (jss:new 'FileOutputStream (namestring p)))
+           (writer
+             (jss:new 'OutputStreamWriter stream)))
+      (#"decompile" 'Decompiler
+                    "java/lang/String"
+                    (jss:new 'PlainTextOutput writer)
+                    settings))))
 
-(in-package :abcl-introspect/jvm/tools/procyon)
-(defun disassemble-class-bytes (object)
+                    
   (error "Unimplemented use of procyon dissassembler."))
+

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -25,5 +25,6 @@ catch (final IOException e) {
 
 |# 
 
+(in-package :abcl-introspect/jvm/tools/procyon)
 (defun disassemble-class-bytes (object)
   (error "Unimplemented use of procyon dissassembler."))

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -4,5 +4,26 @@
     (:export
      #:disassemble-class-bytes))
 
+#|
+  
+  <https://bitbucket.org/mstrobel/procyon/wiki/Decompiler%20API> 
+
+final DecompilerSettings settings = DecompilerSettings.javaDefaults();
+
+try (final FileOutputStream stream = new FileOutputStream("path/to/file");
+     final OutputStreamWriter writer = new OutputStreamWriter(stream)) {
+
+    Decompiler.decompile(
+        "java/lang/String",
+        new PlainTextOutput(writer),
+        settings
+    );
+}
+catch (final IOException e) {
+    // handle error
+}
+
+|# 
+
 (defun disassemble-class-bytes (object)
   (error "Unimplemented use of procyon dissassembler."))

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -27,15 +27,15 @@ catch (final IOException e) {
 }
 
   |#
-  (with-temp-file (p)
+  (let ((p (ext:make-temp-file)))
     (alexandria:with-output-to-file (o p)
-      (write (get-bytes object) :stream o)
+      (write object :stream o))
     (let* ((settings
-             (#"javaDefaults" 'DecompilerSettings))
+            (#"javaDefaults" 'DecompilerSettings))
            (stream
-             (jss:new 'FileOutputStream (namestring p)))
+            (jss:new 'FileOutputStream (namestring p)))
            (writer
-             (jss:new 'OutputStreamWriter stream)))
+            (jss:new 'OutputStreamWriter stream)))
       (#"decompile" 'Decompiler
                     "java/lang/String"
                     (jss:new 'PlainTextOutput writer)

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -1,0 +1,8 @@
+(in-package :cl-user)
+(defpackage :abcl/build/jvm/tools/procyon
+    (:use :cl)
+    (:export
+     #:disassemble-class-bytes))
+
+(defun disassemble-class-bytes (object)
+  (error "Unimplemented use of procyon dissassembler."))

--- a/contrib/abcl-introspect/t/disassemble.lisp
+++ b/contrib/abcl-introspect/t/disassemble.lisp
@@ -3,24 +3,33 @@
 (let ((disassembler (first (abcl-build:split-string
                             ext:*disassembler* #\Space))))
   (prove:plan 1)
-  (prove:ok (abcl-build:introspect-path-for disassembler)
-            (format nil
-                    "Testing invocation of ~a specified by EXT:*DISASSEMBLER*…" disassembler)))
+  (prove:ok
+   (abcl-build:introspect-path-for disassembler)
+   (format nil
+           "Testing invocation of ~a specified by EXT:*DISASSEMBLER*…" disassembler)))
 
-;;; FIXME move dependency load into ASDF definitions
-(asdf:load-system :objectweb)
-(prove:plan 2)
-(prove:is
- (sys:choose-disassembler)
- 'ABCL/BUILD/JVM/TOOLS/OBJECTWEB::DISASSEMBLE-CLASS-BYTES)
-(let ((output (make-string-output-stream)))
-  (let ((*standard-output* output))
-    (disassemble #'cons))
-  (let ((result (get-output-stream-string output)))
-    (prove:ok (and result
-                   (stringp result)
-                   (> (length result) 0))
-              "Invocation of Objectweb disassembler.")))
+(let ((disassemblers '(:objectweb :javap :jad))) 
+  (prove:plan (* 2 (length disassemblers)))
+  (dolist (disassembler disassemblers)
+    (prove:is 
+     (asdf:load-system disassembler)
+     (format nil "Loading ~a" disassembler))
+    (prove:is
+     (sys:choose-disassembler disassembler)
+     (uiop:reify-symbol :disassemble-class-bytes
+                        (format nil "abcl-introspect/jvm/tools/~a" disassembler))
+     (format nil "Able to choose ~a" disassembler)))
+  (prove:plan (length disassemblers))
+  (dolist (disassembler disassemblers)
+    (let ((output (make-string-output-stream)))
+      (sys:choose-disassembler disassembler)
+      (let ((*standard-output* output))
+        (cl:disassemble #'cons))
+      (let ((result (get-output-stream-string output)))
+        (prove:ok (and result
+                       (stringp result)
+                       (> (length result) 0))
+                  (format nil "Invocation of ~a disassembler" disassembler))))))
 
 (prove:finalize)
 


### PR DESCRIPTION
TODO: ensure that CL:DISSASSEMBLER can do do something.  If we can
load ABCL-INTROSPECT we should interogate the assembler hooks until we
work.

TODO: deprecate JAD dissassembler

Start collecting the download URIs for more common JAD archiectures.

TODO: genralize the introspect of the correct architecture at runtime.