### PR TITLE
easye/incomplete/bytebuffer 20200525a

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,12 +57,16 @@ install:
   # Install the patched version of cl+ssl
   - bash -x ${ABCL_ROOT}/ci/install-patched-cl+ssl.bash
 
+  # Install the patched version of static-vectors
+  - bash -x ${ABCL_ROOT}/ci/install-patched-static-vectors.bash
+
   # Install the ANSI-TEST suite
   - bash -x ${ABCL_ROOT}/ci/sync-ansi-test.bash
 
 # TODO: figure out how to add abcl to our path
 
 script:
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-static-vectors.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-introspect.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cffi.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cl+ssl.lisp

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,10 @@ install:
 # TODO: figure out how to add abcl to our path
 
 script:
-  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-static-vectors.lisp
-  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-introspect.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cffi.lisp
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-static-vectors.lisp
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-ironclad.lisp
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-introspect.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cl+ssl.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/abcl-prove.lisp

--- a/ci/install-patched-static-vectors.bash
+++ b/ci/install-patched-static-vectors.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Until <https://github.com/sionescu/static-vectors/pull/23>
+# resolved, we need to use our patched version.
+
+root="${HOME}/quicklisp/local-projects"
+dir="static-vectors"
+tag="easye/abcl"
+
+mkdir -p ${root}
+pushd ${root}
+
+if [[ ! -d ${dir} ]]; then 
+    git clone https://github.com/armedbear/${dir} ${dir}
+fi
+
+pushd ${dir}
+if [[ -d .hg ]]; then
+    hg update -r $tag
+    hg sum -v
+else
+    git checkout $tag
+    git show-ref
+    git rev-parse
+fi
+popd
+
+popd

--- a/ci/test-cl+ssl.lisp
+++ b/ci/test-cl+ssl.lisp
@@ -1,5 +1,7 @@
-(require :asdf)
-(require :abcl-contrib)
+#+abcl
+(progn 
+  (require :asdf)
+  (require :abcl-contrib))
 
 (ql:quickload :cl+ssl)
 (ql:quickload :cl+ssl.test)

--- a/ci/test-ironclad.lisp
+++ b/ci/test-ironclad.lisp
@@ -1,0 +1,5 @@
+(ql:quickload :ironclad)
+(ql:quickload :ironclad/tests)
+
+(asdf:test-system :ironclad)
+

--- a/ci/test-static-vectors.lisp
+++ b/ci/test-static-vectors.lisp
@@ -1,0 +1,7 @@
+(require :asdf)
+(require :abcl-contrib)
+
+(ql:quickload :static-vectors)
+(ql:quickload :static-vectors/test)
+
+(asdf:test-system :static-vectors)

--- a/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
@@ -37,13 +37,13 @@ import static org.armedbear.lisp.Lisp.*;
 import java.nio.ByteBuffer;
 import java.nio.BufferOverflowException;
 
-
 // A basic vector is a specialized vector that is not displaced to another
 // array, has no fill pointer, and is not expressly adjustable.
-public final class BasicVector_ByteBuffer extends AbstractVector
-{
-  private ByteBuffer elements;
+public final class BasicVector_ByteBuffer
+  extends AbstractVector {
 
+  private ByteBuffer elements;
+  
   public BasicVector_ByteBuffer(int capacity) {
     elements = ByteBuffer.allocate(capacity);
   }
@@ -51,7 +51,25 @@ public final class BasicVector_ByteBuffer extends AbstractVector
   public BasicVector_ByteBuffer(byte[] array) {
     elements = ByteBuffer.wrap(array);
   }
-  
+
+  // ### ext:make-bytebuffer-byte-vector BYTEBUFFER
+  // Construct a simple vector from a bytebuffer
+  public static final Primitive MAKE_BYTEBUFFER_BYTE_VECTOR = new pf_make_bytebuffer_byte_vector();
+  private static final class pf_make_bytebuffer_byte_vector extends Primitive {
+    pf_make_bytebuffer_byte_vector() {
+      super(Symbol.MAKE_BYTEBUFFER_BYTE_VECTOR, "bytebuffer");
+    }
+    @Override
+    public LispObject execute(LispObject arg) {
+      return new BasicVector_ByteBuffer(coerceToByteBuffer(arg));
+    }
+  }
+
+  static public ByteBuffer coerceToByteBuffer(LispObject arg) {
+    JavaObject obj = (JavaObject) arg;
+    return (ByteBuffer)obj.getObject();
+  }
+    
   public BasicVector_ByteBuffer(ByteBuffer buffer) {
     elements = buffer;
   }

--- a/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
@@ -1,0 +1,289 @@
+/*
+ * BasicVector_ByteBuffer.java
+ *
+ * Copyright (C) 2020 @easye
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+import java.nio.BufferOverflowException;
+
+
+// A basic vector is a specialized vector that is not displaced to another
+// array, has no fill pointer, and is not expressly adjustable.
+public final class BasicVector_ByteBuffer extends AbstractVector
+{
+  private ByteBuffer elements;
+
+  public BasicVector_ByteBuffer(int capacity) {
+    elements = ByteBuffer.allocate(capacity);
+  }
+
+  public BasicVector_ByteBuffer(byte[] array) {
+    elements = ByteBuffer.wrap(array);
+  }
+  
+  public BasicVector_ByteBuffer(ByteBuffer buffer) {
+    elements = buffer;
+  }
+
+  public BasicVector_ByteBuffer(LispObject[] array) {
+    // FIXME: for now we assume that we're being handled an array of
+    // primitive bytes
+    
+    elements = ByteBuffer.allocate(array.length);
+    for (int i = array.length; i-- > 0;)
+      // Faster please!
+      elements.put((byte)coerceLispObjectToJavaByte(array[i]));
+  }
+
+  @Override
+  public LispObject typeOf() {
+    return list(Symbol.SIMPLE_ARRAY, UNSIGNED_BYTE_8,
+                new Cons(Fixnum.getInstance(elements.limit())));
+  }
+
+  @Override
+  public LispObject classOf() {
+    return BuiltInClass.VECTOR;
+  }
+
+  @Override
+  public LispObject typep(LispObject type) {
+    if (type == Symbol.SIMPLE_ARRAY)
+      return T;
+    if (type == BuiltInClass.SIMPLE_ARRAY)
+      return T;
+    return super.typep(type);
+  }
+
+  @Override
+  public LispObject getElementType() {
+    return UNSIGNED_BYTE_8;
+  }
+
+  @Override
+  public boolean isSimpleVector() {
+    return false;
+  }
+
+  @Override
+  public boolean hasFillPointer() {
+    return false;
+  }
+
+  @Override
+  public boolean isAdjustable() {
+    return false;
+  }
+
+  @Override
+  public int capacity() {
+    return elements.capacity();
+  }
+
+  // In order to "shrink" a ByteBuffer without allocating new memory,
+  // we use the the limit field to mark the end of the usable portion
+  // of the vector
+  @Override
+  public int length() {
+    return elements.limit();
+  }
+
+  @Override
+  public LispObject elt(int index) {
+    try {
+      return coerceJavaByteToLispObject(elements.get(index));
+    } catch (IndexOutOfBoundsException e) {
+      badIndex(index, length());
+      return NIL; // Not reached.
+    }
+  }
+
+  @Override
+  public int aref(int index) {
+    try {
+      return ((elements.get(index) & 0xff)); // XXX Hmmm
+    } catch (IndexOutOfBoundsException e) {
+      badIndex(index, length());
+      // Not reached.
+      return 0;
+    }
+  }
+
+  @Override
+  public LispObject AREF(int index) {
+    try {
+      return coerceJavaByteToLispObject(elements.get(index));
+    } catch (IndexOutOfBoundsException e) {
+      badIndex(index, length());
+      return NIL; // Not reached.
+    }
+  }
+
+  @Override
+  public void aset(int index, int n) {
+    try {
+      elements.put(index,  (byte) n);
+    } catch (IndexOutOfBoundsException e) {
+      badIndex(index, length());
+    }
+  }
+
+  @Override
+  public void aset(int index, LispObject value) {
+    try {
+        elements.put(index, coerceLispObjectToJavaByte(value));
+    } catch (IndexOutOfBoundsException e) {
+      badIndex(index, length());
+    }
+  }
+
+  @Override
+  public LispObject subseq(int start, int end) {
+    BasicVector_ByteBuffer v = new BasicVector_ByteBuffer(end - start);
+    ByteBuffer view = elements.asReadOnlyBuffer();
+    view.position(start);
+    view.limit(end);
+    try {
+      v.elements.put(view);
+      return v;
+    } catch (BufferOverflowException e) {
+      return error(new TypeError("Could not form a subseq from " + start + " to " + end));
+    }
+  }
+
+  @Override
+  public void fill(LispObject obj) {
+    if (!(obj instanceof Fixnum)) {
+      type_error(obj, Symbol.FIXNUM);
+      // Not reached.
+      return;
+    }
+    int n = ((Fixnum) obj).value;
+    if (n < 0 || n > 255) {
+      type_error(obj, UNSIGNED_BYTE_8);
+      // Not reached.
+      return;
+    }
+
+    for (int i = length(); i-- > 0;) {
+      elements.put(i, (byte) n);
+    }
+  }
+
+  @Override
+  public void shrink(int n) {
+    // One cannot shrink a ByteBuffer physically, so 
+    if (n < length()) {
+        elements.limit(n);
+        return;
+    }
+    if (n == length()) {
+      return;
+    }
+    error(new LispError("Attempted to shrink an array to a size greater than its capacity"));
+  }
+
+  @Override
+  public LispObject reverse() {
+    BasicVector_ByteBuffer result = new BasicVector_ByteBuffer(length());
+    int i, j;
+    for (i = 0, j = length() - 1; i < length(); i++, j--) {
+      result.elements.put(i, elements.get(j));
+    }
+    return result;
+  }
+
+  @Override
+  public LispObject nreverse() {
+    int i = 0;
+    int j = capacity() - 1;
+    while (i < j) {
+      byte temp = elements.get(i);
+      elements.put(i, elements.get(j));
+      elements.put(j, temp);
+      ++i;
+      --j;
+    }
+    return this;
+  }
+
+  @Override
+  public AbstractVector adjustArray(int newCapacity,
+                                    LispObject initialElement,
+                                    LispObject initialContents) {
+    if (initialContents != null) {
+      ByteBuffer newElements = ByteBuffer.allocate(newCapacity);
+      if (initialContents.listp()) {
+        LispObject list = initialContents;
+        for (int i = 0; i < newCapacity; i++) {
+          newElements.put(i, coerceLispObjectToJavaByte(list.car()));
+          list = list.cdr();
+        }
+      } else if (initialContents.vectorp()) {
+        for (int i = 0; i < newCapacity; i++)
+          newElements.put(i, coerceLispObjectToJavaByte(initialContents.elt(i)));
+      } else
+        type_error(initialContents, Symbol.SEQUENCE);
+      return new BasicVector_ByteBuffer(newElements);
+    }
+    if (length() != newCapacity) {
+      ByteBuffer newElements = ByteBuffer.allocate(newCapacity);
+      if (elements.hasArray()) {
+        newElements.put(elements.array(), 0, Math.min(length(), newCapacity));
+      } else {
+        // FIXME: a more efficient version when we don't have a backing array
+        int limit = Math.min(length(), newCapacity);
+        for (int i = 0; i < limit; i++) {
+          newElements.put(i, elements.get(i));
+        }
+      }
+        
+      if (initialElement != null) {
+        byte initValue = (byte)(initialElement.intValue() & 0xFF);
+        for (int i = length(); i < newCapacity; i++)
+          newElements.put(i, initValue);
+      }
+      return new BasicVector_ByteBuffer(newElements);
+    }
+    // No change.
+    return this;
+  }
+
+  @Override
+  public AbstractVector adjustArray(int newCapacity,
+                                    AbstractArray displacedTo,
+                                    int displacement) {
+    return new ComplexVector(newCapacity, displacedTo, displacement);
+  }
+}

--- a/src/org/armedbear/lisp/ByteArrayOutputStream.java
+++ b/src/org/armedbear/lisp/ByteArrayOutputStream.java
@@ -33,6 +33,7 @@
 
 package org.armedbear.lisp;
 
+import org.armedbear.lisp.Java.Buffers.AllocationPolicy;
 import static org.armedbear.lisp.Lisp.*;
 
 public final class ByteArrayOutputStream extends Stream
@@ -134,10 +135,16 @@ public final class ByteArrayOutputStream extends Stream
         @Override
         public LispObject execute(LispObject arg)
         {
-            if (arg instanceof ByteArrayOutputStream)
-                return new BasicVector_UnsignedByte8(((ByteArrayOutputStream)arg).getByteArray());
+          if (arg instanceof ByteArrayOutputStream) {
+            byte[] array = ((ByteArrayOutputStream)arg).getByteArray();
+            if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+              return new BasicVector_ByteBuffer(array);
+            } else if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+              return new BasicVector_UnsignedByte8(array);
+            }
+          }
 
-            return type_error(this, Symbol.STREAM); // TODO
+          return type_error(this, Symbol.STREAM); // TODO
         }
     };
 

--- a/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
@@ -1,0 +1,306 @@
+/*
+ * ComplexArray_UnsignedByte8.java
+ *
+ * Copyright (C) 2003-2005 Peter Graves
+ * $Id$
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+
+public final class ComplexArray_ByteBuffer extends AbstractArray
+{
+    private final int[] dimv;
+    private int totalSize;
+
+    // For non-displaced arrays.
+    private byte[] data;
+
+    // For displaced arrays.
+    private AbstractArray array;
+    private int displacement;
+
+    public ComplexArray_ByteBuffer(int[] dimv)
+    {
+        this.dimv = dimv;
+        totalSize = computeTotalSize(dimv);
+        data = new byte[totalSize];
+    }
+
+    public ComplexArray_ByteBuffer(int[] dimv, LispObject initialContents)
+
+    {
+        this.dimv = dimv;
+        final int rank = dimv.length;
+        LispObject rest = initialContents;
+        for (int i = 0; i < rank; i++) {
+            dimv[i] = rest.length();
+            rest = rest.elt(0);
+        }
+        totalSize = computeTotalSize(dimv);
+        data = new byte[totalSize];
+        setInitialContents(0, dimv, initialContents, 0);
+    }
+
+    public ComplexArray_ByteBuffer(int[] dimv, AbstractArray array, int displacement)
+    {
+        this.dimv = dimv;
+        this.array = array;
+        this.displacement = displacement;
+        totalSize = computeTotalSize(dimv);
+    }
+
+    private int setInitialContents(int axis, int[] dims, LispObject contents,
+                                   int index)
+
+    {
+        if (dims.length == 0) {
+            try {
+                data[index] = coerceLispObjectToJavaByte(contents);
+            }
+            catch (ArrayIndexOutOfBoundsException e) {
+                error(new LispError("Bad initial contents for array."));
+                return -1;
+            }
+            ++index;
+        } else {
+            int dim = dims[0];
+            if (dim != contents.length()) {
+                error(new LispError("Bad initial contents for array."));
+                return -1;
+            }
+            int[] newDims = new int[dims.length-1];
+            for (int i = 1; i < dims.length; i++)
+                newDims[i-1] = dims[i];
+            if (contents.listp()) {
+                for (int i = contents.length();i-- > 0;) {
+                    LispObject content = contents.car();
+                    index =
+                        setInitialContents(axis + 1, newDims, content, index);
+                    contents = contents.cdr();
+                }
+            } else {
+                AbstractVector v = checkVector(contents);
+                final int length = v.length();
+                for (int i = 0; i < length; i++) {
+                    LispObject content = v.AREF(i);
+                    index =
+                        setInitialContents(axis + 1, newDims, content, index);
+                }
+            }
+        }
+        return index;
+    }
+
+    @Override
+    public LispObject typeOf()
+    {
+        return list(Symbol.ARRAY, UNSIGNED_BYTE_8, getDimensions());
+    }
+
+    @Override
+    public LispObject classOf()
+    {
+        return BuiltInClass.ARRAY;
+    }
+
+    @Override
+    public int getRank()
+    {
+        return dimv.length;
+    }
+
+    @Override
+    public LispObject getDimensions()
+    {
+        LispObject result = NIL;
+        for (int i = dimv.length; i-- > 0;)
+            result = new Cons(Fixnum.getInstance(dimv[i]), result);
+        return result;
+    }
+
+    @Override
+    public int getDimension(int n)
+    {
+        try {
+            return dimv[n];
+        }
+        catch (ArrayIndexOutOfBoundsException e) {
+            error(new TypeError("Bad array dimension " + n + "."));
+            return -1;
+        }
+    }
+
+    @Override
+    public LispObject getElementType()
+    {
+        return UNSIGNED_BYTE_8;
+    }
+
+    @Override
+    public int getTotalSize()
+    {
+        return totalSize;
+    }
+
+    @Override
+    public LispObject arrayDisplacement()
+    {
+        LispObject value1, value2;
+        if (array != null) {
+            value1 = array;
+            value2 = Fixnum.getInstance(displacement);
+        } else {
+            value1 = NIL;
+            value2 = Fixnum.ZERO;
+        }
+        return LispThread.currentThread().setValues(value1, value2);
+    }
+
+    @Override
+    public LispObject AREF(int index)
+    {
+        if (data != null) {
+            try {
+                return coerceJavaByteToLispObject(data[index]);
+            }
+            catch (ArrayIndexOutOfBoundsException e) {
+                return error(new TypeError("Bad row major index " + index + "."));
+            }
+        } else
+            return array.AREF(index + displacement);
+    }
+
+    @Override
+    public void aset(int index, LispObject newValue)
+    {
+        if (data != null) {
+            try {
+                data[index] = coerceLispObjectToJavaByte(newValue);
+            }
+            catch (ArrayIndexOutOfBoundsException e) {
+                error(new TypeError("Bad row major index " + index + "."));
+            }
+        } else
+            array.aset(index + displacement, newValue);
+    }
+
+    @Override
+    public void fill(LispObject obj)
+    {
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 255) {
+            type_error(obj, UNSIGNED_BYTE_8);
+            // Not reached.
+            return;
+        }
+        if (data != null) {
+            for (int i = data.length; i-- > 0;)
+                data[i] = (byte) n;
+        } else {
+            for (int i = totalSize; i-- > 0;)
+                aset(i, obj);
+        }
+    }
+
+    @Override
+    public String printObject()
+    {
+        if (Symbol.PRINT_READABLY.symbolValue() != NIL) {
+            error(new PrintNotReadable(list(Keyword.OBJECT, this)));
+            // Not reached.
+            return null;
+        }
+        return printObject(dimv);
+    }
+
+
+    @Override
+    public AbstractArray adjustArray(int[] dims,
+                                              LispObject initialElement,
+                                              LispObject initialContents)
+            {
+        if (isAdjustable()) {
+            if (initialContents != null)
+                setInitialContents(0, dims, initialContents, 0);
+            else {
+                //### FIXME Take the easy way out: we don't want to reorganize
+                // all of the array code yet
+                SimpleArray_UnsignedByte8 tempArray = new SimpleArray_UnsignedByte8(dims);
+                if (initialElement != null)
+                    tempArray.fill(initialElement);
+                SimpleArray_UnsignedByte8.copyArray(this, tempArray);
+                this.data = tempArray.data;
+
+                for (int i = 0; i < dims.length; i++)
+                    dimv[i] = dims[i];
+            }
+            return this;
+        } else {
+            if (initialContents != null)
+                return new ComplexArray_ByteBuffer(dims, initialContents);
+            else {
+                ComplexArray_ByteBuffer newArray = new ComplexArray_ByteBuffer(dims);
+                if (initialElement != null)
+                    newArray.fill(initialElement);
+                return newArray;
+            }
+        }
+    }
+
+    @Override
+    public AbstractArray adjustArray(int[] dims,
+                                              AbstractArray displacedTo,
+                                              int displacement)
+            {
+        if (isAdjustable()) {
+            for (int i = 0; i < dims.length; i++)
+                dimv[i] = dims[i];
+
+            this.data = null;
+            this.array = displacedTo;
+            this.displacement = displacement;
+            this.totalSize = computeTotalSize(dims);
+
+            return this;
+        } else {
+            ComplexArray_ByteBuffer a = new ComplexArray_ByteBuffer(dims, displacedTo, displacement);
+
+            return a;
+        }
+    }
+}

--- a/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
@@ -1,8 +1,7 @@
 /*
- * ComplexArray_UnsignedByte8.java
+ * ComplexArray_ByteBuffer.java
  *
- * Copyright (C) 2003-2005 Peter Graves
- * $Id$
+ * Copyright (C) 2020 easye
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -37,270 +36,286 @@ import static org.armedbear.lisp.Lisp.*;
 
 import java.nio.ByteBuffer;
 
-public final class ComplexArray_ByteBuffer extends AbstractArray
+public final class ComplexArray_ByteBuffer
+  extends AbstractArray
 {
-    private final int[] dimv;
-    private int totalSize;
+  private final int[] dimv;
+  private int totalSize;
+  
+  // For non-displaced arrays.
+  // converted from   private byte[] data;
+  private ByteBuffer data; 
 
-    // For non-displaced arrays.
-    private byte[] data;
+  // For displaced arrays.
+  private AbstractArray array;
+  private int displacement;
 
-    // For displaced arrays.
-    private AbstractArray array;
-    private int displacement;
+  public ComplexArray_ByteBuffer(int[] dimv) {
+    this.dimv = dimv;
+    totalSize = computeTotalSize(dimv);
+    data = ByteBuffer.allocate(totalSize);
+  }
 
-    public ComplexArray_ByteBuffer(int[] dimv)
-    {
-        this.dimv = dimv;
-        totalSize = computeTotalSize(dimv);
-        data = new byte[totalSize];
+  public ComplexArray_ByteBuffer(int[] dimv, LispObject initialContents)
+
+  {
+    this.dimv = dimv;
+    final int rank = dimv.length;
+    LispObject rest = initialContents;
+    for (int i = 0; i < rank; i++) {
+      dimv[i] = rest.length();
+      rest = rest.elt(0);
     }
+    totalSize = computeTotalSize(dimv);
+    data = ByteBuffer.allocate(totalSize);
+    setInitialContents(0, dimv, initialContents, 0);
+  }
 
-    public ComplexArray_ByteBuffer(int[] dimv, LispObject initialContents)
+  public ComplexArray_ByteBuffer(int[] dimv, AbstractArray array, int displacement)
+  {
+    this.dimv = dimv;
+    this.array = array;
+    this.displacement = displacement;
+    totalSize = computeTotalSize(dimv);
+  }
 
-    {
-        this.dimv = dimv;
-        final int rank = dimv.length;
-        LispObject rest = initialContents;
-        for (int i = 0; i < rank; i++) {
-            dimv[i] = rest.length();
-            rest = rest.elt(0);
+  private int setInitialContents(int axis, int[] dims, LispObject contents,
+                                 int index)
+
+  {
+    if (dims.length == 0) {
+      try {
+        data.put(index, coerceLispObjectToJavaByte(contents));
+      }
+      catch (IndexOutOfBoundsException e) {
+        error(new LispError("Bad initial contents for array."));
+        return -1;
+      }
+      ++index;
+    } else {
+      int dim = dims[0];
+      if (dim != contents.length()) {
+        error(new LispError("Bad initial contents for array."));
+        return -1;
+      }
+      int[] newDims = new int[dims.length-1];
+      for (int i = 1; i < dims.length; i++)
+        newDims[i-1] = dims[i];
+      if (contents.listp()) {
+        for (int i = contents.length();i-- > 0;) {
+          LispObject content = contents.car();
+          index =
+            setInitialContents(axis + 1, newDims, content, index);
+          contents = contents.cdr();
         }
-        totalSize = computeTotalSize(dimv);
-        data = new byte[totalSize];
-        setInitialContents(0, dimv, initialContents, 0);
-    }
-
-    public ComplexArray_ByteBuffer(int[] dimv, AbstractArray array, int displacement)
-    {
-        this.dimv = dimv;
-        this.array = array;
-        this.displacement = displacement;
-        totalSize = computeTotalSize(dimv);
-    }
-
-    private int setInitialContents(int axis, int[] dims, LispObject contents,
-                                   int index)
-
-    {
-        if (dims.length == 0) {
-            try {
-                data[index] = coerceLispObjectToJavaByte(contents);
-            }
-            catch (ArrayIndexOutOfBoundsException e) {
-                error(new LispError("Bad initial contents for array."));
-                return -1;
-            }
-            ++index;
-        } else {
-            int dim = dims[0];
-            if (dim != contents.length()) {
-                error(new LispError("Bad initial contents for array."));
-                return -1;
-            }
-            int[] newDims = new int[dims.length-1];
-            for (int i = 1; i < dims.length; i++)
-                newDims[i-1] = dims[i];
-            if (contents.listp()) {
-                for (int i = contents.length();i-- > 0;) {
-                    LispObject content = contents.car();
-                    index =
-                        setInitialContents(axis + 1, newDims, content, index);
-                    contents = contents.cdr();
-                }
-            } else {
-                AbstractVector v = checkVector(contents);
-                final int length = v.length();
-                for (int i = 0; i < length; i++) {
-                    LispObject content = v.AREF(i);
-                    index =
-                        setInitialContents(axis + 1, newDims, content, index);
-                }
-            }
+      } else {
+        AbstractVector v = checkVector(contents);
+        final int length = v.length();
+        for (int i = 0; i < length; i++) {
+          LispObject content = v.AREF(i);
+          index =
+            setInitialContents(axis + 1, newDims, content, index);
         }
-        return index;
+      }
     }
+    return index;
+  }
 
-    @Override
-    public LispObject typeOf()
-    {
-        return list(Symbol.ARRAY, UNSIGNED_BYTE_8, getDimensions());
+  @Override
+  public LispObject typeOf()
+  {
+    return list(Symbol.ARRAY, UNSIGNED_BYTE_8, getDimensions());
+  }
+
+  @Override
+  public LispObject classOf()
+  {
+    return BuiltInClass.ARRAY;
+  }
+
+  @Override
+  public int getRank()
+  {
+    return dimv.length;
+  }
+
+  @Override
+  public LispObject getDimensions()
+  {
+    LispObject result = NIL;
+    for (int i = dimv.length; i-- > 0;)
+      result = new Cons(Fixnum.getInstance(dimv[i]), result);
+    return result;
+  }
+
+  @Override
+  public int getDimension(int n)
+  {
+    try {
+      return dimv[n];
     }
-
-    @Override
-    public LispObject classOf()
-    {
-        return BuiltInClass.ARRAY;
+    catch (ArrayIndexOutOfBoundsException e) {
+      error(new TypeError("Bad array dimension " + n + "."));
+      return -1;
     }
+  }
 
-    @Override
-    public int getRank()
-    {
-        return dimv.length;
+  @Override
+  public LispObject getElementType()
+  {
+    return UNSIGNED_BYTE_8;
+  }
+
+  @Override
+  public int getTotalSize()
+  {
+    return totalSize;
+  }
+
+  @Override
+  public LispObject arrayDisplacement()
+  {
+    LispObject value1, value2;
+    if (array != null) {
+      value1 = array;
+      value2 = Fixnum.getInstance(displacement);
+    } else {
+      value1 = NIL;
+      value2 = Fixnum.ZERO;
     }
+    return LispThread.currentThread().setValues(value1, value2);
+  }
 
-    @Override
-    public LispObject getDimensions()
-    {
-        LispObject result = NIL;
-        for (int i = dimv.length; i-- > 0;)
-            result = new Cons(Fixnum.getInstance(dimv[i]), result);
-        return result;
+  @Override
+  public LispObject AREF(int index)
+  {
+    if (data != null) {
+      try {
+        return coerceJavaByteToLispObject(data.get(index));
+      }
+      catch (IndexOutOfBoundsException e) {
+        return error(new TypeError("Bad row major index " + index + "."));
+      }
+    } else
+      return array.AREF(index + displacement);
+  }
+
+  @Override
+  public void aset(int index, LispObject newValue)
+  {
+    if (data != null) {
+      try {
+        data.put(index, coerceLispObjectToJavaByte(newValue));
+      }
+      catch (IndexOutOfBoundsException e) {
+        error(new TypeError("Bad row major index " + index + "."));
+      }
+    } else
+      array.aset(index + displacement, newValue);
+  }
+
+  @Override
+  public void fill(LispObject obj)
+  {
+    if (!(obj instanceof Fixnum)) {
+      type_error(obj, Symbol.FIXNUM);
+      // Not reached.
+      return;
     }
+    int n = ((Fixnum) obj).value;
+    if (n < 0 || n > 255) {
+      type_error(obj, UNSIGNED_BYTE_8);
+      // Not reached.
+      return;
+    }
+    if (data != null) {
+      for (int i = data.limit(); i-- > 0;)
+        data.put(i, (byte) n); // FIXME Faster!!
+    } else {
+      for (int i = totalSize; i-- > 0;)
+        aset(i, obj);
+    }
+  }
 
-    @Override
-    public int getDimension(int n)
-    {
-        try {
-            return dimv[n];
+  @Override
+  public String printObject()
+  {
+    if (Symbol.PRINT_READABLY.symbolValue() != NIL) {
+      error(new PrintNotReadable(list(Keyword.OBJECT, this)));
+      // Not reached.
+      return null;
+    }
+    return printObject(dimv);
+  }
+
+  int arrayTotalSize(int[] dims) {
+    int result = 0;
+    for (int dim : dims) {
+      result += dim;
+    }
+    return result;
+  }
+
+  // FIXME move me to someplace more general
+  public static void fill(ByteBuffer buffer, byte value) {
+    for (int i = 0; i < buffer.limit(); i++) {
+      buffer.put(value);
+    }
+  }
+
+  @Override
+  public AbstractArray adjustArray(int[] dims,
+                                   LispObject initialElement,
+                                   LispObject initialContents)
+  {
+    if (isAdjustable()) {
+      if (initialContents != null)
+        setInitialContents(0, dims, initialContents, 0);
+      else {
+        //### FIXME Take the easy way out: we don't want to reorganize
+        // all of the array code yet
+        //        SimpleArray_ByteBuffer newBuffer = new SimpleArray_ByteBuffer(dims);
+        ByteBuffer newBuffer = ByteBuffer.allocate(computeTotalSize(dims));
+        if (initialElement != null) {
+          fill(newBuffer, coerceLispObjectToJavaByte(initialElement));           
         }
-        catch (ArrayIndexOutOfBoundsException e) {
-            error(new TypeError("Bad array dimension " + n + "."));
-            return -1;
-        }
+        this.data = newBuffer;
+
+        for (int i = 0; i < dims.length; i++)
+          dimv[i] = dims[i];
+      }
+      return this;
+    } else {
+      if (initialContents != null)
+        return new ComplexArray_ByteBuffer(dims, initialContents);
+      else {
+        ComplexArray_ByteBuffer newArray = new ComplexArray_ByteBuffer(dims);
+        if (initialElement != null)
+          newArray.fill(initialElement);
+        return newArray;
+      }
     }
+  }
 
-    @Override
-    public LispObject getElementType()
-    {
-        return UNSIGNED_BYTE_8;
+  @Override
+  public AbstractArray adjustArray(int[] dims,
+                                   AbstractArray displacedTo,
+                                   int displacement)
+  {
+    if (isAdjustable()) {
+      for (int i = 0; i < dims.length; i++)
+        dimv[i] = dims[i];
+
+      this.data = null;
+      this.array = displacedTo;
+      this.displacement = displacement;
+      this.totalSize = computeTotalSize(dims);
+
+      return this;
+    } else {
+      ComplexArray_ByteBuffer a = new ComplexArray_ByteBuffer(dims, displacedTo, displacement);
+
+      return a;
     }
-
-    @Override
-    public int getTotalSize()
-    {
-        return totalSize;
-    }
-
-    @Override
-    public LispObject arrayDisplacement()
-    {
-        LispObject value1, value2;
-        if (array != null) {
-            value1 = array;
-            value2 = Fixnum.getInstance(displacement);
-        } else {
-            value1 = NIL;
-            value2 = Fixnum.ZERO;
-        }
-        return LispThread.currentThread().setValues(value1, value2);
-    }
-
-    @Override
-    public LispObject AREF(int index)
-    {
-        if (data != null) {
-            try {
-                return coerceJavaByteToLispObject(data[index]);
-            }
-            catch (ArrayIndexOutOfBoundsException e) {
-                return error(new TypeError("Bad row major index " + index + "."));
-            }
-        } else
-            return array.AREF(index + displacement);
-    }
-
-    @Override
-    public void aset(int index, LispObject newValue)
-    {
-        if (data != null) {
-            try {
-                data[index] = coerceLispObjectToJavaByte(newValue);
-            }
-            catch (ArrayIndexOutOfBoundsException e) {
-                error(new TypeError("Bad row major index " + index + "."));
-            }
-        } else
-            array.aset(index + displacement, newValue);
-    }
-
-    @Override
-    public void fill(LispObject obj)
-    {
-        if (!(obj instanceof Fixnum)) {
-            type_error(obj, Symbol.FIXNUM);
-            // Not reached.
-            return;
-        }
-        int n = ((Fixnum) obj).value;
-        if (n < 0 || n > 255) {
-            type_error(obj, UNSIGNED_BYTE_8);
-            // Not reached.
-            return;
-        }
-        if (data != null) {
-            for (int i = data.length; i-- > 0;)
-                data[i] = (byte) n;
-        } else {
-            for (int i = totalSize; i-- > 0;)
-                aset(i, obj);
-        }
-    }
-
-    @Override
-    public String printObject()
-    {
-        if (Symbol.PRINT_READABLY.symbolValue() != NIL) {
-            error(new PrintNotReadable(list(Keyword.OBJECT, this)));
-            // Not reached.
-            return null;
-        }
-        return printObject(dimv);
-    }
-
-
-    @Override
-    public AbstractArray adjustArray(int[] dims,
-                                              LispObject initialElement,
-                                              LispObject initialContents)
-            {
-        if (isAdjustable()) {
-            if (initialContents != null)
-                setInitialContents(0, dims, initialContents, 0);
-            else {
-                //### FIXME Take the easy way out: we don't want to reorganize
-                // all of the array code yet
-                SimpleArray_UnsignedByte8 tempArray = new SimpleArray_UnsignedByte8(dims);
-                if (initialElement != null)
-                    tempArray.fill(initialElement);
-                SimpleArray_UnsignedByte8.copyArray(this, tempArray);
-                this.data = tempArray.data;
-
-                for (int i = 0; i < dims.length; i++)
-                    dimv[i] = dims[i];
-            }
-            return this;
-        } else {
-            if (initialContents != null)
-                return new ComplexArray_ByteBuffer(dims, initialContents);
-            else {
-                ComplexArray_ByteBuffer newArray = new ComplexArray_ByteBuffer(dims);
-                if (initialElement != null)
-                    newArray.fill(initialElement);
-                return newArray;
-            }
-        }
-    }
-
-    @Override
-    public AbstractArray adjustArray(int[] dims,
-                                              AbstractArray displacedTo,
-                                              int displacement)
-            {
-        if (isAdjustable()) {
-            for (int i = 0; i < dims.length; i++)
-                dimv[i] = dims[i];
-
-            this.data = null;
-            this.array = displacedTo;
-            this.displacement = displacement;
-            this.totalSize = computeTotalSize(dims);
-
-            return this;
-        } else {
-            ComplexArray_ByteBuffer a = new ComplexArray_ByteBuffer(dims, displacedTo, displacement);
-
-            return a;
-        }
-    }
+  }
 }

--- a/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
@@ -40,410 +40,403 @@ import java.nio.ByteBuffer;
 // another array, has a fill pointer, and/or is expressly adjustable.
 public final class ComplexVector_ByteBuffer extends AbstractVector
 {
-    private int capacity;
-    private int fillPointer = -1; // -1 indicates no fill pointer.
-    private boolean isDisplaced;
+  private int capacity; // needed for displaced arrays
+  private int fillPointer = -1; // -1 indicates no fill pointer.
+  private boolean isDisplaced;
 
-    // For non-displaced arrays.
-    private byte[] elements;
+  // For non-displaced arrays.
+  private ByteBuffer elements;
 
-    // For displaced arrays.
-    private AbstractArray array;
-    private int displacement;
+  // For displaced arrays.
+  private AbstractArray array;
+  private int displacement;
 
-    public ComplexVector_ByteBuffer(int capacity)
-    {
-        elements = new byte[capacity];
-        this.capacity = capacity;
-    }
+  public ComplexVector_ByteBuffer(int capacity) {
+    elements = ByteBuffer.allocate(capacity);
+    this.capacity = capacity; // FIXME: shouldn't need 
+  }
 
-    public ComplexVector_ByteBuffer(int capacity, AbstractArray array,
-                                       int displacement)
-    {
-        this.capacity = capacity;
-        this.array = array;
-        this.displacement = displacement;
-        isDisplaced = true;
-    }
+  public ComplexVector_ByteBuffer(int capacity, AbstractArray array,
+                                  int displacement) {
+    this.capacity = capacity;
+    this.array = array;
+    this.displacement = displacement;
+    isDisplaced = true;
+  }
 
-    @Override
-    public LispObject typeOf()
-    {
-        return list(Symbol.VECTOR, UNSIGNED_BYTE_8, Fixnum.getInstance(capacity));
-    }
+  @Override
+  public LispObject typeOf() {
+    return list(Symbol.VECTOR, UNSIGNED_BYTE_8, Fixnum.getInstance(capacity));
+  }
 
-    @Override
-    public LispObject classOf()
-    {
-        return BuiltInClass.VECTOR;
-    }
+  @Override
+  public LispObject classOf() {
+    return BuiltInClass.VECTOR;
+  }
 
-    @Override
-    public boolean hasFillPointer()
-    {
-        return fillPointer >= 0;
-    }
+  @Override
+  public boolean hasFillPointer() {
+    return fillPointer >= 0;
+  }
 
-    @Override
-    public int getFillPointer()
-    {
-        return fillPointer;
-    }
+  @Override
+  public int getFillPointer()
+  {
+    return fillPointer;
+  }
 
-    @Override
-    public void setFillPointer(int n)
-    {
+  @Override
+  public void setFillPointer(int n)
+  {
+    fillPointer = n;
+  }
+
+  @Override
+  public void setFillPointer(LispObject obj)
+  {
+    if (obj == T)
+      fillPointer = capacity();
+    else {
+      int n = Fixnum.getValue(obj);
+      if (n > capacity()) {
+        StringBuffer sb = new StringBuffer("The new fill pointer (");
+        sb.append(n);
+        sb.append(") exceeds the capacity of the vector (");
+        sb.append(capacity());
+        sb.append(").");
+        error(new LispError(sb.toString()));
+      } else if (n < 0) {
+        StringBuffer sb = new StringBuffer("The new fill pointer (");
+        sb.append(n);
+        sb.append(") is negative.");
+        error(new LispError(sb.toString()));
+      } else
         fillPointer = n;
     }
+  }
 
-    @Override
-    public void setFillPointer(LispObject obj)
-    {
-        if (obj == T)
-            fillPointer = capacity();
-        else {
-            int n = Fixnum.getValue(obj);
-            if (n > capacity()) {
-                StringBuffer sb = new StringBuffer("The new fill pointer (");
-                sb.append(n);
-                sb.append(") exceeds the capacity of the vector (");
-                sb.append(capacity());
-                sb.append(").");
-                error(new LispError(sb.toString()));
-            } else if (n < 0) {
-                StringBuffer sb = new StringBuffer("The new fill pointer (");
-                sb.append(n);
-                sb.append(") is negative.");
-                error(new LispError(sb.toString()));
-            } else
-                fillPointer = n;
-        }
+  @Override
+  public boolean isDisplaced()
+  {
+    return isDisplaced;
+  }
+
+  @Override
+  public LispObject arrayDisplacement()
+  {
+    LispObject value1, value2;
+    if (array != null) {
+      value1 = array;
+      value2 = Fixnum.getInstance(displacement);
+    } else {
+      value1 = NIL;
+      value2 = Fixnum.ZERO;
     }
+    return LispThread.currentThread().setValues(value1, value2);
+  }
 
-    @Override
-    public boolean isDisplaced()
-    {
-        return isDisplaced;
+  @Override
+  public LispObject getElementType()
+  {
+    return UNSIGNED_BYTE_8;
+  }
+
+  @Override
+  public boolean isSimpleVector()
+  {
+    return false;
+  }
+
+  @Override
+  public int capacity()
+  {
+    return capacity;
+  }
+
+  @Override
+  public int length() {
+    return fillPointer >= 0 ? fillPointer : elements.limit();
+  }
+
+  @Override
+  public LispObject elt(int index)
+  {
+    final int limit = length();
+    if (index < 0 || index >= limit)
+      badIndex(index, limit);
+    return AREF(index);
+  }
+
+  // Ignores fill pointer.
+  @Override
+  public LispObject AREF(int index) {
+    if (elements != null) {
+      try {
+        return coerceJavaByteToLispObject(elements.get(index));
+      } catch (ArrayIndexOutOfBoundsException e) {
+        badIndex(index, elements.limit());
+        return NIL; // Not reached.
+      }
+    } else {
+      // Displaced array.
+      if (index < 0 || index >= capacity) {
+        badIndex(index, capacity);
+      }
+      return array.AREF(index + displacement);
     }
+  }
 
-    @Override
-    public LispObject arrayDisplacement()
-    {
-        LispObject value1, value2;
-        if (array != null) {
-            value1 = array;
-            value2 = Fixnum.getInstance(displacement);
-        } else {
-            value1 = NIL;
-            value2 = Fixnum.ZERO;
-        }
-        return LispThread.currentThread().setValues(value1, value2);
+  @Override
+  public void aset(int index, int n) {
+    if (elements != null) {
+      try {
+        elements.put(index, (byte) n);
+      } catch (IndexOutOfBoundsException e) {
+        badIndex(index, capacity);
+      }
+    } else {
+      // Displaced array.
+      if (index < 0 || index >= capacity) {
+        badIndex(index, capacity);
+      } else {
+        array.aset(index + displacement, n);
+      }
     }
+  }
 
-    @Override
-    public LispObject getElementType()
-    {
-        return UNSIGNED_BYTE_8;
+  @Override
+  public void aset(int index, LispObject newValue)
+  {
+    if (elements != null) {
+      try {
+        elements.put(index, coerceLispObjectToJavaByte(newValue));
+      } catch (IndexOutOfBoundsException e) {
+        badIndex(index, elements.limit());
+      }
+    } else {
+      array.aset(index + displacement, newValue);
     }
+  }
 
-    @Override
-    public boolean isSimpleVector()
-    {
-        return false;
+  @Override
+  public LispObject subseq(int start, int end) {
+    SimpleVector v = new SimpleVector(end - start);
+    int i = start, j = 0;
+    try {
+      while (i < end)
+        v.aset(j++, AREF(i++));
+      return v;
     }
-
-    @Override
-    public int capacity()
-    {
-        return capacity;
+    catch (IndexOutOfBoundsException e) {
+      return error(new TypeError("Array index out of bounds: " + i + "."));
     }
+  }
 
-    @Override
-    public int length()
-    {
-        return fillPointer >= 0 ? fillPointer : capacity;
+  @Override
+  public void fill(LispObject obj)
+  {
+    if (!(obj instanceof Fixnum)) {
+      type_error(obj, Symbol.FIXNUM);
+      // Not reached.
+      return;
     }
-
-    @Override
-    public LispObject elt(int index)
-    {
-        final int limit = length();
-        if (index < 0 || index >= limit)
-            badIndex(index, limit);
-        return AREF(index);
+    int n = ((Fixnum) obj).value;
+    if (n < 0 || n > 255) {
+      type_error(obj, UNSIGNED_BYTE_8);
+      // Not reached.
+      return;
     }
+    for (int i = capacity; i-- > 0;)
+      elements.put(i, (byte) n);
+  }
 
-    // Ignores fill pointer.
-    @Override
-    public LispObject AREF(int index)
-    {
-        if (elements != null) {
-            try {
-                return coerceJavaByteToLispObject(elements[index]);
-            }
-            catch (ArrayIndexOutOfBoundsException e) {
-                badIndex(index, elements.length);
-                return NIL; // Not reached.
-            }
-        } else {
-            // Displaced array.
-            if (index < 0 || index >= capacity)
-                badIndex(index, capacity);
-            return array.AREF(index + displacement);
-        }
+  @Override
+  public void shrink(int n) {
+    // One cannot shrink the underlying ByteBuffer physically, so
+    // use the limit marker to denote the length
+    if (n < length()) {
+      elements.limit(n);
+      return;
     }
-
-    @Override
-    public void aset(int index, int n)
-    {
-        if (elements != null) {
-            try {
-                elements[index] = (byte) n;
-            }
-            catch (ArrayIndexOutOfBoundsException e) {
-                badIndex(index, elements.length);
-            }
-        } else {
-            // Displaced array.
-            if (index < 0 || index >= capacity)
-                badIndex(index, capacity);
-            else
-                array.aset(index + displacement, n);
-        }
+    if (n == length()) {
+      return;
     }
+    error(new LispError());
+  }
 
-    @Override
-    public void aset(int index, LispObject newValue)
-    {
-        if (elements != null) {
-            try {
-                elements[index] = coerceLispObjectToJavaByte(newValue);
-            }
-            catch (ArrayIndexOutOfBoundsException e) {
-                badIndex(index, elements.length);
-            }
-        } else
-            array.aset(index + displacement, newValue);
+  @Override
+  public LispObject reverse()
+  {
+    int length = length();
+    BasicVector_ByteBuffer result = new BasicVector_ByteBuffer(length);
+    int i, j;
+    for (i = 0, j = length - 1; i < length; i++, j--)
+      result.aset(i, AREF(j));
+    return result;
+  }
+
+  @Override
+  public LispObject nreverse() {
+    if (elements != null) {
+      int i = 0;
+      int j = capacity() - 1;
+      while (i < j) {
+        byte temp = elements.get(i);
+        elements.put(i, elements.get(j));
+        elements.put(j, temp);
+        ++i;
+        --j;
+      }
+    } else {
+      // Displaced array.
+      int length = length();
+      ByteBuffer data = ByteBuffer.allocate(length);
+      int i, j;
+      for (i = 0, j = length - 1; i < length; i++, j--) {
+        data.put(i, coerceLispObjectToJavaByte(AREF(j)));
+      }
+      elements = data;
+      capacity = length;
+      array = null;
+      displacement = 0;
+      isDisplaced = false;
+      fillPointer = -1;
     }
+    return this;
+  }
 
-    @Override
-    public LispObject subseq(int start, int end)
-    {
-        SimpleVector v = new SimpleVector(end - start);
-        int i = start, j = 0;
-        try {
-            while (i < end)
-                v.aset(j++, AREF(i++));
-            return v;
-        }
-        catch (ArrayIndexOutOfBoundsException e) {
-            return error(new TypeError("Array index out of bounds: " + i + "."));
-        }
+  @Override
+  public void vectorPushExtend(LispObject element)
+  {
+    if (fillPointer < 0)
+      noFillPointer();
+    if (fillPointer >= capacity) {
+      // Need to extend vector.
+      ensureCapacity(capacity * 2 + 1);
     }
+    aset(fillPointer, element);
+    ++fillPointer;
+  }
 
-    @Override
-    public void fill(LispObject obj)
-    {
-        if (!(obj instanceof Fixnum)) {
-            type_error(obj, Symbol.FIXNUM);
-            // Not reached.
-            return;
-        }
-        int n = ((Fixnum) obj).value;
-        if (n < 0 || n > 255) {
-            type_error(obj, UNSIGNED_BYTE_8);
-            // Not reached.
-            return;
-        }
-        for (int i = capacity; i-- > 0;)
-            elements[i] = (byte) n;
+  @Override
+  public LispObject VECTOR_PUSH_EXTEND(LispObject element)
+
+  {
+    vectorPushExtend(element);
+    return Fixnum.getInstance(fillPointer - 1);
+  }
+
+  @Override
+  public LispObject VECTOR_PUSH_EXTEND(LispObject element, LispObject extension)
+
+  {
+    int ext = Fixnum.getValue(extension);
+    if (fillPointer < 0)
+      noFillPointer();
+    if (fillPointer >= capacity) {
+      // Need to extend vector.
+      ext = Math.max(ext, capacity + 1);
+      ensureCapacity(capacity + ext);
     }
+    aset(fillPointer, element);
+    return Fixnum.getInstance(fillPointer++);
+  }
 
-    @Override
-    public void shrink(int n)
-    {
-        if (elements != null) {
-            if (n < elements.length) {
-                byte[] newArray = new byte[n];
-                System.arraycopy(elements, 0, newArray, 0, n);
-                elements = newArray;
-                capacity = n;
-                return;
-            }
-            if (n == elements.length)
-                return;
-        }
-        error(new LispError());
-    }
-
-    @Override
-    public LispObject reverse()
-    {
-        int length = length();
-        BasicVector_ByteBuffer result = new BasicVector_ByteBuffer(length);
-        int i, j;
-        for (i = 0, j = length - 1; i < length; i++, j--)
-            result.aset(i, AREF(j));
-        return result;
-    }
-
-    @Override
-    public LispObject nreverse()
-    {
-        if (elements != null) {
-            int i = 0;
-            int j = length() - 1;
-            while (i < j) {
-                byte temp = elements[i];
-                elements[i] = elements[j];
-                elements[j] = temp;
-                ++i;
-                --j;
-            }
-        } else {
-            // Displaced array.
-            int length = length();
-            byte[] data = new byte[length];
-            int i, j;
-            for (i = 0, j = length - 1; i < length; i++, j--)
-                data[i] = coerceLispObjectToJavaByte(AREF(j));
-            elements = data;
-            capacity = length;
+  private final void ensureCapacity(int minCapacity) {
+    if (elements != null) {
+      if (capacity < minCapacity) {
+        //                byte[] newArray = new byte[minCapacity];
+        ByteBuffer newBuffer = ByteBuffer.allocate(minCapacity);
+        newBuffer.put(elements); 
+        elements = newBuffer;
+        capacity = minCapacity;
+      }
+    } else {
+      // Displaced array.
+      Debug.assertTrue(array != null);
+      if (capacity < minCapacity
+          || array.getTotalSize() - displacement < minCapacity) {
+          // Copy array.
+          //elements = new byte[minCapacity];
+          elements = ByteBuffer.allocate(minCapacity);
+          
+          final int limit
+            = Math.min(length(), array.getTotalSize() - displacement);
+          for (int i = 0; i < limit; i++) {
+            elements.put(i, coerceLispObjectToJavaByte(array.AREF(displacement + i)));
+            capacity = minCapacity;
             array = null;
             displacement = 0;
             isDisplaced = false;
-            fillPointer = -1;
-        }
-        return this;
+          }
+      }
     }
+  }
+
+  @Override
+  public AbstractVector adjustArray(int newCapacity,
+                                    LispObject initialElement,
+                                    LispObject initialContents) {
+    if (initialContents != null) {
+      // "If INITIAL-CONTENTS is supplied, it is treated as for MAKE-
+      // ARRAY. In this case none of the original contents of array
+      // appears in the resulting array."
+      ByteBuffer newElements = ByteBuffer.allocate(newCapacity);
+      //      byte[] newElements = new byte[newCapacity];
+      if (initialContents.listp()) {
+        LispObject list = initialContents;
+          for (int i = 0; i < newCapacity; i++) {
+            newElements.put(i, coerceLispObjectToJavaByte(list.car()));
+            list = list.cdr();
+          }
+      } else if (initialContents.vectorp()) {
+        for (int i = 0; i < newCapacity; i++) {
+          newElements.put(i, coerceLispObjectToJavaByte(initialContents.elt(i)));
+        }
+      } else {
+          type_error(initialContents, Symbol.SEQUENCE);
+      }
+      elements = newElements;
+
+    } else {
+      if (elements == null) {
+        // Displaced array. Copy existing elements.
+        elements = ByteBuffer.allocate(newCapacity);
+        final int limit = Math.min(capacity, newCapacity);
+        for (int i = 0; i < limit; i++) {
+          elements.put(i, coerceLispObjectToJavaByte(array.AREF(displacement + i)));
+        }
+      } else if (capacity != newCapacity) {
+        ByteBuffer newElements = ByteBuffer.allocate(newCapacity);
+        //              byte[] newElements = new byte[newCapacity];
+        newElements.put(elements.array(), 0, 
+                        Math.min(capacity, newCapacity));
+        elements = newElements;
+      }
+      // Initialize new elements (if applicable).
+      if (initialElement != null) {
+        byte b = coerceLispObjectToJavaByte(initialElement);
+        for (int i = capacity; i < newCapacity; i++) {
+          elements.put(b);
+        }
+      }
+    }
+    capacity = newCapacity;
+    array = null;
+    displacement = 0;
+    isDisplaced = false;
+    return this;
+  }
 
     @Override
-    public void vectorPushExtend(LispObject element)
-    {
-        if (fillPointer < 0)
-            noFillPointer();
-        if (fillPointer >= capacity) {
-            // Need to extend vector.
-            ensureCapacity(capacity * 2 + 1);
-        }
-        aset(fillPointer, element);
-        ++fillPointer;
+      public AbstractVector adjustArray(int newCapacity,
+                                        AbstractArray displacedTo,
+                                        int displacement) {
+      capacity = newCapacity;
+      array = displacedTo;
+      this.displacement = displacement;
+      elements = null;
+      isDisplaced = true;
+      return this;
     }
-
-    @Override
-    public LispObject VECTOR_PUSH_EXTEND(LispObject element)
-
-    {
-        vectorPushExtend(element);
-        return Fixnum.getInstance(fillPointer - 1);
-    }
-
-    @Override
-    public LispObject VECTOR_PUSH_EXTEND(LispObject element, LispObject extension)
-
-    {
-        int ext = Fixnum.getValue(extension);
-        if (fillPointer < 0)
-            noFillPointer();
-        if (fillPointer >= capacity) {
-            // Need to extend vector.
-            ext = Math.max(ext, capacity + 1);
-            ensureCapacity(capacity + ext);
-        }
-        aset(fillPointer, element);
-        return Fixnum.getInstance(fillPointer++);
-    }
-
-    private final void ensureCapacity(int minCapacity)
-    {
-        if (elements != null) {
-            if (capacity < minCapacity) {
-                byte[] newArray = new byte[minCapacity];
-                System.arraycopy(elements, 0, newArray, 0, capacity);
-                elements = newArray;
-                capacity = minCapacity;
-            }
-        } else {
-            // Displaced array.
-            Debug.assertTrue(array != null);
-            if (capacity < minCapacity ||
-                array.getTotalSize() - displacement < minCapacity)
-            {
-                // Copy array.
-                elements = new byte[minCapacity];
-                final int limit =
-                    Math.min(capacity, array.getTotalSize() - displacement);
-                for (int i = 0; i < limit; i++)
-                    elements[i] = coerceLispObjectToJavaByte(array.AREF(displacement + i));
-                capacity = minCapacity;
-                array = null;
-                displacement = 0;
-                isDisplaced = false;
-            }
-        }
-    }
-
-    @Override
-    public AbstractVector adjustArray(int newCapacity,
-                                       LispObject initialElement,
-                                       LispObject initialContents)
-
-    {
-        if (initialContents != null) {
-            // "If INITIAL-CONTENTS is supplied, it is treated as for MAKE-
-            // ARRAY. In this case none of the original contents of array
-            // appears in the resulting array."
-            byte[] newElements = new byte[newCapacity];
-            if (initialContents.listp()) {
-                LispObject list = initialContents;
-                for (int i = 0; i < newCapacity; i++) {
-                    newElements[i] = coerceLispObjectToJavaByte(list.car());
-                    list = list.cdr();
-                }
-            } else if (initialContents.vectorp()) {
-                for (int i = 0; i < newCapacity; i++)
-                    newElements[i] = coerceLispObjectToJavaByte(initialContents.elt(i));
-            } else
-                type_error(initialContents, Symbol.SEQUENCE);
-            elements = newElements;
-        } else {
-            if (elements == null) {
-                // Displaced array. Copy existing elements.
-                elements = new byte[newCapacity];
-                final int limit = Math.min(capacity, newCapacity);
-                for (int i = 0; i < limit; i++)
-                    elements[i] = coerceLispObjectToJavaByte(array.AREF(displacement + i));
-            } else if (capacity != newCapacity) {
-                byte[] newElements = new byte[newCapacity];
-                System.arraycopy(elements, 0, newElements, 0,
-                                 Math.min(capacity, newCapacity));
-                elements = newElements;
-            }
-            // Initialize new elements (if aapplicable).
-            if (initialElement != null) {
-                byte b = coerceLispObjectToJavaByte(initialElement);
-                for (int i = capacity; i < newCapacity; i++)
-                    elements[i] = b;
-            }
-        }
-        capacity = newCapacity;
-        array = null;
-        displacement = 0;
-        isDisplaced = false;
-        return this;
-    }
-
-    @Override
-    public AbstractVector adjustArray(int newCapacity,
-                                       AbstractArray displacedTo,
-                                       int displacement)
-
-    {
-        capacity = newCapacity;
-        array = displacedTo;
-        this.displacement = displacement;
-        elements = null;
-        isDisplaced = true;
-        return this;
-    }
-}
+  }

--- a/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
@@ -1,0 +1,449 @@
+/*
+ * ComplexVector_ByteBuffer
+ *
+ * Copyright (C) 2020 @easye
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+
+// A specialized vector of element type (UNSIGNED-BYTE 8) that is displaced to
+// another array, has a fill pointer, and/or is expressly adjustable.
+public final class ComplexVector_ByteBuffer extends AbstractVector
+{
+    private int capacity;
+    private int fillPointer = -1; // -1 indicates no fill pointer.
+    private boolean isDisplaced;
+
+    // For non-displaced arrays.
+    private byte[] elements;
+
+    // For displaced arrays.
+    private AbstractArray array;
+    private int displacement;
+
+    public ComplexVector_ByteBuffer(int capacity)
+    {
+        elements = new byte[capacity];
+        this.capacity = capacity;
+    }
+
+    public ComplexVector_ByteBuffer(int capacity, AbstractArray array,
+                                       int displacement)
+    {
+        this.capacity = capacity;
+        this.array = array;
+        this.displacement = displacement;
+        isDisplaced = true;
+    }
+
+    @Override
+    public LispObject typeOf()
+    {
+        return list(Symbol.VECTOR, UNSIGNED_BYTE_8, Fixnum.getInstance(capacity));
+    }
+
+    @Override
+    public LispObject classOf()
+    {
+        return BuiltInClass.VECTOR;
+    }
+
+    @Override
+    public boolean hasFillPointer()
+    {
+        return fillPointer >= 0;
+    }
+
+    @Override
+    public int getFillPointer()
+    {
+        return fillPointer;
+    }
+
+    @Override
+    public void setFillPointer(int n)
+    {
+        fillPointer = n;
+    }
+
+    @Override
+    public void setFillPointer(LispObject obj)
+    {
+        if (obj == T)
+            fillPointer = capacity();
+        else {
+            int n = Fixnum.getValue(obj);
+            if (n > capacity()) {
+                StringBuffer sb = new StringBuffer("The new fill pointer (");
+                sb.append(n);
+                sb.append(") exceeds the capacity of the vector (");
+                sb.append(capacity());
+                sb.append(").");
+                error(new LispError(sb.toString()));
+            } else if (n < 0) {
+                StringBuffer sb = new StringBuffer("The new fill pointer (");
+                sb.append(n);
+                sb.append(") is negative.");
+                error(new LispError(sb.toString()));
+            } else
+                fillPointer = n;
+        }
+    }
+
+    @Override
+    public boolean isDisplaced()
+    {
+        return isDisplaced;
+    }
+
+    @Override
+    public LispObject arrayDisplacement()
+    {
+        LispObject value1, value2;
+        if (array != null) {
+            value1 = array;
+            value2 = Fixnum.getInstance(displacement);
+        } else {
+            value1 = NIL;
+            value2 = Fixnum.ZERO;
+        }
+        return LispThread.currentThread().setValues(value1, value2);
+    }
+
+    @Override
+    public LispObject getElementType()
+    {
+        return UNSIGNED_BYTE_8;
+    }
+
+    @Override
+    public boolean isSimpleVector()
+    {
+        return false;
+    }
+
+    @Override
+    public int capacity()
+    {
+        return capacity;
+    }
+
+    @Override
+    public int length()
+    {
+        return fillPointer >= 0 ? fillPointer : capacity;
+    }
+
+    @Override
+    public LispObject elt(int index)
+    {
+        final int limit = length();
+        if (index < 0 || index >= limit)
+            badIndex(index, limit);
+        return AREF(index);
+    }
+
+    // Ignores fill pointer.
+    @Override
+    public LispObject AREF(int index)
+    {
+        if (elements != null) {
+            try {
+                return coerceJavaByteToLispObject(elements[index]);
+            }
+            catch (ArrayIndexOutOfBoundsException e) {
+                badIndex(index, elements.length);
+                return NIL; // Not reached.
+            }
+        } else {
+            // Displaced array.
+            if (index < 0 || index >= capacity)
+                badIndex(index, capacity);
+            return array.AREF(index + displacement);
+        }
+    }
+
+    @Override
+    public void aset(int index, int n)
+    {
+        if (elements != null) {
+            try {
+                elements[index] = (byte) n;
+            }
+            catch (ArrayIndexOutOfBoundsException e) {
+                badIndex(index, elements.length);
+            }
+        } else {
+            // Displaced array.
+            if (index < 0 || index >= capacity)
+                badIndex(index, capacity);
+            else
+                array.aset(index + displacement, n);
+        }
+    }
+
+    @Override
+    public void aset(int index, LispObject newValue)
+    {
+        if (elements != null) {
+            try {
+                elements[index] = coerceLispObjectToJavaByte(newValue);
+            }
+            catch (ArrayIndexOutOfBoundsException e) {
+                badIndex(index, elements.length);
+            }
+        } else
+            array.aset(index + displacement, newValue);
+    }
+
+    @Override
+    public LispObject subseq(int start, int end)
+    {
+        SimpleVector v = new SimpleVector(end - start);
+        int i = start, j = 0;
+        try {
+            while (i < end)
+                v.aset(j++, AREF(i++));
+            return v;
+        }
+        catch (ArrayIndexOutOfBoundsException e) {
+            return error(new TypeError("Array index out of bounds: " + i + "."));
+        }
+    }
+
+    @Override
+    public void fill(LispObject obj)
+    {
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 255) {
+            type_error(obj, UNSIGNED_BYTE_8);
+            // Not reached.
+            return;
+        }
+        for (int i = capacity; i-- > 0;)
+            elements[i] = (byte) n;
+    }
+
+    @Override
+    public void shrink(int n)
+    {
+        if (elements != null) {
+            if (n < elements.length) {
+                byte[] newArray = new byte[n];
+                System.arraycopy(elements, 0, newArray, 0, n);
+                elements = newArray;
+                capacity = n;
+                return;
+            }
+            if (n == elements.length)
+                return;
+        }
+        error(new LispError());
+    }
+
+    @Override
+    public LispObject reverse()
+    {
+        int length = length();
+        BasicVector_ByteBuffer result = new BasicVector_ByteBuffer(length);
+        int i, j;
+        for (i = 0, j = length - 1; i < length; i++, j--)
+            result.aset(i, AREF(j));
+        return result;
+    }
+
+    @Override
+    public LispObject nreverse()
+    {
+        if (elements != null) {
+            int i = 0;
+            int j = length() - 1;
+            while (i < j) {
+                byte temp = elements[i];
+                elements[i] = elements[j];
+                elements[j] = temp;
+                ++i;
+                --j;
+            }
+        } else {
+            // Displaced array.
+            int length = length();
+            byte[] data = new byte[length];
+            int i, j;
+            for (i = 0, j = length - 1; i < length; i++, j--)
+                data[i] = coerceLispObjectToJavaByte(AREF(j));
+            elements = data;
+            capacity = length;
+            array = null;
+            displacement = 0;
+            isDisplaced = false;
+            fillPointer = -1;
+        }
+        return this;
+    }
+
+    @Override
+    public void vectorPushExtend(LispObject element)
+    {
+        if (fillPointer < 0)
+            noFillPointer();
+        if (fillPointer >= capacity) {
+            // Need to extend vector.
+            ensureCapacity(capacity * 2 + 1);
+        }
+        aset(fillPointer, element);
+        ++fillPointer;
+    }
+
+    @Override
+    public LispObject VECTOR_PUSH_EXTEND(LispObject element)
+
+    {
+        vectorPushExtend(element);
+        return Fixnum.getInstance(fillPointer - 1);
+    }
+
+    @Override
+    public LispObject VECTOR_PUSH_EXTEND(LispObject element, LispObject extension)
+
+    {
+        int ext = Fixnum.getValue(extension);
+        if (fillPointer < 0)
+            noFillPointer();
+        if (fillPointer >= capacity) {
+            // Need to extend vector.
+            ext = Math.max(ext, capacity + 1);
+            ensureCapacity(capacity + ext);
+        }
+        aset(fillPointer, element);
+        return Fixnum.getInstance(fillPointer++);
+    }
+
+    private final void ensureCapacity(int minCapacity)
+    {
+        if (elements != null) {
+            if (capacity < minCapacity) {
+                byte[] newArray = new byte[minCapacity];
+                System.arraycopy(elements, 0, newArray, 0, capacity);
+                elements = newArray;
+                capacity = minCapacity;
+            }
+        } else {
+            // Displaced array.
+            Debug.assertTrue(array != null);
+            if (capacity < minCapacity ||
+                array.getTotalSize() - displacement < minCapacity)
+            {
+                // Copy array.
+                elements = new byte[minCapacity];
+                final int limit =
+                    Math.min(capacity, array.getTotalSize() - displacement);
+                for (int i = 0; i < limit; i++)
+                    elements[i] = coerceLispObjectToJavaByte(array.AREF(displacement + i));
+                capacity = minCapacity;
+                array = null;
+                displacement = 0;
+                isDisplaced = false;
+            }
+        }
+    }
+
+    @Override
+    public AbstractVector adjustArray(int newCapacity,
+                                       LispObject initialElement,
+                                       LispObject initialContents)
+
+    {
+        if (initialContents != null) {
+            // "If INITIAL-CONTENTS is supplied, it is treated as for MAKE-
+            // ARRAY. In this case none of the original contents of array
+            // appears in the resulting array."
+            byte[] newElements = new byte[newCapacity];
+            if (initialContents.listp()) {
+                LispObject list = initialContents;
+                for (int i = 0; i < newCapacity; i++) {
+                    newElements[i] = coerceLispObjectToJavaByte(list.car());
+                    list = list.cdr();
+                }
+            } else if (initialContents.vectorp()) {
+                for (int i = 0; i < newCapacity; i++)
+                    newElements[i] = coerceLispObjectToJavaByte(initialContents.elt(i));
+            } else
+                type_error(initialContents, Symbol.SEQUENCE);
+            elements = newElements;
+        } else {
+            if (elements == null) {
+                // Displaced array. Copy existing elements.
+                elements = new byte[newCapacity];
+                final int limit = Math.min(capacity, newCapacity);
+                for (int i = 0; i < limit; i++)
+                    elements[i] = coerceLispObjectToJavaByte(array.AREF(displacement + i));
+            } else if (capacity != newCapacity) {
+                byte[] newElements = new byte[newCapacity];
+                System.arraycopy(elements, 0, newElements, 0,
+                                 Math.min(capacity, newCapacity));
+                elements = newElements;
+            }
+            // Initialize new elements (if aapplicable).
+            if (initialElement != null) {
+                byte b = coerceLispObjectToJavaByte(initialElement);
+                for (int i = capacity; i < newCapacity; i++)
+                    elements[i] = b;
+            }
+        }
+        capacity = newCapacity;
+        array = null;
+        displacement = 0;
+        isDisplaced = false;
+        return this;
+    }
+
+    @Override
+    public AbstractVector adjustArray(int newCapacity,
+                                       AbstractArray displacedTo,
+                                       int displacement)
+
+    {
+        capacity = newCapacity;
+        array = displacedTo;
+        this.displacement = displacement;
+        elements = null;
+        isDisplaced = true;
+        return this;
+    }
+}

--- a/src/org/armedbear/lisp/Java.java
+++ b/src/org/armedbear/lisp/Java.java
@@ -1420,4 +1420,12 @@ public final class Java
             message = t.getClass().getName();
         return message;
     }
+
+  // FIXME: better handled as a Lisp symbol?  With a Java enum, the
+  // compiler probably has a better chance to optimize.
+  public static class Buffers {
+    public enum AllocationPolicy { PRIMITIVE_ARRAY, NIO; };
+    public static AllocationPolicy active = AllocationPolicy.NIO;
+  }
+  
 }

--- a/src/org/armedbear/lisp/SimpleArray_ByteBuffer.java
+++ b/src/org/armedbear/lisp/SimpleArray_ByteBuffer.java
@@ -1,0 +1,355 @@
+/*
+ * SimpleArray_ByteBuffer.java
+ *
+ * Copyright (C) 2020 easye
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+
+public final class SimpleArray_ByteBuffer extends AbstractArray
+{
+    private final int[] dimv;
+    private final int totalSize;
+    final byte[] data;
+
+    public SimpleArray_ByteBuffer(int[] dimv)
+    {
+        this.dimv = dimv;
+        totalSize = computeTotalSize(dimv);
+        data = new byte[totalSize];
+    }
+
+    public SimpleArray_ByteBuffer(int[] dimv, LispObject initialContents)
+
+    {
+        this.dimv = dimv;
+        final int rank = dimv.length;
+        LispObject rest = initialContents;
+        for (int i = 0; i < rank; i++) {
+            dimv[i] = rest.length();
+            rest = rest.elt(0);
+        }
+        totalSize = computeTotalSize(dimv);
+        data = new byte[totalSize];
+        setInitialContents(0, dimv, initialContents, 0);
+    }
+
+    public SimpleArray_ByteBuffer(int rank, LispObject initialContents)
+
+    {
+        if (rank < 2)
+            Debug.assertTrue(false);
+        dimv = new int[rank];
+        LispObject rest = initialContents;
+        for (int i = 0; i < rank; i++) {
+            dimv[i] = rest.length();
+            if (rest == NIL || rest.length() == 0)
+                break;
+            rest = rest.elt(0);
+        }
+        totalSize = computeTotalSize(dimv);
+        data = new byte[totalSize];
+        setInitialContents(0, dimv, initialContents, 0);
+    }
+
+    private int setInitialContents(int axis, int[] dims, LispObject contents,
+                                   int index)
+
+    {
+        if (dims.length == 0) {
+            try {
+                data[index] = coerceLispObjectToJavaByte(contents);
+            }
+            catch (ArrayIndexOutOfBoundsException e) {
+                error(new LispError("Bad initial contents for array."));
+                return -1;
+            }
+            ++index;
+        } else {
+            int dim = dims[0];
+            if (dim != contents.length()) {
+                error(new LispError("Bad initial contents for array."));
+                return -1;
+            }
+            int[] newDims = new int[dims.length-1];
+            for (int i = 1; i < dims.length; i++)
+                newDims[i-1] = dims[i];
+            if (contents.listp()) {
+                for (int i = contents.length();i-- > 0;) {
+                    LispObject content = contents.car();
+                    index =
+                        setInitialContents(axis + 1, newDims, content, index);
+                    contents = contents.cdr();
+                }
+            } else {
+                AbstractVector v = checkVector(contents);
+                final int length = v.length();
+                for (int i = 0; i < length; i++) {
+                    LispObject content = v.AREF(i);
+                    index =
+                        setInitialContents(axis + 1, newDims, content, index);
+                }
+            }
+        }
+        return index;
+    }
+
+    @Override
+    public LispObject typeOf()
+    {
+        return list(Symbol.SIMPLE_ARRAY, UNSIGNED_BYTE_8, getDimensions());
+    }
+
+    @Override
+    public LispObject classOf()
+    {
+        return BuiltInClass.SIMPLE_ARRAY;
+    }
+
+    @Override
+    public LispObject typep(LispObject typeSpecifier)
+    {
+        if (typeSpecifier == Symbol.SIMPLE_ARRAY)
+            return T;
+        if (typeSpecifier == BuiltInClass.SIMPLE_ARRAY)
+            return T;
+        return super.typep(typeSpecifier);
+    }
+
+    @Override
+    public int getRank()
+    {
+        return dimv.length;
+    }
+
+    @Override
+    public LispObject getDimensions()
+    {
+        LispObject result = NIL;
+        for (int i = dimv.length; i-- > 0;)
+            result = new Cons(Fixnum.getInstance(dimv[i]), result);
+        return result;
+    }
+
+    @Override
+    public int getDimension(int n)
+    {
+        try {
+            return dimv[n];
+        }
+        catch (ArrayIndexOutOfBoundsException e) {
+            error(new TypeError("Bad array dimension " + n + "."));
+            return -1;
+        }
+    }
+
+    @Override
+    public LispObject getElementType()
+    {
+        return UNSIGNED_BYTE_8;
+    }
+
+    @Override
+    public int getTotalSize()
+    {
+        return totalSize;
+    }
+
+    @Override
+    public boolean isAdjustable()
+    {
+        return false;
+    }
+
+    @Override
+    public LispObject AREF(int index)
+    {
+        try {
+            return coerceJavaByteToLispObject(data[index]);
+        }
+        catch (ArrayIndexOutOfBoundsException e) {
+            return error(new TypeError("Bad row major index " + index + "."));
+        }
+    }
+
+    @Override
+    public void aset(int index, LispObject newValue)
+    {
+        try {
+            data[index] = coerceLispObjectToJavaByte(newValue);
+        }
+        catch (ArrayIndexOutOfBoundsException e) {
+            error(new TypeError("Bad row major index " + index + "."));
+        }
+    }
+
+    @Override
+    public int getRowMajorIndex(int[] subscripts)
+    {
+        final int rank = dimv.length;
+        if (rank != subscripts.length) {
+            StringBuffer sb = new StringBuffer("Wrong number of subscripts (");
+            sb.append(subscripts.length);
+            sb.append(") for array of rank ");
+            sb.append(rank);
+            sb.append('.');
+            program_error(sb.toString());
+        }
+        int sum = 0;
+        int size = 1;
+        for (int i = rank; i-- > 0;) {
+            final int dim = dimv[i];
+            final int lastSize = size;
+            size *= dim;
+            int n = subscripts[i];
+            if (n < 0 || n >= dim) {
+                StringBuffer sb = new StringBuffer("Invalid index ");
+                sb.append(n);
+                sb.append(" for array ");
+                sb.append(this);
+                sb.append('.');
+                program_error(sb.toString());
+            }
+            sum += n * lastSize;
+        }
+        return sum;
+    }
+
+    @Override
+    public LispObject get(int[] subscripts)
+    {
+        try {
+            return coerceJavaByteToLispObject(data[getRowMajorIndex(subscripts)]);
+        }
+        catch (ArrayIndexOutOfBoundsException e) {
+            return error(new TypeError("Bad row major index " +
+                                        getRowMajorIndex(subscripts) + "."));
+        }
+    }
+
+    @Override
+    public void set(int[] subscripts, LispObject newValue)
+
+    {
+        try {
+            data[getRowMajorIndex(subscripts)] = coerceLispObjectToJavaByte(newValue);
+        }
+        catch (ArrayIndexOutOfBoundsException e) {
+            error(new TypeError("Bad row major index " +
+                                 getRowMajorIndex(subscripts) + "."));
+        }
+    }
+
+    @Override
+    public void fill(LispObject obj)
+    {
+        if (!(obj instanceof Fixnum)) {
+            type_error(obj, Symbol.FIXNUM);
+            // Not reached.
+            return;
+        }
+        int n = ((Fixnum) obj).value;
+        if (n < 0 || n > 255) {
+            type_error(obj, UNSIGNED_BYTE_8);
+            // Not reached.
+            return;
+        }
+        for (int i = totalSize; i-- > 0;)
+            data[i] = (byte) n;
+    }
+
+    @Override
+    public String printObject()
+    {
+        if (Symbol.PRINT_READABLY.symbolValue() != NIL) {
+            error(new PrintNotReadable(list(Keyword.OBJECT, this)));
+            // Not reached.
+            return null;
+        }
+        return printObject(dimv);
+    }
+
+    public AbstractArray adjustArray(int[] dimv, LispObject initialElement,
+                                     LispObject initialContents)
+
+    {
+        if (initialContents != null)
+            return new SimpleArray_ByteBuffer(dimv, initialContents);
+        for (int i = 0; i < dimv.length; i++) {
+            if (dimv[i] != this.dimv[i]) {
+                SimpleArray_ByteBuffer newArray =
+                    new SimpleArray_ByteBuffer(dimv);
+                if (initialElement != null)
+                    newArray.fill(initialElement);
+                copyArray(this, newArray);
+                return newArray;
+            }
+        }
+        // New dimensions are identical to old dimensions.
+        return this;
+    }
+
+    // Copy a1 to a2 for index tuples that are valid for both arrays.
+    static void copyArray(AbstractArray a1, AbstractArray a2)
+
+    {
+        Debug.assertTrue(a1.getRank() == a2.getRank());
+        int[] subscripts = new int[a1.getRank()];
+        int axis = 0;
+        copySubArray(a1, a2, subscripts, axis);
+    }
+
+    private static void copySubArray(AbstractArray a1, AbstractArray a2,
+                                     int[] subscripts, int axis)
+
+    {
+        if (axis < subscripts.length) {
+            final int limit =
+                Math.min(a1.getDimension(axis), a2.getDimension(axis));
+            for (int i = 0; i < limit; i++) {
+                subscripts[axis] = i;
+                copySubArray(a1, a2, subscripts, axis + 1);
+            }
+        } else {
+            int i1 = a1.getRowMajorIndex(subscripts);
+            int i2 = a2.getRowMajorIndex(subscripts);
+            a2.aset(i2, a1.AREF(i1));
+        }
+    }
+
+    public AbstractArray adjustArray(int[] dimv, AbstractArray displacedTo,
+                                     int displacement)
+    {
+        return new ComplexArray(dimv, displacedTo, displacement);
+    }
+}

--- a/src/org/armedbear/lisp/Symbol.java
+++ b/src/org/armedbear/lisp/Symbol.java
@@ -2919,6 +2919,8 @@ public class Symbol extends LispObject implements java.io.Serializable
   // End of CL symbols.
 
   // Extensions.
+  public static final Symbol MAKE_BYTEBUFFER_BYTE_VECTOR =
+    PACKAGE_EXT.addExternalSymbol("MAKE-BYTEBUFFER-BYTE-VECTOR");
   public static final Symbol MOST_POSITIVE_JAVA_LONG =
     PACKAGE_EXT.addExternalSymbol("MOST-POSITIVE-JAVA-LONG");
   public static final Symbol MOST_NEGATIVE_JAVA_LONG=

--- a/src/org/armedbear/lisp/buffers.lisp
+++ b/src/org/armedbear/lisp/buffers.lisp
@@ -1,0 +1,22 @@
+(in-package :ext)
+
+(defvar *buffer-allocation* :primitive-array
+  "The current buffer allocation strategy.")
+
+(defun choose-buffer-strategy (&key (new-default :nio new-default-p))
+  "Return current choices for buffer allocation strategy that can then be chosen as a :new-default strategy
+
+Not currently advisable to call in the middle of a runtime. "
+  (if new-default-p
+      (setf *buffer-allocation*  new-default)
+      '((:nio
+         . (BasicVector_ByteBuffer BasicVector_IntBuffer BasicVector_LongBuffer))
+        (:primitive-array
+         . '(BasicVector_UnsignedByte8 BasicVector_UnsignedByte16 BasicVector_UnsignedByte32)))))
+
+
+  
+
+  
+
+  

--- a/src/org/armedbear/lisp/compile-system.lisp
+++ b/src/org/armedbear/lisp/compile-system.lisp
@@ -329,6 +329,7 @@
                            "aver.lisp"
                            "bit-array-ops.lisp"
                            "boole.lisp"
+                           "buffers.lisp"
                            "butlast.lisp"
                            "byte-io.lisp"
                            "case.lisp"

--- a/src/org/armedbear/lisp/gc.java
+++ b/src/org/armedbear/lisp/gc.java
@@ -69,4 +69,6 @@ public final class gc extends Primitive
     }
 
     private static final Primitive GC = new gc();
+
+  // Optionally insert BufferAllocation code in here ???
 }

--- a/src/org/armedbear/lisp/make_array.java
+++ b/src/org/armedbear/lisp/make_array.java
@@ -33,6 +33,7 @@
 
 package org.armedbear.lisp;
 
+import org.armedbear.lisp.Java.Buffers.AllocationPolicy;
 import static org.armedbear.lisp.Lisp.*;
 
 // ### %make-array dimensions element-type initial-element initial-element-p
@@ -93,20 +94,26 @@ public final class make_array extends Primitive
           displacement = 0;
         if (rank == 1)
           {
-            AbstractVector v;
+            AbstractVector v = null; // FIXME needed to get the compiler not to warn
             LispObject arrayElementType = array.getElementType();
-            if (arrayElementType == Symbol.CHARACTER)
+            if (arrayElementType == Symbol.CHARACTER) {
               v = new ComplexString(dimv[0], array, displacement);
-            else if (arrayElementType == Symbol.BIT)
+            } else if (arrayElementType == Symbol.BIT) {
               v = new ComplexBitVector(dimv[0], array, displacement);
-            else if (arrayElementType.equal(UNSIGNED_BYTE_8))
-              v = new ComplexVector_UnsignedByte8(dimv[0], array, displacement);
-            else if (arrayElementType.equal(UNSIGNED_BYTE_32))
+            } else if (arrayElementType.equal(UNSIGNED_BYTE_8)) {
+              if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+                v = new ComplexVector_ByteBuffer(dimv[0], array, displacement);
+              } else if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+                v = new ComplexVector_UnsignedByte8(dimv[0], array, displacement);
+              }
+            } else if (arrayElementType.equal(UNSIGNED_BYTE_32)) {
               v = new ComplexVector_UnsignedByte32(dimv[0], array, displacement);
-            else
+            } else {
               v = new ComplexVector(dimv[0], array, displacement);
-            if (fillPointer != NIL)
+            }
+            if (fillPointer != NIL) {
               v.setFillPointer(fillPointer);
+            }
             return v;
           }
         return new ComplexArray(dimv, array, displacement);
@@ -160,10 +167,20 @@ public final class make_array extends Primitive
           }
         else if (upgradedType.equal(UNSIGNED_BYTE_8))
           {
-            if (fillPointer != NIL || adjustable != NIL)
-              v = new ComplexVector_UnsignedByte8(size);
-            else
-              v = new BasicVector_UnsignedByte8(size);
+            if (fillPointer != NIL || adjustable != NIL) {
+              if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+                v = new ComplexVector_ByteBuffer(size);
+              } else { //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+                v = new ComplexVector_UnsignedByte8(size);
+              }
+            } else {
+              if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+                v = new BasicVector_ByteBuffer(size);
+              } else { //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+                v = new BasicVector_UnsignedByte8(size);
+              }
+            }
+
             defaultInitialElement = Fixnum.ZERO;
           }
         else if (upgradedType.equal(UNSIGNED_BYTE_16) &&

--- a/t/static-vectors.lisp
+++ b/t/static-vectors.lisp
@@ -1,0 +1,15 @@
+(in-package :cl-user)
+
+(require :abcl-contrib)
+(require :jss)
+
+(prove:plan 1)
+(prove:ok
+ (let* ((bytebuffer
+          (#"allocate" 'nio.ByteBuffer 21))
+        (vector
+          (ext:make-bytebuffer-byte-vector bytebuffer)))
+   (and
+    vector
+    (typep vector '(SIMPLE-ARRAY (UNSIGNED-BYTE 8) (21))))))
+(prove:finalize)


### PR DESCRIPTION
INCOMPLETE work on the road to using java.nio.Buffer objects to represent our arrays

Tests for STATIC-VECTORS, CFFI, CL+SSL work with this branch.

Added Java-base enumeration for switching the underlying buffer allocation strategy.

Much more plausible sequence of patches.

supersedes <https://github.com/armedbear/abcl/pull/191>