### PR TITLE
Test for DIVISION-BY-ZERO has ARITHMETIC-ERROR-OPERANDS unbound

### DIFF
--- a/t/math.lisp
+++ b/t/math.lisp
@@ -1,0 +1,11 @@
+;;; <https://github.com/armedbear/abcl/issues/177>
+
+(prove:plan 1)
+
+(prove:is
+ (let ((condition (handler-case (/ 6 0) (division-by-zero (c) c))))
+   (arithmetic-error-operands condition))
+ '(6 0)
+ "DIVISION-BY-ZERO problems with operands")
+
+(prove:finalize)


### PR DESCRIPTION
(phoe)

Works under SBCL, CCL and ECL.

<https://github.com/armedbear/abcl/issues/177>