### PR TITLE
The upper limit for 32 bit values is simply wrong.

### DIFF
--- a/src/org/armedbear/lisp/Bignum.java
+++ b/src/org/armedbear/lisp/Bignum.java
@@ -153,7 +153,7 @@ public final class Bignum extends LispInteger
           {
             if (minusp())
               return NIL;
-            return isLessThan(UNSIGNED_BYTE_32_MAX_VALUE) ? T : NIL;
+            return isLessThanOrEqualTo(UNSIGNED_BYTE_32_MAX_VALUE) ? T : NIL;
           }
       }
     return super.typep(type);

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -1546,8 +1546,8 @@ public final class Lisp
   public static final LispObject UNSIGNED_BYTE_32 =
     list(Symbol.UNSIGNED_BYTE, Fixnum.constants[32]);
 
-  public static final LispObject UNSIGNED_BYTE_32_MAX_VALUE =
-    Bignum.getInstance(4294967296L);
+  public static final LispObject UNSIGNED_BYTE_32_MAX_VALUE
+    = Bignum.getInstance(4294967295L);
 
   public static final LispObject getUpgradedArrayElementType(LispObject type)
 
@@ -1601,9 +1601,9 @@ public final class Lisp
                   }
                 if (lower.isGreaterThanOrEqualTo(Fixnum.ZERO))
                   {
-                    if (lower.isLessThan(UNSIGNED_BYTE_32_MAX_VALUE))
+                    if (lower.isLessThanOrEqualTo(UNSIGNED_BYTE_32_MAX_VALUE))
                       {
-                        if (upper.isLessThan(UNSIGNED_BYTE_32_MAX_VALUE))
+                        if (upper.isLessThanOrEqualTo(UNSIGNED_BYTE_32_MAX_VALUE))
                           return UNSIGNED_BYTE_32;
                       }
                   }
@@ -1630,7 +1630,7 @@ public final class Lisp
               {
                 if (obj.isGreaterThanOrEqualTo(Fixnum.ZERO))
                   {
-                    if (obj.isLessThan(UNSIGNED_BYTE_32_MAX_VALUE))
+                    if (obj.isLessThanOrEqualTo(UNSIGNED_BYTE_32_MAX_VALUE))
                       return UNSIGNED_BYTE_32;
                   }
               }

--- a/t/byte-vectors.lisp
+++ b/t/byte-vectors.lisp
@@ -1,0 +1,33 @@
+(in-package :cl-user)
+
+
+(let ((element-bits '(8 16 32))
+      (length 16))
+  (prove:plan (* (length element-bits) 3))
+  (dolist (bits element-bits)
+    (let* ((type
+             `(unsigned-byte ,bits))
+           (exclusive-max
+             (expt 2 bits))
+           (max
+             (1- exclusive-max)))
+      (prove:ok
+       (let ((array (make-array length :element-type type :initial-element max)))
+         (typep (aref array 0) type))
+       (format nil "Able to make (SIMPLE-ARRAY ~a (~a)) filled with maximum value ~a"
+               type length max))
+      (prove:is-condition 
+       (let ((array (make-array length :element-type type :initial-element -1)))
+         (typep (aref array 0) type))
+       'type-error
+       (format nil "Making a (SIMPLE-ARRAY ~a (~a)) filled with -1 signals a type-error" 
+               type length))
+      (prove:is-condition 
+       (let ((array (make-array 16 :element-type type :initial-element exclusive-max)))
+         (typep (aref array 0) type))
+       'type-error
+       (format nil "Making a (SIMPLE-ARRAY ~a (~a)) filled with ~a signals a type-error" 
+               type length exclusive-max)))))
+
+(prove:finalize)
+


### PR DESCRIPTION
This should signal an error:

    (make-array 16 :element-type '(unsigned-byte 32) :initial-element  (expt 2 32))