### PR TITLE
ci: add TIME form for test invocations

### DIFF
--- a/ci/abcl-prove.lisp
+++ b/ci/abcl-prove.lisp
@@ -1,6 +1,7 @@
 (ql:quickload :abcl-prove)
 
 (asdf:load-system :abcl-prove)
-(asdf:test-system :abcl-prove/t)
+(time 
+ (asdf:test-system :abcl-prove/t))
 
 ;;; also works as :abcl/t under some definitions

--- a/ci/test-abcl-introspect.lisp
+++ b/ci/test-abcl-introspect.lisp
@@ -1,2 +1,4 @@
 (ql:quickload :abcl-introspect-test)
-(asdf:test-system :abcl-introspect)
+(time 
+ (asdf:test-system :abcl-introspect))
+

--- a/ci/test-abcl.lisp
+++ b/ci/test-abcl.lisp
@@ -1,6 +1,5 @@
 (require :asdf)
 
-(ql:quickload :prove) ;; FIXME shouldn't need this
 (asdf:load-system :abcl/test/lisp)
 
 (asdf:test-system :abcl/test/lisp)

--- a/ci/test-ansi.lisp
+++ b/ci/test-ansi.lisp
@@ -1,8 +1,7 @@
 (require :asdf)
 
-(ql:quickload :prove) ;; FIXME
-(ql:quickload :abcl)
-
 (asdf:load-system :abcl)
 
-(asdf:test-system :abcl/test/ansi/compiled)
+(time 
+ (asdf:test-system :abcl/test/ansi/compiled))
+

--- a/ci/test-cffi.lisp
+++ b/ci/test-cffi.lisp
@@ -1,9 +1,11 @@
 (require :asdf)
 (require :abcl-contrib)
 
-(ql:quickload :cffi)
-(ql:quickload :cffi-tests)
+(ql:quickload
+ '(:cffi :cffi-tests))
 
-(asdf:test-system :cffi)
+(time 
+ (asdf:test-system :cffi))
+
 
 

--- a/ci/test-cl+ssl.lisp
+++ b/ci/test-cl+ssl.lisp
@@ -3,8 +3,9 @@
   (require :asdf)
   (require :abcl-contrib))
 
-(ql:quickload :cl+ssl)
-(ql:quickload :cl+ssl.test)
+(ql:quickload
+ '(:cl+ssl :cl+ssl.test))
 
-(fiveam:run-all-tests)
+(time
+ (fiveam:run-all-tests))
 

--- a/ci/test-ironclad.lisp
+++ b/ci/test-ironclad.lisp
@@ -1,5 +1,6 @@
-(ql:quickload :ironclad)
-(ql:quickload :ironclad/tests)
+(ql:quickload
+ '(:ironclad :ironclad/tests))
 
-(asdf:test-system :ironclad)
+(time 
+ (asdf:test-system :ironclad))
 

--- a/ci/test-static-vectors.lisp
+++ b/ci/test-static-vectors.lisp
@@ -1,7 +1,9 @@
 (require :asdf)
 (require :abcl-contrib)
 
-(ql:quickload :static-vectors)
-(ql:quickload :static-vectors/test)
+(ql:quickload
+ '(:static-vectors :static-vectors/test))
 
-(asdf:test-system :static-vectors)
+(time 
+ (asdf:test-system :static-vectors))
+


### PR DESCRIPTION
Fold QL:QUICKLOAD operations into lists (something I learned by
"reading" Twitter).

Housecleaning by removing unneeded references to testing packages to
load the ABCL ASDF definition.