### PR TITLE
Revisions for the long neglected ABCL/TEST/LISP suite

### DIFF
--- a/abcl.asd
+++ b/abcl.asd
@@ -43,6 +43,7 @@
                          (:file "latin1-tests")
                          (:file "bugs" :depends-on 
                                 ("file-system-tests"))
+                         #+abcl
                          (:file "wild-pathnames"
                                 :depends-on ("file-system-tests"))
                          #+abcl 
@@ -51,7 +52,6 @@
                          (:file "zip")
                          #+abcl 
                          (:file "java")
-                         #+abcl
                          (:file "pathname-tests" :depends-on 
                                 ("utilities"))
                          #+abcl

--- a/test/lisp/abcl/clos-tests.lisp
+++ b/test/lisp/abcl/clos-tests.lisp
@@ -23,7 +23,6 @@
 (in-package #:abcl.test.lisp)
 
 
-
 ;; tests for D-M-C, long form, some taken from SBCL
 
 ;; D-M-C should return the name of the new method combination, nothing else.
@@ -245,11 +244,13 @@
 
 ;; From SBCL: method combination (long form) with arguments
 
+#-ccl ;; "The value (ABCL.TEST.LISP::EXTRA :EXTRA) is not of the expected type SYMBOL."
 (define-method-combination dmc-test.5 ()
   ((method-list *))
   (:arguments arg1 arg2 &aux (extra :extra))
   `(progn ,@(mapcar (lambda (method) `(call-method ,method)) method-list)))
 
+#-ccl ;; "The value (ABCL.TEST.LISP::EXTRA :EXTRA) is not of the expected type SYMBOL."
 (defgeneric dmc-test-mc.5 (p1 p2 s)
   (:method-combination dmc-test.5)
   (:method ((p1 number) (p2 t) s)
@@ -453,6 +454,7 @@
     (dmc-test-args-with-optional.1 T T)
   T)
 
+#-ccl ;; "The value (ABCL.TEST.LISP::A :DEFAULT) is not of the expected type SYMBOL."
 (define-method-combination dmc-test-args-with-optional.2 ()
   ((methods *))
   (:arguments &optional (a :default))
@@ -460,6 +462,7 @@
                            methods)
                  ,a)))
 
+#-ccl ;; "The value (ABCL.TEST.LISP::A :DEFAULT) is not of the expected type SYMBOL."
 (defgeneric dmc-test-args-with-optional.2 (x &optional b)
   (:method-combination dmc-test-args-with-optional.2)
   (:method (x &optional b) (progn x b)))
@@ -474,6 +477,7 @@
     (dmc-test-args-with-optional.2 T T)
   T)
 
+#-ccl ;; The value (ABCL.TEST.LISP::A :DEFAULT) is not of the expected type SYMBOL.
 (define-method-combination dmc-test-args-with-optional.3 ()
   ((methods *))
   (:arguments &optional (a :default))
@@ -481,16 +485,18 @@
                            methods)
                  ,a)))
 
+#-ccl ;; The value (ABCL.TEST.LISP::A :DEFAULT) is not of the expected type SYMBOL.
 (defgeneric dmc-test-args-with-optional.3 (x)
   (:method-combination dmc-test-args-with-optional.3)
   (:method (x) (progn x)))
 
+#-ccl ;; The value (ABCL.TEST.LISP::A :DEFAULT) is not of the expected type SYMBOL.
 (deftest dmc-test-args-with-optional.3
     :documentation "TODO"
     (dmc-test-args-with-optional.3 T)
   nil)
 
-
+#-ccl ;; The value (ABCL.TEST.LISP::A :DEFAULT ABCL.TEST.LISP::SUP-P) is not of the expected type SYMBOL.
 (define-method-combination dmc-test-args-with-optional.4 ()
   ((methods ()))
   (:arguments &optional (a :default sup-p))
@@ -498,24 +504,29 @@
                     methods)
           (values ,a ,sup-p)))
 
+#-ccl
 (defgeneric dmc-test-args-with-optional.4a (x &optional b)
   (:method-combination dmc-test-args-with-optional.4)
   (:method (x &optional b) (progn x b)))
 
+#-ccl
 (deftest dmc-test-args-with-optional.4a
     (dmc-test-args-with-optional.4a T)
   :default
   nil)
 
+#-ccl
 (deftest dmc-test-args-with-optional.4b
     (dmc-test-args-with-optional.4a T T)
   T
   T)
 
+#-ccl
 (defgeneric dmc-test-args-with-optional.4c (x)
   (:method-combination dmc-test-args-with-optional.4)
   (:method (x) (progn x)))
 
+#-ccl
 (deftest dmc-test-args-with-optional.4c
     :documentation "TODO"
     (dmc-test-args-with-optional.4c T)

--- a/test/lisp/abcl/compiler-tests.lisp
+++ b/test/lisp/abcl/compiler-tests.lisp
@@ -22,8 +22,9 @@
 
 (in-package #:abcl.test.lisp)
 
-(defconstant most-positive-java-long 9223372036854775807)
-(defconstant most-negative-java-long -9223372036854775808)
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defvar most-positive-java-long 9223372036854775807)
+  (defvar most-negative-java-long -9223372036854775808))
 
 #+abcl
 (assert (eql most-positive-java-long ext:most-positive-java-long))
@@ -104,7 +105,7 @@
   #.(+ most-positive-fixnum most-positive-fixnum))
 #+allegro (pushnew 'plus.3 *expected-failures*)
 
-#-clisp
+#+abcl
 (define-compiler-test plus.4
   (lambda (x y)
     (declare (type (integer #.most-negative-java-long #.most-positive-java-long) x y))

--- a/test/lisp/abcl/package-local-nicknames-tests.lisp
+++ b/test/lisp/abcl/package-local-nicknames-tests.lisp
@@ -19,6 +19,9 @@
 
 ;;; Most of these tests are adapted from the SBCL test suite.
 
+;;;; FIXME:  re-running these tests in the same process fails the second time due to interactions
+;;;          with the problems with DEFPACKAGE "only being run once"
+
 (in-package #:abcl.test.lisp)
 
 (defmacro with-tmp-packages (bindings &body body)

--- a/test/lisp/abcl/package.lisp
+++ b/test/lisp/abcl/package.lisp
@@ -1,6 +1,6 @@
 (defpackage #:abcl.test.lisp
   (:use #:cl #:abcl-rt)
-  (:nicknames "ABCL-TEST-LISP" "ABCL-TEST")
+  (:nicknames "ABCL-TEST-LISP" "ABCL-TEST" "ABCL/TEST/LISP")
   (:export 
    #:run 
    #:do-test 

--- a/test/lisp/abcl/pathname-tests.lisp
+++ b/test/lisp/abcl/pathname-tests.lisp
@@ -562,7 +562,7 @@
   t)
 
 ;; If the prefix isn't a defined logical host, it's not a logical pathname.
-#-(or cmu (and clisp windows))
+#-(or ccl cmu (and clisp windows))
 ;; CMUCL parses this as (:ABSOLUTE #<SEARCH-LIST foo>) "bar.baz" "42".
 ;; CLISP signals a parse error reading #p"foo:bar.baz.42".
 (deftest logical.1
@@ -1334,8 +1334,9 @@
 #+lispworks
 (pushnew 'sbcl.26 *expected-failures*)
 
-(setf (logical-pathname-translations "scratch")
-      '(("**;*.*.*" "/usr/local/doc/**/*")))
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (setf (logical-pathname-translations "scratch")
+        '(("**;*.*.*" "/usr/local/doc/**/*"))))
 
 ;; Trivial merge.
 (deftest sbcl.27

--- a/test/lisp/abcl/wild-pathnames.lisp
+++ b/test/lisp/abcl/wild-pathnames.lisp
@@ -50,12 +50,12 @@
   t)
 
 (deftest wild-pathnames.2
-    (equal 
-     (first (with-test-directories
-                (directory (make-pathname :directory (pathname-directory *temp-directory-root*)
-                                          :name :wild :type "ext"
-                                          :version :newest))))
-     (merge-pathnames *temp-directory-root* "foo.ext"))
+    (check-namestring
+     (namestring (first (with-test-directories
+                            (directory (make-pathname :directory (pathname-directory *temp-directory-root*)
+                                                      :name :wild :type "ext"
+                                                      :version :newest)))))
+     (namestring (merge-pathnames *temp-directory-root* "foo.ext")))
   t)
 
     


### PR DESCRIPTION
Restore loading under SBCL and CCL.

FIXME: package-local-nicknames-tests only runs once in the same
process, causing a mysterious failure on the second time.