### PR TITLE
Further (INCOMPLETE) work on byte vectors

### DIFF
--- a/src/org/armedbear/lisp/ComplexArray_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_IntBuffer.java
@@ -1,0 +1,312 @@
+/*
+ * ComplexArray_UnsignedByte32.java
+ *
+ * Copyright (C) 2020 @easye
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+public final class ComplexArray_IntBuffer
+  extends AbstractArray
+{
+  private final int[] dimv;
+  private int totalSize;
+
+  // For non-displaced arrays.
+  private IntBuffer data;
+  private boolean directAllocation;
+  
+  // For displaced arrays.
+  private AbstractArray array;
+  private int displacement;
+  
+  public ComplexArray_IntBuffer(int[] dimv) {
+    this(dimv, false);
+  }
+  
+  public ComplexArray_IntBuffer(int[] dimv, boolean directAllocation) {
+    this.dimv = dimv;
+    this.directAllocation = directAllocation;
+    totalSize = computeTotalSize(dimv);
+    if (directAllocation) {
+      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 4);
+      data = b.asIntBuffer();
+    } else {
+      data = IntBuffer.allocate(totalSize);
+    }
+  }
+
+  public ComplexArray_IntBuffer(int[] dimv, LispObject initialContents) {
+    this(dimv, initialContents, false);
+  }
+  
+  public ComplexArray_IntBuffer(int[] dimv, LispObject initialContents,
+                                     boolean directAllocation) {
+    this.dimv = dimv;
+    this.directAllocation = directAllocation;
+    final int rank = dimv.length;
+    LispObject rest = initialContents;
+    for (int i = 0; i < rank; i++) {
+      dimv[i] = rest.length();
+      rest = rest.elt(0);
+    }
+    totalSize = computeTotalSize(dimv);
+    if (directAllocation) {
+      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 4);
+      data = b.asIntBuffer();
+    } else {
+      data = IntBuffer.allocate(totalSize);
+    }
+    setInitialContents(0, dimv, initialContents, 0);
+  }
+
+  public ComplexArray_IntBuffer(int[] dimv, AbstractArray array,
+                                     int displacement) {
+    this(dimv, array, displacement, false);
+  }
+
+  public ComplexArray_IntBuffer(int[] dimv, AbstractArray array,
+                                int displacement, boolean directAllocation) {
+    this.dimv = dimv;
+    this.array = array;
+    this.displacement = displacement;
+    this.directAllocation = directAllocation;
+    totalSize = computeTotalSize(dimv);
+  }
+
+  private int setInitialContents(int axis, int[] dims, LispObject contents,
+                                 int index) {
+    if (dims.length == 0) {
+      try {
+        data.put(index,(int)(contents.longValue() & 0xffffffffL));
+      } catch (IndexOutOfBoundsException e) {
+        error(new LispError("Bad initial contents for array."));
+        return -1;
+      }
+      ++index;
+    } else {
+      int dim = dims[0];
+      if (dim != contents.length()) {
+        error(new LispError("Bad initial contents for array."));
+        return -1;
+      }
+      int[] newDims = new int[dims.length-1];
+      for (int i = 1; i < dims.length; i++) {
+        newDims[i-1] = dims[i];
+      }
+      if (contents.listp()) {
+        for (int i = contents.length();i-- > 0;) {
+          LispObject content = contents.car();
+          index = setInitialContents(axis + 1, newDims, content, index);
+          contents = contents.cdr();
+        }
+      } else {
+        AbstractVector v = checkVector(contents);
+        final int length = v.length();
+        for (int i = 0; i < length; i++) {
+          LispObject content = v.AREF(i);
+          index =
+            setInitialContents(axis + 1, newDims, content, index);
+        }
+      }
+    }
+    return index;
+  }
+
+  @Override
+  public LispObject typeOf() {
+    return list(Symbol.ARRAY, UNSIGNED_BYTE_32, getDimensions());
+  }
+
+  @Override
+  public LispObject classOf() {
+    return BuiltInClass.ARRAY;
+  }
+
+  @Override
+  public int getRank() {
+    return dimv.length;
+  }
+
+  @Override
+  public LispObject getDimensions() {
+    LispObject result = NIL;
+    for (int i = dimv.length; i-- > 0;) {
+            result = new Cons(Fixnum.getInstance(dimv[i]), result);
+    }
+    return result;
+  }
+
+  @Override
+  public int getDimension(int n) {
+    try {
+      return dimv[n];
+    } catch (ArrayIndexOutOfBoundsException e) {
+      error(new TypeError("Bad array dimension " + n + "."));
+      return -1;
+    }
+  }
+
+  @Override
+  public LispObject getElementType() {
+    return UNSIGNED_BYTE_32;
+  }
+
+  @Override
+  public int getTotalSize() {
+    return totalSize;
+  }
+
+  @Override
+  public LispObject arrayDisplacement() {
+    LispObject value1, value2;
+    if (array != null) {
+      value1 = array;
+      value2 = Fixnum.getInstance(displacement);
+    } else {
+      value1 = NIL;
+      value2 = Fixnum.ZERO;
+    }
+    return LispThread.currentThread().setValues(value1, value2);
+  }
+
+  @Override
+  public LispObject AREF(int index) {
+    if (data != null) {
+      try {
+        return number(((long)data.get(index)) & 0xffffffffL);
+      } catch (IndexOutOfBoundsException e) {
+        return error(new TypeError("Bad row major index " + index + "."));
+      }
+    } else
+      return array.AREF(index + displacement);
+  }
+
+  @Override
+  public void aset(int index, LispObject newValue) {
+    if (data != null) {
+      try {
+        if (newValue.isLessThan(Fixnum.ZERO) || newValue.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+          type_error(newValue, UNSIGNED_BYTE_32);
+        }
+        data.put(index, (int)(newValue.longValue() & 0xffffffffL));
+      } catch (IndexOutOfBoundsException e) {
+        error(new TypeError("Bad row major index " + index + "."));
+      }
+    } else
+      array.aset(index + displacement, newValue);
+  }
+
+  @Override
+  public void fill(LispObject obj) {
+    if (!(obj instanceof LispInteger)) {
+      type_error(obj, Symbol.INTEGER);
+      // Not reached.
+      return;
+    }
+    if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(obj, UNSIGNED_BYTE_32);
+    }
+    if (data != null) {
+      for (int i = data.limit(); i-- > 0;) {
+        data.put(i, (int) (obj.longValue() & 0xffffffffL));;
+      }
+    } else {
+      for (int i = totalSize; i-- > 0;) 
+        aset(i, obj);
+    }
+  }
+
+  @Override
+  public String printObject() {
+    return printObject(dimv);
+  }
+
+  @Override
+  public AbstractArray adjustArray(int[] dims,
+                                   LispObject initialElement,
+                                   LispObject initialContents) {
+    if (isAdjustable()) {
+      if (initialContents != null) {
+        setInitialContents(0, dims, initialContents, 0);
+      } else {
+        //### FIXME Take the easy way out: we don't want to reorganize
+        // all of the array code yet
+        // ME 20200710:  I don't understand why this is the "easy way"
+        SimpleArray_IntBuffer tempArray = new SimpleArray_IntBuffer(dims);
+        if (initialElement != null) {
+          tempArray.fill(initialElement);
+        }
+        SimpleArray_IntBuffer.copyArray(this, tempArray);
+        this.data = tempArray.data;
+
+        for (int i = 0; i < dims.length; i++) {
+          dimv[i] = dims[i];
+        }
+      }
+      return this;
+    } else {
+      if (initialContents != null) {
+        return new ComplexArray_IntBuffer(dims, initialContents);
+      } else {
+        ComplexArray_IntBuffer newArray = new ComplexArray_IntBuffer(dims);
+        if (initialElement != null) {
+          newArray.fill(initialElement);
+        }
+        return newArray;
+      }
+    }
+  }
+
+  @Override
+  public AbstractArray adjustArray(int[] dims,
+                                   AbstractArray displacedTo,
+                                   int displacement) {
+    if (isAdjustable()) {
+      for (int i = 0; i < dims.length; i++) {
+        dimv[i] = dims[i];
+      }
+
+      this.data = null;
+      this.array = displacedTo;
+      this.displacement = displacement;
+      this.totalSize = computeTotalSize(dims);
+
+      return this;
+    } else {
+      ComplexArray_IntBuffer a = new ComplexArray_IntBuffer(dims, displacedTo, displacement);
+      return a;
+    }
+  }
+}

--- a/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
@@ -1,0 +1,466 @@
+/*
+ * ComplexVector_IntBuffer.java
+ *
+ * Copyright (C) 2020 @easye
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+// A specialized vector of element type (UNSIGNED-BYTE 32) that is displaced to
+// another array, has a fill pointer, and/or is expressly adjustable.
+public final class ComplexVector_IntBuffer
+  extends AbstractVector
+{
+  private int capacity;
+  private int fillPointer = -1; // -1 indicates no fill pointer.
+  private boolean isDisplaced;
+
+  // For non-displaced arrays.
+  private IntBuffer elements;
+  private boolean directAllocation;
+
+  // For displaced arrays.
+  private AbstractArray array;
+  private int displacement;
+
+  public ComplexVector_IntBuffer(int capacity) {
+    this(capacity, false);
+  }
+
+  public ComplexVector_IntBuffer(int capacity, boolean directAllocation) {
+    this.capacity = capacity;
+    this.directAllocation = directAllocation;
+    if (directAllocation) {
+      ByteBuffer b = ByteBuffer.allocateDirect(capacity * 4);
+      elements = b.asIntBuffer();
+    } else {
+      elements = IntBuffer.allocate(capacity);
+    }
+  }
+
+  public ComplexVector_IntBuffer(int capacity, AbstractArray array,
+                                 int displacement) {
+    this(capacity, array, displacement, false);
+  }
+
+  public ComplexVector_IntBuffer(int capacity, AbstractArray array,
+                                      int displacement, boolean directAllocation) {
+    this.capacity = capacity;
+    this.array = array;
+    this.displacement = displacement;
+    this.directAllocation = directAllocation;
+    isDisplaced = true;
+  }
+
+  @Override
+  public LispObject typeOf() {
+    return list(Symbol.VECTOR, UNSIGNED_BYTE_32, Fixnum.getInstance(capacity));
+  }
+
+  @Override
+  public LispObject classOf() {
+    return BuiltInClass.VECTOR;
+  }
+
+  @Override
+  public boolean hasFillPointer() {
+    return fillPointer >= 0;
+  }
+
+  @Override
+  public int getFillPointer() {
+    return fillPointer;
+  }
+
+  @Override
+  public void setFillPointer(int n) {
+    fillPointer = n;
+  }
+
+  @Override
+  public void setFillPointer(LispObject obj) {
+    if (obj == T) {
+      fillPointer = capacity();
+    } else {
+      int n = Fixnum.getValue(obj);
+      if (n > capacity()) {
+        StringBuffer sb = new StringBuffer("The new fill pointer (");
+        sb.append(n);
+        sb.append(") exceeds the capacity of the vector (");
+        sb.append(capacity());
+        sb.append(").");
+        error(new LispError(sb.toString()));
+      } else if (n < 0) {
+        StringBuffer sb = new StringBuffer("The new fill pointer (");
+        sb.append(n);
+        sb.append(") is negative.");
+        error(new LispError(sb.toString()));
+      } else {
+                fillPointer = n;
+      }
+    }
+  }
+
+  @Override
+  public boolean isDisplaced() {
+    return isDisplaced;
+  }
+
+  @Override
+  public LispObject arrayDisplacement() {
+    LispObject value1, value2;
+    if (array != null) {
+      value1 = array;
+      value2 = Fixnum.getInstance(displacement);
+    } else {
+      value1 = NIL;
+      value2 = Fixnum.ZERO;
+    }
+    return LispThread.currentThread().setValues(value1, value2);
+  }
+
+  @Override
+  public LispObject getElementType() {
+    return UNSIGNED_BYTE_32;
+  }
+
+  @Override public boolean isSimpleVector() {
+    return false;
+  }
+
+  @Override
+  public int capacity() {
+    return capacity;
+  }
+
+  @Override
+  public int length() {
+    return fillPointer >= 0 ? fillPointer : capacity;
+  }
+
+  @Override
+  public LispObject elt(int index) {
+    final int limit = length();
+    if (index < 0 || index >= limit)
+      badIndex(index, limit);
+    return AREF(index);
+  }
+
+  // Ignores fill pointer.
+  @Override
+  public LispObject AREF(int index) {
+    if (elements != null) {
+      try {
+        return number(((long)elements.get(index)) & 0xffffffffL);
+      } catch (IndexOutOfBoundsException e) {
+        badIndex(index, elements.limit());
+        return NIL; // Not reached.
+      }
+    } else {
+      // Displaced array.
+      if (index < 0 || index >= capacity) {
+        badIndex(index, capacity);
+      }
+      return array.AREF(index + displacement);
+    }
+  }
+
+  @Override
+  public void aset(int index, LispObject newValue) {
+    if (newValue.isLessThan(Fixnum.ZERO)
+        || newValue.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(newValue, UNSIGNED_BYTE_32);
+    }
+    if (elements != null) {
+      try {
+        elements.put(index, (int)(newValue.longValue() & 0xffffffffL));
+      } catch (IndexOutOfBoundsException e) {
+        badIndex(index, elements.limit());
+      }
+    } else {
+      // Displaced array.
+      if (index < 0 || index >= capacity) {
+        badIndex(index, capacity);
+      } else {
+        array.aset(index + displacement, newValue);
+      }
+    }
+  }
+
+  @Override
+  public LispObject subseq(int start, int end) {
+    SimpleVector v = new SimpleVector(end - start);
+    int i = start, j = 0;
+    try {
+      while (i < end) {
+        v.aset(j++, AREF(i++));
+      }
+      return v;
+    } catch (IndexOutOfBoundsException e) {
+      return error(new TypeError("Array index out of bounds: " + i + "."));
+    }
+  }
+
+  @Override
+  public void fill(LispObject obj) {
+    if (!(obj instanceof LispInteger)) {
+      type_error(obj, Symbol.INTEGER);
+      // Not reached.
+      return;
+    }
+    if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(obj, UNSIGNED_BYTE_32);
+    }
+    for (int i = capacity; i-- > 0;) {
+      elements.put(i, coerceToJavaUnsignedInt(obj));
+    }
+  }
+
+  @Override
+  public void shrink(int n) {
+    // One cannot shrink the underlying ByteBuffer physically, so
+    // use the limit marker to denote the length
+    if (n < length()) {
+      elements.limit(n);
+      this.capacity = n;
+      return;
+    }
+    if (n == elements.limit()) {
+      return;
+    }
+    error(new LispError());
+  }
+
+  @Override
+  public LispObject reverse() {
+    int length = length();
+    SimpleVector result = new SimpleVector(length);
+    int i, j;
+    for (i = 0, j = length - 1; i < length; i++, j--) {
+      result.aset(i, AREF(j));
+    }
+    return result;
+  }
+
+  @Override
+  public LispObject nreverse() {
+    if (elements != null) {
+      int i = 0;
+      int j = length() - 1;
+      while (i < j) {
+        int temp = elements.get(i);
+        elements.put(i, elements.get(j));
+        elements.put(j, temp);
+        ++i;
+        --j;
+      }
+    } else {
+      // Displaced array.
+      int length = length();
+      IntBuffer data = null;
+      if (directAllocation) {
+        ByteBuffer b = ByteBuffer.allocateDirect(length);
+        data = b.asIntBuffer();
+      } else {
+        data = IntBuffer.allocate(length);
+      }
+      int i, j;
+      for (i = 0, j = length - 1; i < length; i++, j--) {
+        data.put(i, coerceToJavaUnsignedInt(AREF(j)));
+      }
+      elements = data;
+      capacity = length;
+      array = null;
+      displacement = 0;
+      isDisplaced = false;
+      fillPointer = -1;
+    }
+    return this;
+  }
+
+  @Override
+  public void vectorPushExtend(LispObject element) {
+    if (fillPointer < 0) {
+      noFillPointer();
+    }
+    if (fillPointer >= capacity) {
+      // Need to extend vector.
+      ensureCapacity(capacity * 2 + 1);
+    }
+    aset(fillPointer, element);
+    ++fillPointer;
+  }
+
+  @Override
+  public LispObject VECTOR_PUSH_EXTEND(LispObject element) {
+    vectorPushExtend(element);
+    return Fixnum.getInstance(fillPointer - 1);
+  }
+
+  @Override
+  public LispObject VECTOR_PUSH_EXTEND(LispObject element,
+                                       LispObject extension) {
+    int ext = Fixnum.getValue(extension);
+    if (fillPointer < 0) {
+      noFillPointer();
+    }
+    if (fillPointer >= capacity) {
+      // Need to extend vector.
+      ext = Math.max(ext, capacity + 1);
+      ensureCapacity(capacity + ext);
+    }
+    aset(fillPointer, element);
+    return Fixnum.getInstance(fillPointer++);
+  }
+
+  private final void ensureCapacity(int minCapacity) {
+    if (elements != null) {
+      if (capacity < minCapacity) {
+        IntBuffer newBuffer = null;
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(minCapacity * 4);
+          newBuffer = b.asIntBuffer();
+        } else {
+          newBuffer = IntBuffer.allocate(minCapacity);
+        }
+        newBuffer.put(elements);
+        elements = newBuffer;
+        capacity = minCapacity;
+      }
+    } else {
+      // Displaced array.
+      Debug.assertTrue(array != null);
+      if (capacity < minCapacity
+          || array.getTotalSize() - displacement < minCapacity) {
+        // Copy array.
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(minCapacity * 4);
+          elements = b.asIntBuffer();
+        } else {
+          elements = IntBuffer.allocate(minCapacity);
+        }
+        final int limit
+          = Math.min(capacity, array.getTotalSize() - displacement);
+        for (int i = 0; i < limit; i++) {
+          elements.put(i, coerceToJavaUnsignedInt(AREF(displacement + i)));
+        }
+        capacity = minCapacity;
+        array = null;
+        displacement = 0;
+        isDisplaced = false;
+      }
+    }
+  }
+
+  @Override
+  public AbstractVector adjustArray(int newCapacity,
+                                    LispObject initialElement,
+                                    LispObject initialContents) {
+    if (initialContents != null) {
+      // "If INITIAL-CONTENTS is supplied, it is treated as for MAKE-
+      // ARRAY. In this case none of the original contents of array
+      // appears in the resulting array."
+      IntBuffer newElements = null;
+      if (directAllocation) {
+        ByteBuffer b = ByteBuffer.allocateDirect(newCapacity * 4);
+        newElements = b.asIntBuffer();
+      } else {
+        newElements = IntBuffer.allocate(newCapacity);
+      }
+      if (initialContents.listp()) {
+        LispObject list = initialContents;
+        for (int i = 0; i < newCapacity; i++) {
+          newElements.put(i, coerceToJavaUnsignedInt(list.car()));
+          list = list.cdr();
+        }
+      } else if (initialContents.vectorp()) {
+        for (int i = 0; i < newCapacity; i++) {
+          newElements.put(i, coerceToJavaUnsignedInt(initialContents.elt(i)));
+
+        }
+      } else {
+        type_error(initialContents, Symbol.SEQUENCE);
+      }
+      elements = newElements;
+    } else {
+      if (elements == null) {
+        // Displaced array. Copy existing elements.
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(newCapacity * 4);
+          elements = b.asIntBuffer();
+        } else {
+          elements = IntBuffer.allocate(newCapacity);
+        }
+        final int limit = Math.min(capacity, newCapacity);
+        for (int i = 0; i < limit; i++) {
+          elements.put(i,(int)(array.AREF(displacement + i).longValue() & 0xffffffffL));
+        }
+      } else if (capacity != newCapacity) {
+        IntBuffer newElements = null;
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(newCapacity * 4);
+          newElements = b.asIntBuffer();
+        } else {
+          newElements = IntBuffer.allocate(newCapacity);
+        }
+        newElements.put(elements.array(),
+                        0, Math.min(capacity, newCapacity));
+        elements = newElements;
+      }
+      // Initialize new elements (if aapplicable).
+      if (initialElement != null) {
+        for (int i = capacity; i < newCapacity; i++) {
+          elements.put(i, coerceToJavaUnsignedInt(initialElement));
+        }
+      }
+    }
+    capacity = newCapacity;
+    array = null;
+    displacement = 0;
+    isDisplaced = false;
+    return this;
+  }
+
+  @Override
+    public AbstractVector adjustArray(int newCapacity,
+                                      AbstractArray displacedTo,
+                                      int displacement) {
+    capacity = newCapacity;
+    array = displacedTo;
+    this.displacement = displacement;
+    elements = null;
+    isDisplaced = true;
+    return this;
+  }
+}

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -1652,16 +1652,21 @@ public final class Lisp
     return T;
   }
 
+  // TODO rename to coerceToJavaChar
   public static final char coerceLispObjectToJavaChar(LispObject obj) {
     return (char)Fixnum.getValue(obj);
   }
 
+  // TODO rename to coerceToJavaByte
   public static final byte coerceLispObjectToJavaByte(LispObject obj)
-
   {
           return (byte)Fixnum.getValue(obj);
   }
 
+  public static final int coerceToJavaUnsignedInt(LispObject obj) {
+    return (int) (obj.longValue() & 0xffffffffL);
+  }
+  // TODO rename to coerceFromJavaByte
   public static final LispObject coerceJavaByteToLispObject(byte b)
   {
     return Fixnum.constants[((int)b) & 0xff];

--- a/src/org/armedbear/lisp/SimpleArray_UnsignedByte32.java
+++ b/src/org/armedbear/lisp/SimpleArray_UnsignedByte32.java
@@ -35,6 +35,32 @@ package org.armedbear.lisp;
 
 import static org.armedbear.lisp.Lisp.*;
 
+/*
+ N.b. this implementation has problems somewhere with converting bytes
+
+      Not fixing currently, as this type is unused with NIO
+
+(let* ((unspecialized
+         #(2025373960 3099658457 3238582529 148439321
+           3099658456 3238582528 3000000000 1000000000
+           2000000000 2900000000 2400000000 2800000000
+           0 1))
+       (array 
+         (make-array (length unspecialized)
+                     :element-type '(unsigned-byte 32) 
+                     :initial-contents unspecialized)))
+  (prove:plan (length array))
+  (loop :for i :below (length array)
+        :doing
+           (let ((x0
+                   (elt unspecialized i))
+                 (x1
+                   (elt array i)))
+           (prove:ok
+            (equal x0 x1)
+            (format nil "~a: ~a equals ~a" i x0 x1)))))
+*/
+
 public final class SimpleArray_UnsignedByte32 extends AbstractArray
 {
     private final int[] dimv;

--- a/src/org/armedbear/lisp/make_array.java
+++ b/src/org/armedbear/lisp/make_array.java
@@ -111,11 +111,16 @@ public final class make_array extends Primitive
               if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
                 // an abstract array doesn't have a directAllocation  ???
                 v = new ComplexVector_ByteBuffer(dimv[0], array, displacement, directAllocation); 
-              } else if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+              } else { // if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) 
                 v = new ComplexVector_UnsignedByte8(dimv[0], array, displacement);
               }
             } else if (arrayElementType.equal(UNSIGNED_BYTE_32)) {
-              v = new ComplexVector_UnsignedByte32(dimv[0], array, displacement);
+              if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+                // an abstract array doesn't have a directAllocation  ???
+                v = new ComplexVector_IntBuffer(dimv[0], array, displacement, directAllocation);
+              } else { //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY))
+                v = new ComplexVector_UnsignedByte32(dimv[0], array, displacement);
+              }
             } else {
               v = new ComplexVector(dimv[0], array, displacement);
             }
@@ -207,19 +212,18 @@ public final class make_array extends Primitive
 
             defaultInitialElement = Fixnum.ZERO;
           }
-        else if (upgradedType.equal(UNSIGNED_BYTE_32))
-          {
-            if (fillPointer != NIL || adjustable != NIL)
-              v = new ComplexVector_UnsignedByte32(size);
-            else {
-              if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
-                v = new BasicVector_IntBuffer(size, directAllocation);
-              } else { //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
-                v = new BasicVector_UnsignedByte32(size);
-              }
+        else if (upgradedType.equal(UNSIGNED_BYTE_32)) {
+          if (fillPointer != NIL || adjustable != NIL) {
+            v = new ComplexVector_UnsignedByte32(size);
+          } else {
+            if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+              v = new BasicVector_IntBuffer(size, directAllocation);
+            } else { //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+              v = new BasicVector_UnsignedByte32(size);
             }
-            defaultInitialElement = Fixnum.ZERO;
           }
+          defaultInitialElement = Fixnum.ZERO;
+        }
         else if (upgradedType == NIL)
           {
             v = new NilVector(size);
@@ -314,25 +318,26 @@ public final class make_array extends Primitive
             }
           }
         }
-        // N.b. There is no implementation of SimpleArray with
-        // contents (unsigned-byte 32) using either a
-        // primitive array or an nio.Buffer
-        else if (upgradedType.equal(UNSIGNED_BYTE_32))
-          {
-            if (initialContents != NIL)
-              {
-                array = new SimpleArray_UnsignedByte32(dimv, initialContents);
-              }
-            else
-              {
-                array = new SimpleArray_UnsignedByte32(dimv);
-                if (initialElementProvided != NIL)
-                  array.fill(initialElement);
-                else
-                  array.fill(Fixnum.ZERO);
-              }
+        else if (upgradedType.equal(UNSIGNED_BYTE_32)) {
+          if (initialContents != NIL) {
+            if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+              array = new SimpleArray_IntBuffer(dimv, initialContents, directAllocation);
+            } else { //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+              array = new SimpleArray_UnsignedByte32(dimv, initialContents);
+            }
+          } else {
+            if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+              array = new SimpleArray_IntBuffer(dimv, directAllocation);
+            } else {
+              array = new SimpleArray_UnsignedByte32(dimv);
+            }
+            if (initialElementProvided != NIL) {
+              array.fill(initialElement);
+            } else {
+              array.fill(Fixnum.ZERO);
+            }
           }
-        else
+        } else
           {
             if (initialContents != NIL)
               {
@@ -371,21 +376,26 @@ public final class make_array extends Primitive
                 array.fill(Fixnum.ZERO);
               }
           }
-        else if (upgradedType.equal(UNSIGNED_BYTE_32))
-          {
-            if (initialContents != NIL)
-              {
-                array = new ComplexArray_UnsignedByte32(dimv, initialContents);
-              }
-            else
-              {
-                array = new ComplexArray_UnsignedByte32(dimv);
-                if (initialElementProvided != NIL)
-                  array.fill(initialElement);
-                else
-                  array.fill(Fixnum.ZERO);
-              }
+        else if (upgradedType.equal(UNSIGNED_BYTE_32)) {
+          if (initialContents != NIL) {
+            if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+              array = new ComplexArray_IntBuffer(dimv, initialContents, directAllocation);
+            } else {  //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+              array = new ComplexArray_UnsignedByte32(dimv, initialContents);
+            }
+          } else {
+            if (Java.Buffers.active.equals(AllocationPolicy.NIO)) {
+              array = new ComplexArray_IntBuffer(dimv, directAllocation);
+            } else {  //if (Java.Buffers.active.equals(AllocationPolicy.PRIMITIVE_ARRAY)) {
+              array = new ComplexArray_UnsignedByte32(dimv);
+            }
+            if (initialElementProvided != NIL) {
+              array.fill(initialElement);
+            } else {
+              array.fill(Fixnum.ZERO);
+            }
           }
+        }
         else
           {
             if (initialContents != NIL)


### PR DESCRIPTION
GOAL: completely remove allocation of any UnsignedByte32 in
      make_array.java.  Surprised that it mostly works this way…

Fix directAllocation in SimpleArray_CharBuffer.java

TODO: finish checking the directAllocation for types

TODO: finish refactoring lisp.coerce…method names