### PR TITLE
build: fix autoconfiguration script

### DIFF
--- a/ci/create-abcl-properties.awk
+++ b/ci/create-abcl-properties.awk
@@ -1,0 +1,4 @@
+/^java.options/ {print $0 " " options; next}
+/^abcl.javac.target/ {print "abcl.javac.target=" target; next}
+/^abcl.javac.source/ {print "abcl.javac.source=" source; next}
+{print $0}

--- a/ci/create-abcl-properties.bash
+++ b/ci/create-abcl-properties.bash
@@ -18,30 +18,48 @@ abcl_javac_source=1.8
 case $jdk in
     6|openjdk6)
         options="-d64 -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1g -XX:+UseConcMarkSweepGC"
-        abcl_javac_source=1.6
+        abcl_javac_target=1.6
+	abcl_javac_source=1.6
         ;;
     7|openjdk7)
 	options="-d64 -XX:+UseG1GC"
-        abcl_javac_source=1.7
+        abcl_javac_target=1.7
+	abcl_javac_source=1.7
 	;;
     8|openjdk8)
         options="-XX:+UseG1GC -XX:+AggressiveOpts -XX:CompileThreshold=10"
+	abcl_javac_target=1.8
+	abcl_javac_source=1.8
         ;;
     11|openjdk11)
         options="-XX:CompileThreshold=10"
+	abcl_javac_target=11
+	abcl_javac_source=1.8
         ;;
     # untested: weakly unsupported 
     12|openjdk12)
         options="-XX:CompileThreshold=10"
+	abcl_javac_target=12
+	abcl_javac_source=1.8
         ;;
     13|openjdk13)
         options="-XX:CompileThreshold=10"
+	abcl_javac_target=13
+	abcl_javac_source=1.8
         ;;
     14|openjdk14)
         options="-XX:CompileThreshold=10 ${zgc}"
+	abcl_javac_target=14
+	abcl_javac_source=1.8
         ;;
 esac
 
-cat ${root}/abcl.properties.in | awk -F = -v options="$options" -v source="$abcl_javac_source" '/^java.options/ {print $0 " " options; next}; /^abcl.javac.source/ {print "abcl.javac.source=" source; next}; {print $0}' > ${root}/abcl.properties
+cat ${root}/abcl.properties.in \
+    | awk -F = \
+	  -v options="$options" \
+	  -v target="$abcl_javac_target" \
+	  -v source="$abcl_javac_source" \
+       -f ${DIR}/create-abcl-properties.awk \
+  > ${root}/abcl.properties
 
 echo "Finished configuring for $jdk into <${prop_out}>."


### PR DESCRIPTION
Running the autoconfiguration script now sets both the target and
source options for the java compilation, selecting the maximum target
for compilation platform.