### PR TITLE
ci: run the IRONCLAD tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,8 @@ script:
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cl+ssl.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/abcl-prove.lisp
+  # IRONCLAD takes a long time to test, so we place it near the end
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-ironclad.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-ansi.lisp
   
   # This would build a release, which needs an installed TeX which is judged too

--- a/ci/test-ironclad.lisp
+++ b/ci/test-ironclad.lisp
@@ -1,0 +1,5 @@
+(ql:quickload :ironclad)
+(ql:quickload :ironclad/tests)
+
+(asdf:test-system :ironclad)
+


### PR DESCRIPTION
This shakes down our vector implementation; showcases how slow
unoptimized-for-abcl IRONCLAD code can be.