### PR TITLE
ci: test CL+SSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
   - ${ABCL_ROOT}/abcl --eval '(require :asdf)' --eval '(require :abcl-contrib)' --eval '(asdf:load-system :quicklisp-abcl :force t)' --eval '(progn (setf ql-util::*do-not-prompt* t)(ql:add-to-init-file))' --eval '(ext:quit)'
 
   # Install the patched version of cl+ssl
-  - bash -x ${ABCL_ROOT}/ci/install-patched-cl+ssl.bash
+  - bash -x ${ABCL_ROOT}/ci/install-cl+ssl.bash
 
   # Install the ANSI-TEST suite
   - bash -x ${ABCL_ROOT}/ci/sync-ansi-test.bash

--- a/ci/install-cl+ssl.bash
+++ b/ci/install-cl+ssl.bash
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
-#
-# Until <https://github.com/cl-plus-ssl/cl-plus-ssl/pull/97> is
-# resolved, we need to use our patched version.
 
-root="${HOME}/quicklisp/local-projects"
 dir="cl-plus-ssl"
-tag="easye/stream-fd"
+uri="https://github.com/armedbear/${dir}"
+root="${HOME}/quicklisp/local-projects"
+tag="easye/openjdk14"
 
 mkdir -p ${root}
 pushd ${root}
 
 if [[ ! -d ${dir} ]]; then 
-    git clone https://github.com/armedbear/cl-plus-ssl ${dir}
+    git clone ${uri} ${dir}
 fi
 
 pushd ${dir}

--- a/ci/test-cl+ssl.lisp
+++ b/ci/test-cl+ssl.lisp
@@ -1,5 +1,7 @@
-(require :asdf)
-(require :abcl-contrib)
+#+abcl
+(progn 
+  (require :asdf)
+  (require :abcl-contrib))
 
 (ql:quickload :cl+ssl)
 (ql:quickload :cl+ssl.test)

--- a/patches/cl-plus-ssl-abcl.patch
+++ b/patches/cl-plus-ssl-abcl.patch
@@ -1,49 +1,40 @@
 # HG changeset patch
-# Parent  97a70ad89e9799a7cfb1c794095bf372522c8f81
-Implement stream-fd for ABCL
+# Parent  e997fa4665748951d229e8622102c67fca5f22f9
+abcl: fix getting the underlying stream fd for openjdk14
 
-This fixes for broken BIO on OpenSSL 1.1.1 ff. which causes ABCL to
-segfault.
-
-This hack allows ABCL to get at the underlying file descriptor using
-undocumented portions of the JVM that are not guaranteed to be stable.
-
-Tested under openjdk8 and openjdk11.
-
-c.f. <https://github.com/cl-plus-ssl/cl-plus-ssl/issues/72>,
-<https://abcl.org/trac/ticket/464>.
-
-diff -r 97a70ad89e97 src/streams.lisp
---- a/src/streams.lisp	Sat Mar 14 15:07:32 2020 +0300
-+++ b/src/streams.lisp	Fri May 15 21:34:28 2020 +0200
-@@ -208,7 +208,7 @@
-   (when unwrap-stream-p
-     (let ((fd (stream-fd socket)))
-       (when fd
--  (setf socket fd))))
-+        (setf socket fd))))
-   (etypecase socket
-     (integer
-      (install-nonblock-flag socket)
-@@ -486,3 +486,21 @@
- #+lispworks
- (defmethod stream-fd ((stream comm::socket-stream))
-   (comm:socket-stream-socket stream))
-+
-+#+abcl
-+(progn
-+  (require :abcl-contrib)
-+  (require :jss)
-+
-+  (defmethod stream-fd ((stream system::socket-stream))
-+    ;;; Don't ask...
-+    (let* ((s0
-+             (#"getWrappedInputStream" (two-way-stream-input-stream stream)))
-+           (s1
-+             (jss:get-java-field s0 "in" t))
-+           (s2
-+             (jss:get-java-field s1 "ch" t)))
-+      (jss:get-java-field s2 "fdVal" t))))
-+    
-+
-+
+diff -r e997fa466574 -r 58f46634d03d src/streams.lisp
+--- a/src/streams.lisp	Wed May 27 17:20:38 2020 +0300
++++ b/src/streams.lisp	Sat May 30 08:30:17 2020 +0200
+@@ -493,18 +493,25 @@
+   (require :jss)
+ 
+   ;;; N.b. Getting the file descriptor from a socket is not supported
+-  ;;; by any published JVM API, but the following private data
+-  ;;; structures have been present from openjdk6 through openjdk14 so
+-  ;;; there's hope that this is somewhat unofficially official.
++  ;;; by any published JVM API, so every JVM implementation may behave
++  ;;; somewhat differently.  By using the ability of
++  ;;; jss:get-java-fields to access private fields, it is usually
++  ;;; possible to "find" an access path to read the underlying integer
++  ;;; value of the file decriptor, which is all we need to pass to
++  ;;; SSL.
+   (defmethod stream-fd ((stream system::socket-stream))
++    (setf *debug* stream)
+     (flet ((get-java-fields (object fields) ;; Thanks to Cyrus Harmon
+              (reduce (lambda (x y)
+                        (jss:get-java-field x y t))
+                      fields
+-                     :initial-value object)))
++                     :initial-value object))
++           (jvm-version ()
++             (parse-integer (java:jstatic "getProperty" "java.lang.System"
++                                          "java.specification.version"))))
+       (ignore-errors
+        (get-java-fields (java:jcall "getWrappedInputStream"  ;; TODO: define this as a constant
+                                     (two-way-stream-input-stream stream))
+-                        '("in" "ch" "fdVal"))))))
+-
+-
++                        (if (< (jvm-version) 14)
++                            '("in" "ch" "fdVal")
++                            '("in" "this$0" "sc" "fd" "fd")))))))


### PR DESCRIPTION
Update version of ci tested CL+SSL to use patch for openjdk14, and
update the local version of the patch under <file:patches/>.