### PR TITLE
Further fixes for floating point values

### DIFF
--- a/src/org/armedbear/lisp/FloatFunctions.java
+++ b/src/org/armedbear/lisp/FloatFunctions.java
@@ -95,20 +95,14 @@ public final class FloatFunctions
     private static final Primitive INTEGER_DECODE_FLOAT =
         new Primitive("integer-decode-float", "float")
     {
-//         (defun sane-integer-decode-float (float)
-//           (multiple-value-bind (mantissa exp sign)
-//               (integer-decode-float float)
-//             (let ((fixup (- (integer-length mantissa) (float-precision float))))
-//                   (values (ash mantissa (- fixup))
-//                           (+ exp fixup)
-//                           sign))))
-
-        // See also: http://paste.lisp.org/display/10847
-
         @Override
         public LispObject execute(LispObject arg)
         {
             if (arg instanceof SingleFloat) {
+                if (arg.equals(SingleFloat.SINGLE_FLOAT_POSITIVE_INFINITY)
+                    || arg.equals(SingleFloat.SINGLE_FLOAT_NEGATIVE_INFINITY)) {
+                    return error(new LispError("Cannot decode infinity."));
+                }
                 int bits =
                     Float.floatToRawIntBits(((SingleFloat)arg).value);
                 int s = ((bits >> 31) == 0) ? 1 : -1;
@@ -126,6 +120,11 @@ public final class FloatFunctions
                                                             sign);
             }
             if (arg instanceof DoubleFloat) {
+                if (arg.equals(DoubleFloat.DOUBLE_FLOAT_POSITIVE_INFINITY)
+                    || arg.equals(DoubleFloat.DOUBLE_FLOAT_NEGATIVE_INFINITY)) {
+                    return error(new LispError("Cannot decode infinity."));
+                }
+
                 long bits =
                     Double.doubleToRawLongBits((double)((DoubleFloat)arg).value);
                 int s = ((bits >> 63) == 0) ? 1 : -1;

--- a/src/org/armedbear/lisp/Ratio.java
+++ b/src/org/armedbear/lisp/Ratio.java
@@ -36,6 +36,9 @@ package org.armedbear.lisp;
 import static org.armedbear.lisp.Lisp.*;
 
 import java.math.BigInteger;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 
 public final class Ratio extends LispObject
 {
@@ -192,8 +195,17 @@ public final class Ratio extends LispObject
         final int numLen = num.bitLength();
         final int denLen = den.bitLength();
         int length = Math.min(numLen, denLen);
-        if (length <= 1)
-            return result;
+        if (length <= 1) {  
+          // A precision of 512 is overkill for DOUBLE-FLOAT types
+          // based on java.lang.Double  TODO: optimize for space/time 
+          final MathContext mathContext = new MathContext(512, RoundingMode.HALF_EVEN);
+          BigDecimal p = new BigDecimal(numerator, mathContext);
+          BigDecimal q = new BigDecimal(denominator, mathContext);
+          BigDecimal r = p.divide(q, mathContext);
+          result = r.doubleValue();
+          return result; 
+        }
+
         BigInteger n = num;
         BigInteger d = den;
         final int digits = 54;

--- a/src/org/armedbear/lisp/numbers.lisp
+++ b/src/org/armedbear/lisp/numbers.lisp
@@ -163,11 +163,20 @@
              :format-control "~S is neither SINGLE-FLOAT nor DOUBLE-FLOAT."
              :format-arguments (list float)))))
 
+;;; From <http://paste.lisp.org/display/10847>.  Thanks Xophe!
+(defun sane-integer-decode-float (float)
+  (multiple-value-bind (mantissa exp sign)
+      (integer-decode-float float)
+    (let ((fixup (- (integer-length mantissa) (float-precision float))))
+      (values (ash mantissa (- fixup))
+              (+ exp fixup)
+              sign))))
+
 (defun decode-float-single (float)
   ;; TODO memoize
   (let ((float-precision-single (float-precision 1f0)))
     (multiple-value-bind (significand exponent sign)
-        (integer-decode-float float)
+        (sane-integer-decode-float float)
       (values (coerce (/ significand (expt 2 float-precision-single)) 'single-float)
               (+ exponent float-precision-single)
               (if (minusp sign) -1f0 1f0)))))
@@ -177,7 +186,7 @@
   ;; TODO memoize
   (let ((float-precision-double (float-precision 1d0)))
     (multiple-value-bind (significand exponent sign)
-        (integer-decode-float float)
+        (sane-integer-decode-float float)
       (values (coerce (/ significand (expt 2 float-precision-double)) 'double-float)
               (+ exponent float-precision-double)
               (if (minusp sign) -1d0 1d0)))))

--- a/t/decode-float.lisp
+++ b/t/decode-float.lisp
@@ -43,11 +43,37 @@
     (let ((result (decode-float float)))
       (prove:is-type result 'double-float))))
 
-;;; additional things along the way…
+;; From the REPL, I don't get a signaled condition, but these tests succeed…
+(let ((infinities '(single-float-positive-infinity
+                    single-float-negative-infinity
+                    double-float-positive-infinity
+                    double-float-negative-infinity)))
+  (prove:plan (length infinities))
+  (dolist (infinity infinities)
+    (prove:is-error
+     (decode-float infinity)
+     'error
+     (format nil "Attempting to DECODE-FLOAT ~a should signal error" infinity))))
 
-#|
-Should fail, as you shouldn't be able to 
-(decode-float single-float-positive-infinity)
-|# 
+
+(let ((floats `(1f0
+                1d0
+                1f6
+                1d6
+                1f-6
+                1d-6
+                ,least-positive-normalized-single-float
+                ,least-positive-single-float
+                ,least-positive-normalized-double-float
+                ,least-positive-double-float)))
+  (prove:plan (length floats))
+  (dolist (float floats)
+    (multiple-value-bind (significand exponent sign)
+        (integer-decode-float float)
+      (prove:is
+       (coerce (* significand (expt 2 exponent)) (type-of float))
+       float
+       (format nil "INTEGER-DECODE-FLOAT roundtrips for ~s" float)))))
+
 
 (prove:finalize)


### PR DESCRIPTION
DECODE-FLOAT now returns a significand in the interval between 1/2
(inclusive) and 1 (exclusive) as implied by ANSI.

Coercion of values smaller than 2^-1023 to double floats no longer
returns zero.

Completed addressing the issues raised by Robert Dodier in
<https://github.com/armedbear/abcl/issues/93>,
<https://github.com/armedbear/abcl/issues/94>, and
<https://github.com/armedbear/abcl/issues/95>.