### PR TITLE
ci: Use Jeannie to test <urn:abcl.org/**/*> namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ install:
   # Install the patched version of static-vectors
   - bash -x ${ABCL_ROOT}/ci/install-static-vectors.bash
 
+  # Install Jeannie for testing
+  - bash -x ${ABCL_ROOT}/ci/install-jeannie.bash
+
 # TODO: figure out how to add abcl to our path
 
 script:

--- a/ci/install-jeannie.bash
+++ b/ci/install-jeannie.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+dir="jeannie"
+uri="https://github.com/easye/${dir}"
+root="${HOME}/quicklisp/local-projects"
+tag="master"
+
+mkdir -p ${root}
+pushd ${root}
+
+if [[ ! -d ${dir} ]]; then 
+    git clone ${uri} ${dir}
+fi
+
+pushd ${dir}
+if [[ -d .hg ]]; then
+    hg pull
+    hg update -r $tag
+    hg sum -v
+else
+    git pull
+    git checkout $tag
+    git show-ref
+    git rev-parse
+fi
+popd
+
+popd

--- a/t/rdf.lisp
+++ b/t/rdf.lisp
@@ -1,0 +1,19 @@
+(require :abcl-contrib)
+(require :quicklisp-abcl)
+(require :abcl-asdf)
+
+(time
+  (progn
+    (ql:quickload :jeannie/test)
+    (asdf:load-system :jeannie)))
+
+(prove:plan 1)
+
+(time 
+ (let ((p (asdf:system-relative-pathname :abcl "abcl.rdf")))
+   (prove:ok
+    (jeannie:read-rdf p :format :n3))
+   (format nil "Reading RDF from <file:~a>." (namestring p))))
+
+(prove:finalize)
+


### PR DESCRIPTION
ABCL-PROVE now executes the new <file:t/rdf.lisp> test.

supersedes #229 