### PR TITLE
Make javap the default for CL:DISASSEMBLE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ install:
 # TODO: figure out how to add abcl to our path
 
 script:
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-introspect.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cffi.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cl+ssl.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl.lisp

--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,11 @@ Unreleased
 <https://gitlab.common-lisp.net/abcl/abcl/>
 <https://abcl.org/svn/trunk/abcl/>
 
+Enhancements
+============
+
+* [] Fix and extend SYS:CHOOSE-ASSEMBLER functionality for CL:DISASSEMBLE
+
 
 Version 1.6.1
 =============

--- a/abcl.rdf
+++ b/abcl.rdf
@@ -19,7 +19,7 @@
   dc:identifier         <urn:abcl.org/1.6.2#dev> ;           
   doap:language        "Common Lisp" ;
   dc:created           "01-JAN-2004" ;
-  dc:modified          "29-APR-2020" ;
+  dc:modified          "11-MAY-2020" ;
   dc:version           "abcl-1.6.2" ;
   dc:release           "dev" ;
   abcl:git             <https://github.com/armedbear/abcl/> ;
@@ -162,7 +162,7 @@ abcl:asdf
         dc:version "3.3.4" .
 
 abcl:abcl-introspect  
-  rdfs:seeAlso <file:contrib/abcl-introspect/README.markdown> .                             
+  rdfs:seeAlso <file:contrib/abcl-introspect/README.org> .                             
 
 abcl:abcl-contrib  
   rdfs:seeAlso <file:contrib/README.markdown> .                             

--- a/ci/test-abcl-introspect.lisp
+++ b/ci/test-abcl-introspect.lisp
@@ -1,2 +1,2 @@
-(ql:quickload :abcl-introspect)
+(ql:quickload :abcl-introspect-test)
 (asdf:test-system :abcl-introspect)

--- a/ci/test-abcl-introspect.lisp
+++ b/ci/test-abcl-introspect.lisp
@@ -1,0 +1,2 @@
+(ql:quickload :abcl-introspect)
+(asdf:test-system :abcl-introspect)

--- a/contrib/abcl-introspect/README.markdown
+++ b/contrib/abcl-introspect/README.markdown
@@ -9,9 +9,130 @@ variables are inspectable.
 See <https://github.com/easye/slime/tree/evenson-merge-20170529a> for
 the changes to SLIME that were working well at the time of release.
 
-ObjectWeb
----------
 
-The ObjectWeb JVM bytecode assembler may be used via loading the
-'objectweb.asd' definition.
+CL:DISASSEMBLE
+--------------
+
+ABCL-INTROSPECT also contains a number of ASDF systems which provide
+modules to install as implementations for JVM code analysis provided
+by CL:DISASSEMBLE.
+
+objectweb
+  
+javap
+
+jad
+
+procyon 
+
+cfr
+
+fernflower
+
+
+These systems may be used by first loading the appropiate ASDF
+definition then using the SYS:CHOOSE-DISASSEMBLER function to select.
+Currently available disassemblers are contained in the
+SYS:*DISASSEMBLERS* variable.
+
+For example, to use the javap command-line tool included with the Java
+Development Kit:
+
+    (require :abcl-contrib)
+    (asdf:load-system :javap)
+    (sys:choose-disassembler :javap)
+    (cl:disassembler 'cons)
+    ; Classfile /var/folders/yb/xlwjwjfs3l73n3vrcjwqwqs40000gn/T/abcl3108750031103632433.class
+    ;   Last modified May 11, 2020; size 910 bytes
+    ;   MD5 checksum fec1c72a76ccbb35e17be8c2de9b315e
+    ;   Compiled from "Primitives.java"
+    ; final class org.armedbear.lisp.Primitives$pf_cons extends org.armedbear.lisp.Primitive
+    ;   minor version: 0
+    ;   major version: 52
+    ;   flags: ACC_FINAL, ACC_SUPER
+    ; Constant pool:
+    ;    #1 = Fieldref           #24.#25        // org/armedbear/lisp/Symbol.CONS:Lorg/armedbear/lisp/Symbol;
+    ;    #2 = String             #26            // object-1 object-2
+    ;    #3 = Methodref          #7.#27         // org/armedbear/lisp/Primitive."<init>":(Lorg/armedbear/lisp/Symbol;Ljava/lang/String;)V
+    ;    #4 = Class              #28            // org/armedbear/lisp/Cons
+    ;    #5 = Methodref          #4.#29         // org/armedbear/lisp/Cons."<init>":(Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)V
+    ;    #6 = Class              #31            // org/armedbear/lisp/Primitives$pf_cons
+    ;    #7 = Class              #32            // org/armedbear/lisp/Primitive
+    ;    #8 = Utf8               <init>
+    ;    #9 = Utf8               ()V
+    ;   #10 = Utf8               Code
+    ;   #11 = Utf8               LineNumberTable
+    ;   #12 = Utf8               LocalVariableTable
+    ;   #13 = Utf8               this
+    ;   #14 = Utf8               pf_cons
+    ;   #15 = Utf8               InnerClasses
+    ;   #16 = Utf8               Lorg/armedbear/lisp/Primitives$pf_cons;
+    ;   #17 = Utf8               execute
+    ;   #18 = Utf8               (Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)Lorg/armedbear/lisp/LispObject;
+    ;   #19 = Utf8               first
+    ;   #20 = Utf8               Lorg/armedbear/lisp/LispObject;
+    ;   #21 = Utf8               second
+    ;   #22 = Utf8               SourceFile
+    ;   #23 = Utf8               Primitives.java
+    ;   #24 = Class              #33            // org/armedbear/lisp/Symbol
+    ;   #25 = NameAndType        #34:#35        // CONS:Lorg/armedbear/lisp/Symbol;
+    ;   #26 = Utf8               object-1 object-2
+    ;   #27 = NameAndType        #8:#36         // "<init>":(Lorg/armedbear/lisp/Symbol;Ljava/lang/String;)V
+    ;   #28 = Utf8               org/armedbear/lisp/Cons
+    ;   #29 = NameAndType        #8:#37         // "<init>":(Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)V
+    ;   #30 = Class              #38            // org/armedbear/lisp/Primitives
+    ;   #31 = Utf8               org/armedbear/lisp/Primitives$pf_cons
+    ;   #32 = Utf8               org/armedbear/lisp/Primitive
+    ;   #33 = Utf8               org/armedbear/lisp/Symbol
+    ;   #34 = Utf8               CONS
+    ;   #35 = Utf8               Lorg/armedbear/lisp/Symbol;
+    ;   #36 = Utf8               (Lorg/armedbear/lisp/Symbol;Ljava/lang/String;)V
+    ;   #37 = Utf8               (Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)V
+    ;   #38 = Utf8               org/armedbear/lisp/Primitives
+    ; {
+    ;   org.armedbear.lisp.Primitives$pf_cons();
+    ;     descriptor: ()V
+    ;     flags:
+    ;     Code:
+    ;       stack=3, locals=1, args_size=1
+    ;          0: aload_0
+    ;          1: getstatic     #1                  // Field org/armedbear/lisp/Symbol.CONS:Lorg/armedbear/lisp/Symbol;
+    ;          4: ldc           #2                  // String object-1 object-2
+    ;          6: invokespecial #3                  // Method org/armedbear/lisp/Primitive."<init>":(Lorg/armedbear/lisp/Symbol;Ljava/lang/String;)V
+    ;          9: return
+    ;       LineNumberTable:
+    ;         line 467: 0
+    ;         line 468: 9
+    ;       LocalVariableTable:
+    ;         Start  Length  Slot  Name   Signature
+    ;             0      10     0  this   Lorg/armedbear/lisp/Primitives$pf_cons;
+    ; 
+    ;   public org.armedbear.lisp.LispObject execute(org.armedbear.lisp.LispObject, org.armedbear.lisp.LispObject);
+    ;     descriptor: (Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)Lorg/armedbear/lisp/LispObject;
+    ;     flags: ACC_PUBLIC
+    ;     Code:
+    ;       stack=4, locals=3, args_size=3
+    ;          0: new           #4                  // class org/armedbear/lisp/Cons
+    ;          3: dup
+    ;          4: aload_1
+    ;          5: aload_2
+    ;          6: invokespecial #5                  // Method org/armedbear/lisp/Cons."<init>":(Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)V
+    ;          9: areturn
+    ;       LineNumberTable:
+    ;         line 474: 0
+    ;       LocalVariableTable:
+    ;         Start  Length  Slot  Name   Signature
+    ;             0      10     0  this   Lorg/armedbear/lisp/Primitives$pf_cons;
+    ;             0      10     1 first   Lorg/armedbear/lisp/LispObject;
+    ;             0      10     2 second   Lorg/armedbear/lisp/LispObject;
+    ; }
+    ; SourceFile: "Primitives.java"
+
+
+
+
+
+
+
+
 

--- a/contrib/abcl-introspect/README.markdown
+++ b/contrib/abcl-introspect/README.markdown
@@ -41,7 +41,7 @@ Development Kit:
     (require :abcl-contrib)
     (asdf:load-system :javap)
     (sys:choose-disassembler :javap)
-    (cl:disassembler 'cons)
+    (cl:disassemble 'cons)
     ; Classfile /var/folders/yb/xlwjwjfs3l73n3vrcjwqwqs40000gn/T/abcl3108750031103632433.class
     ;   Last modified May 11, 2020; size 910 bytes
     ;   MD5 checksum fec1c72a76ccbb35e17be8c2de9b315e

--- a/contrib/abcl-introspect/README.org
+++ b/contrib/abcl-introspect/README.org
@@ -1,7 +1,4 @@
-#+TITLE: ABCL-INTROSPECT
-
 * ABCL-INTROSPECT
-
 ** Introduction
 
 ABCL-INTROSPECT offers more extensive systems for inspecting the state
@@ -33,13 +30,11 @@ provided by CL:DISASSEMBLE.
 
 
 These systems may be used by first loading the appropiate ASDF
-definition then using the SYS:CHOOSE-DISASSEMBLER function to select.
-Currently available disassemblers are contained in the
-SYS:*DISASSEMBLERS* variable.
+definition then using the SYS:CHOOSE-DISASSEMBLER function to select
+the loaded system.  Currently available disassemblers are contained in
+the SYS:*DISASSEMBLERS* variable.
 
-For example, to use the javap command-line tool included with the Java
-Development Kit:
-
+#+caption: Using the ~javap~ Tool to Disassemble a Function
 #+begin_src lisp
     (require :abcl-contrib)
     (asdf:load-system :javap)
@@ -132,16 +127,11 @@ Development Kit:
     ; SourceFile: "Primitives.java"
 #+end_src    
     
-# Colophon
+* Colophon
 
-<> <https://abcl.org/svn/trunk/abcl/contrib/abcl-introspect/README.org> ;
-:supersedes <https://abcl.org/svn/trunk/abcl/contrib/abcl-introspect/README.markdown> .
-
-
-
-
-
-
-
-
-
+#+caption: Metadata Colophon
+#+begin_src n3
+<> dc:source   <https://abcl.org/svn/trunk/abcl/contrib/abcl-introspect/README.org> ;
+   dc:replaces <https://abcl.org/svn/trunk/abcl/contrib/abcl-introspect/README.markdown> ;
+   dc:modified "<2020-05-12 Tue 10:21>" .
+#+end_src

--- a/contrib/abcl-introspect/README.org
+++ b/contrib/abcl-introspect/README.org
@@ -1,5 +1,8 @@
-ABCL-INTROSPECT
-===============
+#+TITLE: ABCL-INTROSPECT
+
+* ABCL-INTROSPECT
+
+** Introduction
 
 ABCL-INTROSPECT offers more extensive systems for inspecting the state
 of the implementation, most notably in integration with SLIME, where
@@ -9,25 +12,22 @@ variables are inspectable.
 See <https://github.com/easye/slime/tree/evenson-merge-20170529a> for
 the changes to SLIME that were working well at the time of release.
 
-
-CL:DISASSEMBLE
---------------
+** CL:DISASSEMBLE
 
 ABCL-INTROSPECT also contains a number of ASDF systems which provide
-modules to install as implementations for JVM code analysis provided
-by CL:DISASSEMBLE.
+modules to install as implementations for the JVM code analysis
+provided by CL:DISASSEMBLE.
 
-objectweb
-  
-javap
-
-jad
-
-procyon 
-
-cfr
-
-fernflower
+#+TABLE: Currently available decompilers as ASDF systems 
+|------------+--------------------------+-----------------------------------------------------------------------------|
+| ASDF       | status                   | URI                                                                         |
+|------------+--------------------------+-----------------------------------------------------------------------------|
+| objectweb  | working                  | <http://asm.ow2.org>                                                        |
+| javap      | working                  | <<https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javap.html> |
+| cfr        | working                  | <https://www.benf.org/other/cfr>                                            |
+| jad        | fails ABCL-BUILD/install | <http://www.javadecompilers.com/jad/>                                       |
+| procyon    | loading                  | <https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler>             |
+| fernflower | loading                  | <https://github.com/fesh0r/fernflower>                                      |
 
 
 These systems may be used by first loading the appropiate ASDF
@@ -41,7 +41,7 @@ Development Kit:
     (require :abcl-contrib)
     (asdf:load-system :javap)
     (sys:choose-disassembler :javap)
-    (cl:disassemble 'cons)
+    (cl:disassemble #'cons)
     ; Classfile /var/folders/yb/xlwjwjfs3l73n3vrcjwqwqs40000gn/T/abcl3108750031103632433.class
     ;   Last modified May 11, 2020; size 910 bytes
     ;   MD5 checksum fec1c72a76ccbb35e17be8c2de9b315e
@@ -127,6 +127,12 @@ Development Kit:
     ;             0      10     2 second   Lorg/armedbear/lisp/LispObject;
     ; }
     ; SourceFile: "Primitives.java"
+    
+    
+# Colophon
+
+<> <https://abcl.org/svn/trunk/abcl/contrib/abcl-introspect/README.org> ;
+:supersedes <https://abcl.org/svn/trunk/abcl/contrib/abcl-introspect/README.markdown> .
 
 
 

--- a/contrib/abcl-introspect/README.org
+++ b/contrib/abcl-introspect/README.org
@@ -9,8 +9,10 @@ of the implementation, most notably in integration with SLIME, where
 the back-trace mechanism is augmented to the point that local
 variables are inspectable.
 
-See <https://github.com/easye/slime/tree/evenson-merge-20170529a> for
-the changes to SLIME that were working well at the time of release.
+Version of SLIME 2.25 dramatically increases the utility of the
+available inspectors under ABCL.  Unfortunately, this version of SLIME
+is unreleased, so please use something post
+<https://github.com/slime/slime/commit/6f06402595df0ec6b305fc5a13e18f48e8989c64>.
 
 ** CL:DISASSEMBLE
 
@@ -38,6 +40,7 @@ SYS:*DISASSEMBLERS* variable.
 For example, to use the javap command-line tool included with the Java
 Development Kit:
 
+#+begin_src lisp
     (require :abcl-contrib)
     (asdf:load-system :javap)
     (sys:choose-disassembler :javap)
@@ -127,7 +130,7 @@ Development Kit:
     ;             0      10     2 second   Lorg/armedbear/lisp/LispObject;
     ; }
     ; SourceFile: "Primitives.java"
-    
+#+end_src    
     
 # Colophon
 

--- a/contrib/abcl-introspect/abcl-introspect-test.asd
+++ b/contrib/abcl-introspect/abcl-introspect-test.asd
@@ -1,6 +1,6 @@
 ;;;; -*- Mode: LISP -*-
 
-(defsystem abcl-introspect-tests
+(defsystem abcl-introspect-test
   :author "Mark Evenson"
   :long-description "<urn:abcl.org/release/1.6.1/contrib/abcl-introspect/test#>"
   :version "2.0.0"

--- a/contrib/abcl-introspect/abcl-introspect.asd
+++ b/contrib/abcl-introspect/abcl-introspect.asd
@@ -7,5 +7,5 @@
   :depends-on (jss)
   :components ((:file "abcl-introspect")
 	       (:file "stacktrace"))
-  :in-order-to ((test-op (test-op abcl-introspect-tests))))
+  :in-order-to ((test-op (test-op abcl-introspect-test))))
 

--- a/contrib/abcl-introspect/cfr.asd
+++ b/contrib/abcl-introspect/cfr.asd
@@ -1,0 +1,12 @@
+(defsystem cfr
+  :homepage "https://www.benf.org/other/cfr"
+  :description "CFR - a Class File Reader decompiler" :components
+  ((:module mvn-libs :components
+            ((:mvn "org.benf/cfr/0.149")))
+   (:module source
+    :depends-on (mvn-libs)
+    :pathname "" :components
+    ((:file "cfr")))))
+
+
+    

--- a/contrib/abcl-introspect/cfr.lisp
+++ b/contrib/abcl-introspect/cfr.lisp
@@ -1,0 +1,24 @@
+(defpackage :abcl-introspect/jvm/tools/cfr
+  (:use :cl)
+  (:export
+   #:disassemble-class-bytes))
+(in-package :abcl-introspect/jvm/tools/cfr)
+
+(defun cfr-jar-pathname ()
+  ;; Very ugly.  How to make more intelligble?
+  (slot-value (first (asdf:component-children (asdf:find-component  :cfr "mvn-libs")))
+              'asdf/interface::resolved-classpath))
+
+(defun disassemble-class-bytes (object)
+  (let ((sys::*disassembler*
+          ;; FIXME: use same java that is hosting ABCL
+          (format nil "java -jar ~a" (cfr-jar-pathname))))
+    (sys:disassemble-class-bytes object)))
+
+(eval-when (:load-toplevel :execute)
+  (pushnew `(:cfr . abcl-introspect/jvm/tools/cfr::disassemble-class-bytes)
+           sys::*disassemblers*)
+  (format cl:*load-verbose* "~&; ~a: Successfully added cfr disassembler.~%" *package*))
+
+
+

--- a/contrib/abcl-introspect/fernflower.asd
+++ b/contrib/abcl-introspect/fernflower.asd
@@ -1,5 +1,6 @@
 (defsystem fernflower
   :homepage "https://github.com/fesh0r/fernflower"
+  :version "2.5.0"
   :description "An analytical decompiler for Java" :components
   ((:module mvn-libs :components
             ((:mvn "org.jboss.windup.decompiler.fernflower/fernflower/2.5.0.Final")))

--- a/contrib/abcl-introspect/fernflower.asd
+++ b/contrib/abcl-introspect/fernflower.asd
@@ -1,0 +1,11 @@
+(defsystem fernflower
+  :homepage "https://github.com/fesh0r/fernflower"
+  :description "An analytical decompiler for Java" :components
+  ((:module mvn-libs :components
+            ((:mvn "org.jboss.windup.decompiler.fernflower/fernflower/2.5.0.Final")))
+   (:module source
+    :depends-on (mvn-libs)
+    :pathname "" :components
+    ((:file "fernflower")))))
+
+

--- a/contrib/abcl-introspect/fernflower.lisp
+++ b/contrib/abcl-introspect/fernflower.lisp
@@ -1,0 +1,25 @@
+(defpackage :abcl-introspect/jvm/tools/fernflower
+  (:use :cl)
+  (:export
+   #:disassemble-class-bytes))
+(in-package :abcl-introspect/jvm/tools/fernflower)
+
+(defun fernflower-classpath ()
+  ;; Very ugly.  How to make more intelligble?
+  (slot-value (first (asdf:component-children (asdf:find-component  :fernflower "mvn-libs")))
+              'asdf/interface::resolved-classpath))
+
+(defun disassemble-class-bytes (object)
+  (let ((sys::*disassembler*
+          ;; FIXME: use same java that is hosting ABCL
+          ;; !!! unclear options; wants to write output to filesystem
+          (format nil "java -cp ~a org.jetbrains.java.decompiler.main.decompiler.BaseDecompiler"
+                  (fernflower-classpath))))
+    (sys:disassemble-class-bytes object)))
+
+(eval-when (:load-toplevel :execute)
+  (pushnew `(:fernflower . abcl-introspect/jvm/tools/fernflower::disassemble-class-bytes)
+           sys::*disassemblers*)
+  (format cl:*load-verbose* "~&; ~a: Successfully added fernflower disassembler.~%" *package*))
+
+

--- a/contrib/abcl-introspect/jad.asd
+++ b/contrib/abcl-introspect/jad.asd
@@ -1,4 +1,5 @@
 (defsystem jad
+  :homepage "http://www.javadecompilers.com/jad/"
   :description "Introspect runtime architecture, install appropiate JAD binary, use it."
   :depends-on (abcl-build)
   :components ((:file "jad")))

--- a/contrib/abcl-introspect/jad.asd
+++ b/contrib/abcl-introspect/jad.asd
@@ -1,0 +1,5 @@
+(defsystem jad
+  :description "Introspect runtime architecture, install appropiate JAD binary, use it."
+  :depends-on (abcl-build)
+  :components ((:file "jad")))
+

--- a/contrib/abcl-introspect/jad.lisp
+++ b/contrib/abcl-introspect/jad.lisp
@@ -1,0 +1,47 @@
+(defpackage :abcl-introspect/jvm/tools/jad
+  (:use #:cl)
+  (:nicknames #:jvm/tools/jad #:jad)
+  (:export
+   #:disassemble-class-bytes))
+
+#|
+
+<http://www.javadecompilers.com/jad/Jad%201.5.8g%20for%20Mac%20OS%20X%2010.4.6%20on%20Intel%20platform.zip>
+
+|#
+
+(in-package :abcl-introspect/jvm/tools/jad)
+
+(defun introspect-jad-uri ()
+  (uiop:os-cond
+   ((uiop/os:os-macosx-p)
+    "http://www.javadecompilers.com/jad/Jad%201.5.8g%20for%20Mac%20OS%20X%2010.4.6%20on%20Intel%20platform.zip")))
+
+(defvar *working-jad-executable* nil)
+  
+(defun ensure-jad ()
+  (flet
+      ((install-jad-returning-path (uri)
+         (abcl-build:xdg/install (pathname uri) :type :unzip))
+       (working-jad-p (jad-path)
+         (handler-case
+             (uiop:run-program jad-path)
+           (uiop/run-program:subprocess-error (e) nil))))
+      (if (null *working-jad-executable*)
+          (let ((jad-path (abcl-build:introspect-path-for "jad")))
+            (if (and jad-path
+                     (working-jad-p jad-path))
+                (setf *working-jad-executable* jad-path)
+                (progn
+                  (install-jad-returning-path (introspect-jad-uri))
+                  (setf *working-jad-executable* jad-path))))
+          (unless (working-jad-p *working-jad-executable*)
+            (setf *working-jad-executable*
+                  (install-jad-returning-path (introspect-jad-uri)))))))
+          
+(defun disassemble-class-bytes (object)
+  (ensure-jad)
+  (let ((sys::*disassembler*
+          (format nil "~s -a -p" *working-jad-executable*)))
+    (sys:disassemble-class-bytes object)))
+

--- a/contrib/abcl-introspect/javap.asd
+++ b/contrib/abcl-introspect/javap.asd
@@ -1,0 +1,4 @@
+(defsystem javap
+  :description "Utilization of the javap command line dissassembler"
+  :components ((:file "javap")))
+

--- a/contrib/abcl-introspect/javap.asd
+++ b/contrib/abcl-introspect/javap.asd
@@ -1,4 +1,5 @@
 (defsystem javap
+  :homepage "<https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javap.html>" ;; FIXME
   :description "Utilization of the javap command line dissassembler"
   :components ((:file "javap")))
 

--- a/contrib/abcl-introspect/javap.lisp
+++ b/contrib/abcl-introspect/javap.lisp
@@ -1,0 +1,28 @@
+(defpackage :abcl-introspect/jvm/tools/javap
+  (:use #:cl)
+  (:export
+   #:disassemble-class-bytes))
+
+;;;; JDK javap <https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javap.html>
+#|
+(let ((sys::*disassembler* "javap -c -verbose"))
+  (disassemble 'cons))
+|#
+
+(in-package :abcl-introspect/jvm/tools/javap)
+
+(defun disassemble-class-bytes (object)
+  (let ((sys::*disassembler* "javap -c -verbose"))
+    (sys:disassemble-class-bytes object)))
+
+(eval-when (:load-toplevel :execute)
+  (pushnew `(:javap . abcl-introspect/jvm/tools/javap::disassemble-class-bytes)
+           sys::*disassemblers*)
+  (format cl:*load-verbose* "~&; ~a ; Successfully added javap disassembler.~%" *package*))
+
+
+
+
+
+
+

--- a/contrib/abcl-introspect/objectweb.asd
+++ b/contrib/abcl-introspect/objectweb.asd
@@ -1,15 +1,13 @@
 (defsystem objectweb
-  :homepage "http://asm.ow2.org"
+  :homepage "https://asm.ow2.org"
   :description "Disassembly to JVM byte code via Objectweb"
-  :defsystem-depends-on (abcl-asdf)
-  :components
-  ((:module maven
-            :components
-            ((:mvn "org.ow2.asm/asm-all/5.2")))
+  :version "8.0.1"
+  :defsystem-depends-on (abcl-asdf) :components
+  ((:module maven :components
+            ((:mvn "org.ow2.asm/asm-util/8.0.1")))
    (:module source
             :depends-on (maven)
-            :pathname ""
-            :components
+            :pathname "" :components
             ((:file "objectweb")))))
 
 

--- a/contrib/abcl-introspect/objectweb.asd
+++ b/contrib/abcl-introspect/objectweb.asd
@@ -1,5 +1,6 @@
 (defsystem objectweb
   :homepage "http://asm.ow2.org"
+  :description "Disassembly to JVM byte code via Objectweb"
   :defsystem-depends-on (abcl-asdf)
   :components
   ((:module maven

--- a/contrib/abcl-introspect/objectweb.lisp
+++ b/contrib/abcl-introspect/objectweb.lisp
@@ -1,9 +1,8 @@
-(in-package :cl-user)
-(defpackage :abcl/build/jvm/tools/objectweb
+(defpackage :abcl-introspect/jvm/tools/objectweb
   (:use :cl)
   (:export
    #:disassemble-class-bytes))
-(in-package :abcl/build/jvm/tools/objectweb)
+(in-package :abcl-introspect/jvm/tools/objectweb)
 
 (defun disassemble-class-bytes (object)
   (let* ((reader (java:jnew "org.objectweb.asm.ClassReader" object))
@@ -16,7 +15,7 @@
     (java:jcall "toString" writer)))
 
 (eval-when (:load-toplevel :execute)
-  (pushnew `(:objectweb . abcl/build/jvm/tools/objectweb::disassemble-class-bytes)
+  (pushnew `(:objectweb . abcl-introspect/jvm/tools/objectweb::disassemble-class-bytes)
            sys::*disassemblers*)
   (format cl:*load-verbose* "~&; ~a ; Successfully added Objectweb disassembler.~%" *package*))
 

--- a/contrib/abcl-introspect/procyon.asd
+++ b/contrib/abcl-introspect/procyon.asd
@@ -1,0 +1,17 @@
+(defsystem procyon
+  :homepage "https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler"
+  :description "A Java decompiler by Mike Strobel"
+  :version "0.5.26"
+  :depends-on (alexandria) :components
+  ((:module mvn-libs :components
+            ((:mvn "org.bitbucket.mstrobel/procyon-compilertools/0.5.36")))
+   (:module source
+    :depends-on (mvn-libs)
+    :pathname "" :components
+    ((:file "procyon")))))
+
+
+
+
+
+

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -1,0 +1,49 @@
+(defpackage :abcl-introspect/jvm/tools/procyon
+    (:use :cl)
+    (:export
+     #:disassemble-class-bytes))
+(in-package :abcl-introspect/jvm/tools/procyon)
+
+(defun disassemble-class-bytes (object)
+  #|
+  <https://bitbucket.org/mstrobel/procyon/wiki/Decompiler%20API> 
+
+    final DecompilerSettings settings = DecompilerSettings.javaDefaults();
+
+    try (final FileOutputStream stream = new FileOutputStream("path/to/file");
+         final OutputStreamWriter writer = new OutputStreamWriter(stream)) {
+
+        Decompiler.decompile(
+            "java/lang/String",
+            new PlainTextOutput(writer),
+            settings
+        );
+    }
+    catch (final IOException e) {
+        // handle error
+    }
+  |#
+  (let* ((settings
+           (#"javaDefaults" 'DecompilerSettings))
+         (writer
+           (jss:new 'StringWriter)))
+    (#"decompile" 'Decompiler
+                  ;;; !!! need to reference as a type in the current VM
+                  ;;; c.f.<https://github.com/Konloch/bytecode-viewer/blob/master/src/the/bytecode/club/bytecodeviewer/decompilers/ProcyonDecompiler.java>
+                  object
+                  (jss:new 'PlainTextOutput writer)
+                  settings)
+    (write (#"toString writer"))))
+
+(eval-when (:load-toplevel :execute)
+  (pushnew `(:procyon . abcl-introspect/jvm/tools/procyon::disassemble-class-bytes)
+           sys::*disassemblers*)
+  (format cl:*load-verbose* "~&; ~a: Successfully added procyon disassembler.~%" *package*))
+
+
+
+
+
+
+  
+  

--- a/contrib/abcl-introspect/t/disassemble.lisp
+++ b/contrib/abcl-introspect/t/disassemble.lisp
@@ -3,24 +3,47 @@
 (let ((disassembler (first (abcl-build:split-string
                             ext:*disassembler* #\Space))))
   (prove:plan 1)
-  (prove:ok (abcl-build:introspect-path-for disassembler)
-            (format nil
-                    "Testing invocation of ~a specified by EXT:*DISASSEMBLER*…" disassembler)))
+  (prove:ok
+   (abcl-build:introspect-path-for disassembler)
+   (format nil
+           "Testing invocation of ~a specified by EXT:*DISASSEMBLER*…" disassembler)))
 
-;;; FIXME move dependency load into ASDF definitions
-(asdf:load-system :objectweb)
-(prove:plan 2)
-(prove:is
- (sys:choose-disassembler)
- 'ABCL/BUILD/JVM/TOOLS/OBJECTWEB::DISASSEMBLE-CLASS-BYTES)
-(let ((output (make-string-output-stream)))
-  (let ((*standard-output* output))
-    (disassemble #'cons))
-  (let ((result (get-output-stream-string output)))
-    (prove:ok (and result
-                   (stringp result)
-                   (> (length result) 0))
-              "Invocation of Objectweb disassembler.")))
+(let ((disassemblers '(:objectweb :javap :jad :fernflower :cfr :procyon))) 
+  (prove:plan (* 2 (length disassemblers)))
+  (dolist (disassembler disassemblers)
+    (prove:ok
+     (asdf:load-system disassembler)
+     (format nil "Loading ~a" disassembler))
+    (prove:ok
+     (handler-case
+         (let ((expected (intern :disassemble-class-bytes
+                                 (format nil "ABCL-INTROSPECT/JVM/TOOLS/~a" (symbol-name disassembler)))))
+           (equal
+            (sys:choose-disassembler disassembler)
+            expected))
+       (t (e)
+         (progn
+           (prove:diag (format nil "Choosing ~a failed: ~a" disassembler e))
+           nil)))
+     (format nil "Able to choose ~a disassembler" disassembler)))
+  
+  (prove:plan (length disassemblers))
+  (dolist (disassembler disassemblers)
+    (let ((output (make-string-output-stream)))
+      (prove:ok
+       (handler-case
+           (let ((*standard-output* output))
+             (sys:choose-disassembler disassembler)
+             (cl:disassemble #'cons)
+             (let ((result (get-output-stream-string output)))
+               (not (null (and result
+                               (stringp result)
+                               (> (length result) 0))))))
+         (t (e)
+            (progn
+              (prove:diag (format nil "Invocation failed: ~a" e))
+              nil)))
+       (format nil "Invocation of ~a disassembler" disassembler)))))
 
 (prove:finalize)
 

--- a/doc/manual/abcl.tex
+++ b/doc/manual/abcl.tex
@@ -11,7 +11,7 @@
 \title{Armed Bear Common Lisp User Manual}
 \date{Version 1.6.2\\
 \smallskip
-Unreleased
+Unreleased}
 \author{Mark Evenson \and Erik H\"{u}lsmann \and Rudolf Schlatte \and
   Alessio Stalla \and Ville Voutilainen}
 
@@ -935,6 +935,20 @@ reporting stream.  The generalized boolean
 \code{JVM:*RESIGNAL-COMPILER-WARNINGS*} provides the interface to
 enabling the compiler to signal all warnings.
 
+\subsection{Decompilation}
+
+\label{CL:DISASSEMBLE}
+Since \textsc{ABCL} compiles to JVM bytecode, the
+\code{CL:DISASSEMBLE} function provides introspection for the result
+of that compilation.  By default the implementation attempts to find
+and use the \code{javap} command line tool shipped as part of the Java
+Development Kit to disassemble the results.  Code for the use of
+additional JVM bytecode introspection tools is packaged as part of the
+ABCL-INTROSPECT contrib.  After loading one of these tools via ASDF,
+the \code{SYS:CHOOSE-DISASSEMBLER} function can be used to select the
+tool used by \code{CL:DISASSEMBLE}.  See
+\ref{abcl-introspect-disassemblers}
+on \pageref{abcl-introspect-disassemblers} for further details.
 
 \section{Pathname}
 
@@ -1087,7 +1101,7 @@ expect the following:
 \end{itemize}
 
 \section{Package-Local Nicknames}
-\label{sec:pack-local-nickn}
+\label{sec:package-local-nicknames}
 
 ABCL allows giving packages local nicknames: they allow short and
 easy-to-use names to be used without fear of name conflict associated
@@ -1346,14 +1360,15 @@ semantics to the execution of \code{REQUIRE} on the following symbols:
         \end{enumerate}
       \item \code{quicklisp-abcl} Boot a local Quicklisp installation
         via the ASDF:IRI type introduced via ABCL-ASDF.
-
       \item \code{jfli} A descendant of Rich Hickey's pre-Clojure work
         on the JVM.
       \item \code{jss} Introduces dynamic inspection of present
         symbols via the \code{SHARPSIGN-QUOTATION\_MARK} macros as Java Syntax
         Sucks
       \item \code{abcl-introspect} Provides a framework for
-        introspecting runtime Java and Lisp object values.
+        introspecting runtime Java and Lisp object values.  Include
+        packaging for installing and using java decompilation tools
+        for use with \code{CL:DISASSEMBLE}.
       \item \code{abcl-build} Provides a toolkit for building ABCL
         from source, as well as installing the necessary tools for
         such builds.
@@ -1534,16 +1549,18 @@ Some more information on jss can be found in its documentation at
 \section{jfli}
 \label{section:jfli}
 
-The contrib contains a pure-Java version of JFLI. 
+The contrib contains a pure-Java version of \textsc{JFLI}, apparently
+a descendent of Rich Hickey's early experimentations with using Java
+from Common Lisp.
 
 \url{http://abcl.org/svn/tags/1.6.1/contrib/jfli/README}.
 
 \section{abcl-introspect}
 
-\textsc{ABCL-INTROSPECT} offers more extensive systems for inspecting the state
-of the implementation, most notably in integration with SLIME, where
-the backtrace mechanism is augmented to the point that local
-variables are inspectable.
+\textsc{ABCL-INTROSPECT} offers more extensive functionality for
+inspecting the state of the implementation, most notably in
+integration with SLIME, where the backtrace mechanism is augmented to
+the point that local variables are inspectable.
 
 A compiled function is an instance of a class - This class has
 multiple instances if it represents a closure, or a single instance if
@@ -1556,7 +1573,7 @@ function, locally-defined functions (such as via \code{LABEL} or
 \textsc{ABCL-INTROSPECT} implements a ``do what I mean'' API for
 introspecting these constants.
 
-ABCL-INTROSPECT provides access to those internal values, and
+\textsc{ABCL-INTROSPECT} provides access to those internal values, and
 uses them in at least two ways. First, to annotate locally defined
 functions with the top-level function they are defined within, and
 second to search for callers of a give function \footnote{ Since java
@@ -1570,16 +1587,76 @@ useful. The second use to to find source locations for frames in the
 debugger. If the source location for a local function is asked for the
 location of its 'owner' is instead returns.
 
-In order to record information about local functions, ABCL defines a
-function-plist, which is for the most part unused, but is used here
-with set of keys indicating where the local function was defined and
-in what manner, i.e. as normal local function, as a method function,
-or as an initarg function. There may be other places functions are
-stashed away (defstructs come to mind) and this file should be added
-to to take them into account as they are discovered.
+In order to record information about local functions, \textsc{ABCL}
+defines a function-plist, which is for the most part unused, but is
+used here with set of keys indicating where the local function was
+defined and in what manner, i.e. as normal local function, as a method
+function, or as an initarg function. There may be other places
+functions are stashed away (defstructs come to mind) and this file
+should be added to to take them into account as they are discovered.
 
-ABCL-INTROSPECT does not depend on jss, but provides a bit of
-jss-specific functionality if jss *is* loaded.
+\textsc{ABCL-INTROSPECT} does not depend on \textsc{JSS}, but provides
+  a bit of jss-specific functionality if \textsc{JSS} *is* loaded.
+
+\subsection{Implementations for CL:DISASSEMBLE}
+\label{abcl-introspect-disassemblers}
+
+The following ASDF systems packages various external tools that may be
+selected by the \code{SYS:CHOOSE-DISASSEMBLER} interface:
+
+\begin{enumerate}
+\item \code{objectweb}
+\item \code{jad}
+\item \code{javap}
+\item \code{fernweb}
+\item \code{cfr}
+\item \code{procyon}
+\end{enumerate}
+
+To use one of these tools, first load the system via \textsc{ASDF}
+(and/or \textsc{Quicklisp}), then use the
+\code{SYS:CHOOSE-DISASSEMBLER} function to select the keyword that
+appears in \code{SYS:*DISASSEMBLERS*}.
+\begin{listing-lisp}
+CL-USER> (require :abcl-contrib)(asdf:load-system :objectweb)
+CL-USER> sys:*disassemblers*
+((:OBJECTWEB
+  . ABCL-INTROSPECT/JVM/TOOLS/OBJECTWEB:DISASSEMBLE-CLASS-BYTES)
+ (:SYSTEM-JAVAP . SYSTEM:DISASSEMBLE-CLASS-BYTES))
+CL-USER> (sys:choose-disassembler :objectweb)
+ABCL-INTROSPECT/JVM/TOOLS/OBJECTWEB:DISASSEMBLE-CLASS-BYTES
+CL-USER> (disassemble 'cons)
+; // class version 52.0 (52)
+; // access flags 0x30
+; final class org/armedbear/lisp/Primitives$pf_cons extends org/armedbear/lisp/Primitive  {
+; 
+;   // access flags 0x1A
+;   private final static INNERCLASS org/armedbear/lisp/Primitives$pf_cons org/armedbear/lisp/Primitives pf_cons
+; 
+;   // access flags 0x0
+;   <init>()V
+;     ALOAD 0
+;     GETSTATIC org/armedbear/lisp/Symbol.CONS : Lorg/armedbear/lisp/Symbol;
+;     LDC "object-1 object-2"
+;     INVOKESPECIAL org/armedbear/lisp/Primitive.<init> (Lorg/armedbear/lisp/Symbol;Ljava/lang/String;)V
+;     RETURN
+;     MAXSTACK = 3
+;     MAXLOCALS = 1
+; 
+;   // access flags 0x1
+;   public execute(Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)Lorg/armedbear/lisp/LispObject;
+;     NEW org/armedbear/lisp/Cons
+;     DUP
+;     ALOAD 1
+;     ALOAD 2
+;     INVOKESPECIAL org/armedbear/lisp/Cons.<init> (Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)V
+;     ARETURN
+;     MAXSTACK = 4
+;     MAXLOCALS = 3
+; }
+NIL
+\end{listing-lisp}
+  
 
 \url{http://abcl.org/svn/tags/1.6.1/contrib/abcl-introspect/}.
 

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2698,7 +2698,7 @@ public final class Lisp
   // ### *disassembler*
   public static final Symbol _DISASSEMBLER_ =
     exportSpecial("*DISASSEMBLER*", PACKAGE_EXT,
-                  new SimpleString("jad -a -p")); // or "jad -dis -p"
+                  new SimpleString("javap -c -verbose")); // or "jad -dis -p"
 
   // ### *speed* compiler policy
   public static final Symbol _SPEED_ =

--- a/src/org/armedbear/lisp/disassemble.lisp
+++ b/src/org/armedbear/lisp/disassemble.lisp
@@ -40,29 +40,43 @@ Available disassemblers are configured by pushing a strategy to SYSTEM:*DISASSEM
 SYSTEM:CHOOSE-DISASSEMBLER selects a current strategy from this list .")
 
 (defvar *disassemblers*
-  `((:jad . disassemble-class-bytes))
-  "Methods of invoking CL:DISASSEMBLE consisting of a pushable list of (name function), where function takes a object to disassemble, returns the results as a string.
+  `((:system-javap . disassemble-class-bytes))
+  "Methods of invoking CL:DISASSEMBLE consisting of a enumeration of (keyword function) pairs
 
-The system is :jad using the venerable-but-still-works JAD. 
+The pairs (keyword function) contain a keyword identifying this
+particulat disassembler, and a symbol designating function takes a
+object to disassemble.
+
+Use SYS:CHOOSE-DISASSEMBLER to install a given disassembler as the one
+used by CL:DISASSEMBLE.  Additional disassemblers/decompilers are
+packaged in the ABCL-INTROSPECT contrib.
+
+The intial default is :javap using the javap command line tool which
+is part of the Java Developement Kit.
 ")
 
 (defun choose-disassembler (&optional name)
-  "Hook to choose invoked behavior of CL:DISASSEMBLE by using one of the methods registered in SYSTEM:*DISASSEMBLERS*. 
+  "Report current disassembler that would be used by CL:DISASSEMBLE
 
-Optionally, prefer the strategy named NAME if one exists."
+With optional keyword NAME, select the associated disassembler from
+SYS:*DISASSEMBLERS*."
+  (flet ((sane-disassembler-p (disassembler)
+           (and disassembler
+                (fboundp disassembler))))
     (setf *disassembler-function*
           (if name
               (let ((disassembler (cdr (assoc name *disassemblers*))))
-                (if (and disassembler
-                         (fboundp disassembler))
+                (if (sane-disassembler-p disassembler)
                     disassembler
                     (error "Disassembler ~a doesn't appear to work." name)))
-              (loop
-                 :for (nil . disassembler) in *disassemblers*
-                 :when (and disassembler
-                            (fboundp disassembler))
-                 :do (return disassembler)
-                 finally (warn "Can't find suitable disassembler.")))))
+              (if (sane-disassembler-p *disassembler-function*)
+                  *disassembler-function*
+                  ;; simplest strategy: choose the first working one
+                  (loop
+                    :for (nil . disassembler) in *disassemblers*
+                    :when (sane-disassembler-p disassembler)
+                      :do (return disassembler)
+                    :finally (warn "Can't find suitable disassembler.")))))))
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defmacro with-open ((name value) &body body)


### PR DESCRIPTION
Fix system interface for choosing disassemblers.  Use
SYS:CHOOSE-DISASSEMBLER to interogate and/or change the active
disassembler for CL:DISASSEMBLER from the available assemblers
enumerated in SYS:*DISASSEMBLERS*.  Test the ABCL-INTROSPECT for
loading available disassemblers as part of CI.

Additional disassemblers are collected in the ABCL-INTROSPECT contrib
as top-level ASDF systems.  Currently available disassemblers include
OBJECTWEB, JAVAP, JAD, PROCYON, FERNFLOWER, and CFR.

Encapsulate the loading and use of javap and jad command line
disassemblers as ASDF systems.

Rename all packages as ABCL-INTROSPECT/mumble/mumble.

Basic introspection and retrieval of resources in place.  TODO: add
correct URIs for introspected operation.  Current URI is not available
(lot of unexpected escaping going on).

Normalize ASDF formatting with dangling ":components" keyword.  N.b. I
don't like this convention, as stylistically keyword arguments should
not occur in a line without their parameter, but otherwise ASDF
systems creep into too much screen.

Speculative implementation for Procyon.  Apparently ok to declare
Quicklisp loadable systems as dependencies.

Fix test semantics.  Normalize test system ASDF name to
the singular form.

Move the JAD dissassembler into a contrib.

TODO: generalize the introspect of the correct architecture at
runtime, collecting the download URIs for more common JAD
archiectures, debug the actual download and testing.

Supersedes #176 