### PR TITLE
Abcl/arrays/nio/buffer

### DIFF
--- a/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
@@ -80,7 +80,7 @@ public final class BasicVector_ByteBuffer
     }
     for (int i = array.length; i-- > 0;) {
       // Faster please!
-      elements.put((byte)coerceLispObjectToJavaByte(array[i]));
+      elements.put((byte)coerceToJavaByte(array[i]));
     }
   }
 
@@ -143,7 +143,7 @@ public final class BasicVector_ByteBuffer
   @Override
   public LispObject elt(int index) {
     try {
-      return coerceJavaByteToLispObject(elements.get(index));
+      return coerceFromJavaByte(elements.get(index));
     } catch (IndexOutOfBoundsException e) {
       badIndex(index, capacity);
       return NIL; // Not reached.
@@ -164,7 +164,7 @@ public final class BasicVector_ByteBuffer
   @Override
   public LispObject AREF(int index) {
     try {
-      return coerceJavaByteToLispObject(elements.get(index));
+      return coerceFromJavaByte(elements.get(index));
     } catch (IndexOutOfBoundsException e) {
       badIndex(index, elements.limit()); 
       return NIL; // Not reached.
@@ -183,7 +183,7 @@ public final class BasicVector_ByteBuffer
   @Override
   public void aset(int index, LispObject value) {
     try {
-        elements.put(index, coerceLispObjectToJavaByte(value));
+        elements.put(index, coerceToJavaByte(value));
     } catch (IndexOutOfBoundsException e) {
       badIndex(index, capacity);
     }
@@ -279,12 +279,12 @@ public final class BasicVector_ByteBuffer
       if (initialContents.listp()) {
         LispObject list = initialContents;
         for (int i = 0; i < newCapacity; i++) {
-          newElements.put(i, coerceLispObjectToJavaByte(list.car()));
+          newElements.put(i, coerceToJavaByte(list.car()));
           list = list.cdr();
         }
       } else if (initialContents.vectorp()) {
         for (int i = 0; i < newCapacity; i++)
-          newElements.put(i, coerceLispObjectToJavaByte(initialContents.elt(i)));
+          newElements.put(i, coerceToJavaByte(initialContents.elt(i)));
       } else
         type_error(initialContents, Symbol.SEQUENCE);
       return new BasicVector_ByteBuffer(newElements, directAllocation);

--- a/src/org/armedbear/lisp/BasicVector_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/BasicVector_UnsignedByte8.java
@@ -61,7 +61,7 @@ public final class BasicVector_UnsignedByte8 extends AbstractVector
     capacity = array.length;
     elements = new byte[capacity];
     for (int i = array.length; i-- > 0;)
-      elements[i] = coerceLispObjectToJavaByte(array[i]);
+      elements[i] = coerceToJavaByte(array[i]);
   }
 
   @Override
@@ -127,7 +127,7 @@ public final class BasicVector_UnsignedByte8 extends AbstractVector
   {
     try
       {
-        return coerceJavaByteToLispObject(elements[index]);
+        return coerceFromJavaByte(elements[index]);
       }
     catch (ArrayIndexOutOfBoundsException e)
       {
@@ -156,7 +156,7 @@ public final class BasicVector_UnsignedByte8 extends AbstractVector
   {
     try
       {
-        return coerceJavaByteToLispObject(elements[index]);
+        return coerceFromJavaByte(elements[index]);
       }
     catch (ArrayIndexOutOfBoundsException e)
       {
@@ -183,7 +183,7 @@ public final class BasicVector_UnsignedByte8 extends AbstractVector
   {
     try
       {
-        elements[index] = coerceLispObjectToJavaByte(value);
+        elements[index] = coerceToJavaByte(value);
       }
     catch (ArrayIndexOutOfBoundsException e)
       {

--- a/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
@@ -105,7 +105,7 @@ public final class ComplexArray_ByteBuffer
   {
     if (dims.length == 0) {
       try {
-        data.put(index, coerceLispObjectToJavaByte(contents));
+        data.put(index, coerceToJavaByte(contents));
       }
       catch (IndexOutOfBoundsException e) {
         error(new LispError("Bad initial contents for array."));
@@ -211,7 +211,7 @@ public final class ComplexArray_ByteBuffer
   {
     if (data != null) {
       try {
-        return coerceJavaByteToLispObject(data.get(index));
+        return coerceFromJavaByte(data.get(index));
       }
       catch (IndexOutOfBoundsException e) {
         return error(new TypeError("Bad row major index " + index + "."));
@@ -225,7 +225,7 @@ public final class ComplexArray_ByteBuffer
   {
     if (data != null) {
       try {
-        data.put(index, coerceLispObjectToJavaByte(newValue));
+        data.put(index, coerceToJavaByte(newValue));
       }
       catch (IndexOutOfBoundsException e) {
         error(new TypeError("Bad row major index " + index + "."));
@@ -302,7 +302,7 @@ public final class ComplexArray_ByteBuffer
           newBuffer = ByteBuffer.allocate(computeTotalSize(dims));
         }
         if (initialElement != null) {
-          fill(newBuffer, coerceLispObjectToJavaByte(initialElement));           
+          fill(newBuffer, coerceToJavaByte(initialElement));           
         }
         this.data = newBuffer;
 

--- a/src/org/armedbear/lisp/ComplexArray_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_IntBuffer.java
@@ -1,0 +1,312 @@
+/*
+ * ComplexArray_IntBuffer.java
+ *
+ * Copyright (C) 2020 @easye
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+public final class ComplexArray_IntBuffer
+  extends AbstractArray
+{
+  private final int[] dimv;
+  private int totalSize;
+
+  // For non-displaced arrays.
+  private IntBuffer data;
+  private boolean directAllocation;
+  
+  // For displaced arrays.
+  private AbstractArray array;
+  private int displacement;
+  
+  public ComplexArray_IntBuffer(int[] dimv) {
+    this(dimv, false);
+  }
+  
+  public ComplexArray_IntBuffer(int[] dimv, boolean directAllocation) {
+    this.dimv = dimv;
+    this.directAllocation = directAllocation;
+    totalSize = computeTotalSize(dimv);
+    if (directAllocation) {
+      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 4);
+      data = b.asIntBuffer();
+    } else {
+      data = IntBuffer.allocate(totalSize);
+    }
+  }
+
+  public ComplexArray_IntBuffer(int[] dimv, LispObject initialContents) {
+    this(dimv, initialContents, false);
+  }
+  
+  public ComplexArray_IntBuffer(int[] dimv, LispObject initialContents,
+                                     boolean directAllocation) {
+    this.dimv = dimv;
+    this.directAllocation = directAllocation;
+    final int rank = dimv.length;
+    LispObject rest = initialContents;
+    for (int i = 0; i < rank; i++) {
+      dimv[i] = rest.length();
+      rest = rest.elt(0);
+    }
+    totalSize = computeTotalSize(dimv);
+    if (directAllocation) {
+      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 4);
+      data = b.asIntBuffer();
+    } else {
+      data = IntBuffer.allocate(totalSize);
+    }
+    setInitialContents(0, dimv, initialContents, 0);
+  }
+
+  public ComplexArray_IntBuffer(int[] dimv, AbstractArray array,
+                                     int displacement) {
+    this(dimv, array, displacement, false);
+  }
+
+  public ComplexArray_IntBuffer(int[] dimv, AbstractArray array,
+                                int displacement, boolean directAllocation) {
+    this.dimv = dimv;
+    this.array = array;
+    this.displacement = displacement;
+    this.directAllocation = directAllocation;
+    totalSize = computeTotalSize(dimv);
+  }
+
+  private int setInitialContents(int axis, int[] dims, LispObject contents,
+                                 int index) {
+    if (dims.length == 0) {
+      try {
+        data.put(index,(int)(contents.longValue() & 0xffffffffL));
+      } catch (IndexOutOfBoundsException e) {
+        error(new LispError("Bad initial contents for array."));
+        return -1;
+      }
+      ++index;
+    } else {
+      int dim = dims[0];
+      if (dim != contents.length()) {
+        error(new LispError("Bad initial contents for array."));
+        return -1;
+      }
+      int[] newDims = new int[dims.length-1];
+      for (int i = 1; i < dims.length; i++) {
+        newDims[i-1] = dims[i];
+      }
+      if (contents.listp()) {
+        for (int i = contents.length();i-- > 0;) {
+          LispObject content = contents.car();
+          index = setInitialContents(axis + 1, newDims, content, index);
+          contents = contents.cdr();
+        }
+      } else {
+        AbstractVector v = checkVector(contents);
+        final int length = v.length();
+        for (int i = 0; i < length; i++) {
+          LispObject content = v.AREF(i);
+          index =
+            setInitialContents(axis + 1, newDims, content, index);
+        }
+      }
+    }
+    return index;
+  }
+
+  @Override
+  public LispObject typeOf() {
+    return list(Symbol.ARRAY, UNSIGNED_BYTE_32, getDimensions());
+  }
+
+  @Override
+  public LispObject classOf() {
+    return BuiltInClass.ARRAY;
+  }
+
+  @Override
+  public int getRank() {
+    return dimv.length;
+  }
+
+  @Override
+  public LispObject getDimensions() {
+    LispObject result = NIL;
+    for (int i = dimv.length; i-- > 0;) {
+            result = new Cons(Fixnum.getInstance(dimv[i]), result);
+    }
+    return result;
+  }
+
+  @Override
+  public int getDimension(int n) {
+    try {
+      return dimv[n];
+    } catch (ArrayIndexOutOfBoundsException e) {
+      error(new TypeError("Bad array dimension " + n + "."));
+      return -1;
+    }
+  }
+
+  @Override
+  public LispObject getElementType() {
+    return UNSIGNED_BYTE_32;
+  }
+
+  @Override
+  public int getTotalSize() {
+    return totalSize;
+  }
+
+  @Override
+  public LispObject arrayDisplacement() {
+    LispObject value1, value2;
+    if (array != null) {
+      value1 = array;
+      value2 = Fixnum.getInstance(displacement);
+    } else {
+      value1 = NIL;
+      value2 = Fixnum.ZERO;
+    }
+    return LispThread.currentThread().setValues(value1, value2);
+  }
+
+  @Override
+  public LispObject AREF(int index) {
+    if (data != null) {
+      try {
+        return number(((long)data.get(index)) & 0xffffffffL);
+      } catch (IndexOutOfBoundsException e) {
+        return error(new TypeError("Bad row major index " + index + "."));
+      }
+    } else
+      return array.AREF(index + displacement);
+  }
+
+  @Override
+  public void aset(int index, LispObject newValue) {
+    if (data != null) {
+      try {
+        if (newValue.isLessThan(Fixnum.ZERO) || newValue.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+          type_error(newValue, UNSIGNED_BYTE_32);
+        }
+        data.put(index, (int)(newValue.longValue() & 0xffffffffL));
+      } catch (IndexOutOfBoundsException e) {
+        error(new TypeError("Bad row major index " + index + "."));
+      }
+    } else
+      array.aset(index + displacement, newValue);
+  }
+
+  @Override
+  public void fill(LispObject obj) {
+    if (!(obj instanceof LispInteger)) {
+      type_error(obj, Symbol.INTEGER);
+      // Not reached.
+      return;
+    }
+    if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(obj, UNSIGNED_BYTE_32);
+    }
+    if (data != null) {
+      for (int i = data.limit(); i-- > 0;) {
+        data.put(i, (int) (obj.longValue() & 0xffffffffL));;
+      }
+    } else {
+      for (int i = totalSize; i-- > 0;) 
+        aset(i, obj);
+    }
+  }
+
+  @Override
+  public String printObject() {
+    return printObject(dimv);
+  }
+
+  @Override
+  public AbstractArray adjustArray(int[] dims,
+                                   LispObject initialElement,
+                                   LispObject initialContents) {
+    if (isAdjustable()) {
+      if (initialContents != null) {
+        setInitialContents(0, dims, initialContents, 0);
+      } else {
+        //### FIXME Take the easy way out: we don't want to reorganize
+        // all of the array code yet
+        // ME 20200710:  I don't understand why this is the "easy way"
+        SimpleArray_IntBuffer tempArray = new SimpleArray_IntBuffer(dims);
+        if (initialElement != null) {
+          tempArray.fill(initialElement);
+        }
+        SimpleArray_IntBuffer.copyArray(this, tempArray);
+        this.data = tempArray.data;
+
+        for (int i = 0; i < dims.length; i++) {
+          dimv[i] = dims[i];
+        }
+      }
+      return this;
+    } else {
+      if (initialContents != null) {
+        return new ComplexArray_IntBuffer(dims, initialContents);
+      } else {
+        ComplexArray_IntBuffer newArray = new ComplexArray_IntBuffer(dims);
+        if (initialElement != null) {
+          newArray.fill(initialElement);
+        }
+        return newArray;
+      }
+    }
+  }
+
+  @Override
+  public AbstractArray adjustArray(int[] dims,
+                                   AbstractArray displacedTo,
+                                   int displacement) {
+    if (isAdjustable()) {
+      for (int i = 0; i < dims.length; i++) {
+        dimv[i] = dims[i];
+      }
+
+      this.data = null;
+      this.array = displacedTo;
+      this.displacement = displacement;
+      this.totalSize = computeTotalSize(dims);
+
+      return this;
+    } else {
+      ComplexArray_IntBuffer a = new ComplexArray_IntBuffer(dims, displacedTo, displacement);
+      return a;
+    }
+  }
+}

--- a/src/org/armedbear/lisp/ComplexArray_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/ComplexArray_UnsignedByte8.java
@@ -83,7 +83,7 @@ public final class ComplexArray_UnsignedByte8 extends AbstractArray
     {
         if (dims.length == 0) {
             try {
-                data[index] = coerceLispObjectToJavaByte(contents);
+                data[index] = coerceToJavaByte(contents);
             }
             catch (ArrayIndexOutOfBoundsException e) {
                 error(new LispError("Bad initial contents for array."));
@@ -189,7 +189,7 @@ public final class ComplexArray_UnsignedByte8 extends AbstractArray
     {
         if (data != null) {
             try {
-                return coerceJavaByteToLispObject(data[index]);
+                return coerceFromJavaByte(data[index]);
             }
             catch (ArrayIndexOutOfBoundsException e) {
                 return error(new TypeError("Bad row major index " + index + "."));
@@ -203,7 +203,7 @@ public final class ComplexArray_UnsignedByte8 extends AbstractArray
     {
         if (data != null) {
             try {
-                data[index] = coerceLispObjectToJavaByte(newValue);
+                data[index] = coerceToJavaByte(newValue);
             }
             catch (ArrayIndexOutOfBoundsException e) {
                 error(new TypeError("Bad row major index " + index + "."));

--- a/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
@@ -189,7 +189,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
   public LispObject AREF(int index) {
     if (elements != null) {
       try {
-        return coerceJavaByteToLispObject(elements.get(index));
+        return coerceFromJavaByte(elements.get(index));
       } catch (ArrayIndexOutOfBoundsException e) {
         badIndex(index, elements.limit());
         return NIL; // Not reached.
@@ -226,7 +226,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
   {
     if (elements != null) {
       try {
-        elements.put(index, coerceLispObjectToJavaByte(newValue));
+        elements.put(index, coerceToJavaByte(newValue));
       } catch (IndexOutOfBoundsException e) {
         badIndex(index, elements.limit());
       }
@@ -316,7 +316,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
       }
       int i, j;
       for (i = 0, j = length - 1; i < length; i++, j--) {
-        data.put(i, coerceLispObjectToJavaByte(AREF(j)));
+        data.put(i, coerceToJavaByte(AREF(j)));
       }
       elements = data;
       capacity = length;
@@ -391,7 +391,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
         final int limit
           = Math.min(length(), array.getTotalSize() - displacement);
         for (int i = 0; i < limit; i++) {
-          elements.put(i, coerceLispObjectToJavaByte(array.AREF(displacement + i)));
+          elements.put(i, coerceToJavaByte(array.AREF(displacement + i)));
         }
         capacity = minCapacity;
         array = null;
@@ -420,12 +420,12 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
       if (initialContents.listp()) {
         LispObject list = initialContents;
           for (int i = 0; i < newCapacity; i++) {
-            newElements.put(i, coerceLispObjectToJavaByte(list.car()));
+            newElements.put(i, coerceToJavaByte(list.car()));
             list = list.cdr();
           }
       } else if (initialContents.vectorp()) {
         for (int i = 0; i < newCapacity; i++) {
-          newElements.put(i, coerceLispObjectToJavaByte(initialContents.elt(i)));
+          newElements.put(i, coerceToJavaByte(initialContents.elt(i)));
         }
       } else {
           type_error(initialContents, Symbol.SEQUENCE);
@@ -442,7 +442,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
         }
         final int limit = Math.min(capacity, newCapacity);
         for (int i = 0; i < limit; i++) {
-          elements.put(i, coerceLispObjectToJavaByte(array.AREF(displacement + i)));
+          elements.put(i, coerceToJavaByte(array.AREF(displacement + i)));
         }
       } else if (capacity != newCapacity) {
         ByteBuffer newElements = null;
@@ -457,7 +457,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
       }
       // Initialize new elements (if applicable).
       if (initialElement != null) {
-        byte b = coerceLispObjectToJavaByte(initialElement);
+        byte b = coerceToJavaByte(initialElement);
         for (int i = capacity; i < newCapacity; i++) {
           elements.put(b);
         }

--- a/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
@@ -1,0 +1,466 @@
+/*
+ * ComplexVector_IntBuffer.java
+ *
+ * Copyright (C) 2020 @easye
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ *
+ * As a special exception, the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent
+ * modules, and to copy and distribute the resulting executable under
+ * terms of your choice, provided that you also meet, for each linked
+ * independent module, the terms and conditions of the license of that
+ * module.  An independent module is a module which is not derived from
+ * or based on this library.  If you modify this library, you may extend
+ * this exception to your version of the library, but you are not
+ * obligated to do so.  If you do not wish to do so, delete this
+ * exception statement from your version.
+ */
+
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+
+// A specialized vector of element type (UNSIGNED-BYTE 32) that is displaced to
+// another array, has a fill pointer, and/or is expressly adjustable.
+public final class ComplexVector_IntBuffer
+  extends AbstractVector
+{
+  private int capacity;
+  private int fillPointer = -1; // -1 indicates no fill pointer.
+  private boolean isDisplaced;
+
+  // For non-displaced arrays.
+  private IntBuffer elements;
+  private boolean directAllocation;
+
+  // For displaced arrays.
+  private AbstractArray array;
+  private int displacement;
+
+  public ComplexVector_IntBuffer(int capacity) {
+    this(capacity, false);
+  }
+
+  public ComplexVector_IntBuffer(int capacity, boolean directAllocation) {
+    this.capacity = capacity;
+    this.directAllocation = directAllocation;
+    if (directAllocation) {
+      ByteBuffer b = ByteBuffer.allocateDirect(capacity * 4);
+      elements = b.asIntBuffer();
+    } else {
+      elements = IntBuffer.allocate(capacity);
+    }
+  }
+
+  public ComplexVector_IntBuffer(int capacity, AbstractArray array,
+                                 int displacement) {
+    this(capacity, array, displacement, false);
+  }
+
+  public ComplexVector_IntBuffer(int capacity, AbstractArray array,
+                                      int displacement, boolean directAllocation) {
+    this.capacity = capacity;
+    this.array = array;
+    this.displacement = displacement;
+    this.directAllocation = directAllocation;
+    isDisplaced = true;
+  }
+
+  @Override
+  public LispObject typeOf() {
+    return list(Symbol.VECTOR, UNSIGNED_BYTE_32, Fixnum.getInstance(capacity));
+  }
+
+  @Override
+  public LispObject classOf() {
+    return BuiltInClass.VECTOR;
+  }
+
+  @Override
+  public boolean hasFillPointer() {
+    return fillPointer >= 0;
+  }
+
+  @Override
+  public int getFillPointer() {
+    return fillPointer;
+  }
+
+  @Override
+  public void setFillPointer(int n) {
+    fillPointer = n;
+  }
+
+  @Override
+  public void setFillPointer(LispObject obj) {
+    if (obj == T) {
+      fillPointer = capacity();
+    } else {
+      int n = Fixnum.getValue(obj);
+      if (n > capacity()) {
+        StringBuffer sb = new StringBuffer("The new fill pointer (");
+        sb.append(n);
+        sb.append(") exceeds the capacity of the vector (");
+        sb.append(capacity());
+        sb.append(").");
+        error(new LispError(sb.toString()));
+      } else if (n < 0) {
+        StringBuffer sb = new StringBuffer("The new fill pointer (");
+        sb.append(n);
+        sb.append(") is negative.");
+        error(new LispError(sb.toString()));
+      } else {
+                fillPointer = n;
+      }
+    }
+  }
+
+  @Override
+  public boolean isDisplaced() {
+    return isDisplaced;
+  }
+
+  @Override
+  public LispObject arrayDisplacement() {
+    LispObject value1, value2;
+    if (array != null) {
+      value1 = array;
+      value2 = Fixnum.getInstance(displacement);
+    } else {
+      value1 = NIL;
+      value2 = Fixnum.ZERO;
+    }
+    return LispThread.currentThread().setValues(value1, value2);
+  }
+
+  @Override
+  public LispObject getElementType() {
+    return UNSIGNED_BYTE_32;
+  }
+
+  @Override public boolean isSimpleVector() {
+    return false;
+  }
+
+  @Override
+  public int capacity() {
+    return capacity;
+  }
+
+  @Override
+  public int length() {
+    return fillPointer >= 0 ? fillPointer : capacity;
+  }
+
+  @Override
+  public LispObject elt(int index) {
+    final int limit = length();
+    if (index < 0 || index >= limit)
+      badIndex(index, limit);
+    return AREF(index);
+  }
+
+  // Ignores fill pointer.
+  @Override
+  public LispObject AREF(int index) {
+    if (elements != null) {
+      try {
+        return number(((long)elements.get(index)) & 0xffffffffL);
+      } catch (IndexOutOfBoundsException e) {
+        badIndex(index, elements.limit());
+        return NIL; // Not reached.
+      }
+    } else {
+      // Displaced array.
+      if (index < 0 || index >= capacity) {
+        badIndex(index, capacity);
+      }
+      return array.AREF(index + displacement);
+    }
+  }
+
+  @Override
+  public void aset(int index, LispObject newValue) {
+    if (newValue.isLessThan(Fixnum.ZERO)
+        || newValue.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(newValue, UNSIGNED_BYTE_32);
+    }
+    if (elements != null) {
+      try {
+        elements.put(index, (int)(newValue.longValue() & 0xffffffffL));
+      } catch (IndexOutOfBoundsException e) {
+        badIndex(index, elements.limit());
+      }
+    } else {
+      // Displaced array.
+      if (index < 0 || index >= capacity) {
+        badIndex(index, capacity);
+      } else {
+        array.aset(index + displacement, newValue);
+      }
+    }
+  }
+
+  @Override
+  public LispObject subseq(int start, int end) {
+    SimpleVector v = new SimpleVector(end - start);
+    int i = start, j = 0;
+    try {
+      while (i < end) {
+        v.aset(j++, AREF(i++));
+      }
+      return v;
+    } catch (IndexOutOfBoundsException e) {
+      return error(new TypeError("Array index out of bounds: " + i + "."));
+    }
+  }
+
+  @Override
+  public void fill(LispObject obj) {
+    if (!(obj instanceof LispInteger)) {
+      type_error(obj, Symbol.INTEGER);
+      // Not reached.
+      return;
+    }
+    if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(obj, UNSIGNED_BYTE_32);
+    }
+    for (int i = capacity; i-- > 0;) {
+      elements.put(i, coerceToJavaUnsignedInt(obj));
+    }
+  }
+
+  @Override
+  public void shrink(int n) {
+    // One cannot shrink the underlying ByteBuffer physically, so
+    // use the limit marker to denote the length
+    if (n < length()) {
+      elements.limit(n);
+      this.capacity = n;
+      return;
+    }
+    if (n == elements.limit()) {
+      return;
+    }
+    error(new LispError());
+  }
+
+  @Override
+  public LispObject reverse() {
+    int length = length();
+    SimpleVector result = new SimpleVector(length);
+    int i, j;
+    for (i = 0, j = length - 1; i < length; i++, j--) {
+      result.aset(i, AREF(j));
+    }
+    return result;
+  }
+
+  @Override
+  public LispObject nreverse() {
+    if (elements != null) {
+      int i = 0;
+      int j = length() - 1;
+      while (i < j) {
+        int temp = elements.get(i);
+        elements.put(i, elements.get(j));
+        elements.put(j, temp);
+        ++i;
+        --j;
+      }
+    } else {
+      // Displaced array.
+      int length = length();
+      IntBuffer data = null;
+      if (directAllocation) {
+        ByteBuffer b = ByteBuffer.allocateDirect(length * 4);
+        data = b.asIntBuffer();
+      } else {
+        data = IntBuffer.allocate(length);
+      }
+      int i, j;
+      for (i = 0, j = length - 1; i < length; i++, j--) {
+        data.put(i, coerceToJavaUnsignedInt(AREF(j)));
+      }
+      elements = data;
+      capacity = length;
+      array = null;
+      displacement = 0;
+      isDisplaced = false;
+      fillPointer = -1;
+    }
+    return this;
+  }
+
+  @Override
+  public void vectorPushExtend(LispObject element) {
+    if (fillPointer < 0) {
+      noFillPointer();
+    }
+    if (fillPointer >= capacity) {
+      // Need to extend vector.
+      ensureCapacity(capacity * 2 + 1);
+    }
+    aset(fillPointer, element);
+    ++fillPointer;
+  }
+
+  @Override
+  public LispObject VECTOR_PUSH_EXTEND(LispObject element) {
+    vectorPushExtend(element);
+    return Fixnum.getInstance(fillPointer - 1);
+  }
+
+  @Override
+  public LispObject VECTOR_PUSH_EXTEND(LispObject element,
+                                       LispObject extension) {
+    int ext = Fixnum.getValue(extension);
+    if (fillPointer < 0) {
+      noFillPointer();
+    }
+    if (fillPointer >= capacity) {
+      // Need to extend vector.
+      ext = Math.max(ext, capacity + 1);
+      ensureCapacity(capacity + ext);
+    }
+    aset(fillPointer, element);
+    return Fixnum.getInstance(fillPointer++);
+  }
+
+  private final void ensureCapacity(int minCapacity) {
+    if (elements != null) {
+      if (capacity < minCapacity) {
+        IntBuffer newBuffer = null;
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(minCapacity * 4);
+          newBuffer = b.asIntBuffer();
+        } else {
+          newBuffer = IntBuffer.allocate(minCapacity);
+        }
+        newBuffer.put(elements);
+        elements = newBuffer;
+        capacity = minCapacity;
+      }
+    } else {
+      // Displaced array.
+      Debug.assertTrue(array != null);
+      if (capacity < minCapacity
+          || array.getTotalSize() - displacement < minCapacity) {
+        // Copy array.
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(minCapacity * 4);
+          elements = b.asIntBuffer();
+        } else {
+          elements = IntBuffer.allocate(minCapacity);
+        }
+        final int limit
+          = Math.min(capacity, array.getTotalSize() - displacement);
+        for (int i = 0; i < limit; i++) {
+          elements.put(i, coerceToJavaUnsignedInt(AREF(displacement + i)));
+        }
+        capacity = minCapacity;
+        array = null;
+        displacement = 0;
+        isDisplaced = false;
+      }
+    }
+  }
+
+  @Override
+  public AbstractVector adjustArray(int newCapacity,
+                                    LispObject initialElement,
+                                    LispObject initialContents) {
+    if (initialContents != null) {
+      // "If INITIAL-CONTENTS is supplied, it is treated as for MAKE-
+      // ARRAY. In this case none of the original contents of array
+      // appears in the resulting array."
+      IntBuffer newElements = null;
+      if (directAllocation) {
+        ByteBuffer b = ByteBuffer.allocateDirect(newCapacity * 4);
+        newElements = b.asIntBuffer();
+      } else {
+        newElements = IntBuffer.allocate(newCapacity);
+      }
+      if (initialContents.listp()) {
+        LispObject list = initialContents;
+        for (int i = 0; i < newCapacity; i++) {
+          newElements.put(i, coerceToJavaUnsignedInt(list.car()));
+          list = list.cdr();
+        }
+      } else if (initialContents.vectorp()) {
+        for (int i = 0; i < newCapacity; i++) {
+          newElements.put(i, coerceToJavaUnsignedInt(initialContents.elt(i)));
+
+        }
+      } else {
+        type_error(initialContents, Symbol.SEQUENCE);
+      }
+      elements = newElements;
+    } else {
+      if (elements == null) {
+        // Displaced array. Copy existing elements.
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(newCapacity * 4);
+          elements = b.asIntBuffer();
+        } else {
+          elements = IntBuffer.allocate(newCapacity);
+        }
+        final int limit = Math.min(capacity, newCapacity);
+        for (int i = 0; i < limit; i++) {
+          elements.put(i,(int)(array.AREF(displacement + i).longValue() & 0xffffffffL));
+        }
+      } else if (capacity != newCapacity) {
+        IntBuffer newElements = null;
+        if (directAllocation) {
+          ByteBuffer b = ByteBuffer.allocateDirect(newCapacity * 4);
+          newElements = b.asIntBuffer();
+        } else {
+          newElements = IntBuffer.allocate(newCapacity);
+        }
+        newElements.put(elements.array(),
+                        0, Math.min(capacity, newCapacity));
+        elements = newElements;
+      }
+      // Initialize new elements (if aapplicable).
+      if (initialElement != null) {
+        for (int i = capacity; i < newCapacity; i++) {
+          elements.put(i, coerceToJavaUnsignedInt(initialElement));
+        }
+      }
+    }
+    capacity = newCapacity;
+    array = null;
+    displacement = 0;
+    isDisplaced = false;
+    return this;
+  }
+
+  @Override
+    public AbstractVector adjustArray(int newCapacity,
+                                      AbstractArray displacedTo,
+                                      int displacement) {
+    capacity = newCapacity;
+    array = displacedTo;
+    this.displacement = displacement;
+    elements = null;
+    isDisplaced = true;
+    return this;
+  }
+}

--- a/src/org/armedbear/lisp/ComplexVector_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/ComplexVector_UnsignedByte8.java
@@ -178,7 +178,7 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
     {
         if (elements != null) {
             try {
-                return coerceJavaByteToLispObject(elements[index]);
+                return coerceFromJavaByte(elements[index]);
             }
             catch (ArrayIndexOutOfBoundsException e) {
                 badIndex(index, elements.length);
@@ -216,7 +216,7 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
     {
         if (elements != null) {
             try {
-                elements[index] = coerceLispObjectToJavaByte(newValue);
+                elements[index] = coerceToJavaByte(newValue);
             }
             catch (ArrayIndexOutOfBoundsException e) {
                 badIndex(index, elements.length);
@@ -305,7 +305,7 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
             byte[] data = new byte[length];
             int i, j;
             for (i = 0, j = length - 1; i < length; i++, j--)
-                data[i] = coerceLispObjectToJavaByte(AREF(j));
+                data[i] = coerceToJavaByte(AREF(j));
             elements = data;
             capacity = length;
             array = null;
@@ -373,7 +373,7 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
                 final int limit =
                     Math.min(capacity, array.getTotalSize() - displacement);
                 for (int i = 0; i < limit; i++)
-                    elements[i] = coerceLispObjectToJavaByte(array.AREF(displacement + i));
+                    elements[i] = coerceToJavaByte(array.AREF(displacement + i));
                 capacity = minCapacity;
                 array = null;
                 displacement = 0;
@@ -396,12 +396,12 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
             if (initialContents.listp()) {
                 LispObject list = initialContents;
                 for (int i = 0; i < newCapacity; i++) {
-                    newElements[i] = coerceLispObjectToJavaByte(list.car());
+                    newElements[i] = coerceToJavaByte(list.car());
                     list = list.cdr();
                 }
             } else if (initialContents.vectorp()) {
                 for (int i = 0; i < newCapacity; i++)
-                    newElements[i] = coerceLispObjectToJavaByte(initialContents.elt(i));
+                    newElements[i] = coerceToJavaByte(initialContents.elt(i));
             } else
                 type_error(initialContents, Symbol.SEQUENCE);
             elements = newElements;
@@ -411,7 +411,7 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
                 elements = new byte[newCapacity];
                 final int limit = Math.min(capacity, newCapacity);
                 for (int i = 0; i < limit; i++)
-                    elements[i] = coerceLispObjectToJavaByte(array.AREF(displacement + i));
+                    elements[i] = coerceToJavaByte(array.AREF(displacement + i));
             } else if (capacity != newCapacity) {
                 byte[] newElements = new byte[newCapacity];
                 System.arraycopy(elements, 0, newElements, 0,
@@ -420,7 +420,7 @@ public final class ComplexVector_UnsignedByte8 extends AbstractVector
             }
             // Initialize new elements (if aapplicable).
             if (initialElement != null) {
-                byte b = coerceLispObjectToJavaByte(initialElement);
+                byte b = coerceToJavaByte(initialElement);
                 for (int i = capacity; i < newCapacity; i++)
                     elements[i] = b;
             }

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -1652,18 +1652,20 @@ public final class Lisp
     return T;
   }
 
-  public static final char coerceLispObjectToJavaChar(LispObject obj) {
+  // TODO rename to coerceToJavaChar
+  public static final char coerceToJavaChar(LispObject obj) {
     return (char)Fixnum.getValue(obj);
   }
 
-  public static final byte coerceLispObjectToJavaByte(LispObject obj)
-
-  {
+  public static final byte coerceToJavaByte(LispObject obj) {
           return (byte)Fixnum.getValue(obj);
   }
 
-  public static final LispObject coerceJavaByteToLispObject(byte b)
-  {
+  public static final int coerceToJavaUnsignedInt(LispObject obj) {
+    return (int) (obj.longValue() & 0xffffffffL);
+  }
+  
+  public static final LispObject coerceFromJavaByte(byte b) {
     return Fixnum.constants[((int)b) & 0xff];
   }
 

--- a/src/org/armedbear/lisp/SimpleArray_ByteBuffer.java
+++ b/src/org/armedbear/lisp/SimpleArray_ByteBuffer.java
@@ -110,7 +110,7 @@ public final class SimpleArray_ByteBuffer
                                  int index) {
     if (dims.length == 0) {
       try {
-        data.put(index, coerceLispObjectToJavaByte(contents));
+        data.put(index, coerceToJavaByte(contents));
       } catch (IndexOutOfBoundsException e) {
         error(new LispError("Bad initial contents for array."));
         return -1;
@@ -205,7 +205,7 @@ public final class SimpleArray_ByteBuffer
   @Override
   public LispObject AREF(int index) {
     try {
-      return coerceJavaByteToLispObject(data.get(index));
+      return coerceFromJavaByte(data.get(index));
     } catch (IndexOutOfBoundsException e) {
       return error(new TypeError("Bad row major index " + index + "."));
     }
@@ -214,7 +214,7 @@ public final class SimpleArray_ByteBuffer
   @Override
   public void aset(int index, LispObject newValue) {
     try {
-      data.put(index, coerceLispObjectToJavaByte(newValue));
+      data.put(index, coerceToJavaByte(newValue));
     } catch (IndexOutOfBoundsException e) {
       error(new TypeError("Bad row major index " + index + "."));
     }
@@ -254,7 +254,7 @@ public final class SimpleArray_ByteBuffer
   @Override
   public LispObject get(int[] subscripts) {
     try {
-      return coerceJavaByteToLispObject(data.get(getRowMajorIndex(subscripts)));
+      return coerceFromJavaByte(data.get(getRowMajorIndex(subscripts)));
     } catch (IndexOutOfBoundsException e) {
       return error(new TypeError("Bad row major index " +
                                  getRowMajorIndex(subscripts) + "."));
@@ -264,7 +264,7 @@ public final class SimpleArray_ByteBuffer
   @Override
   public void set(int[] subscripts, LispObject newValue) {
     try {
-      data.put(getRowMajorIndex(subscripts),coerceLispObjectToJavaByte(newValue));
+      data.put(getRowMajorIndex(subscripts),coerceToJavaByte(newValue));
     } catch (IndexOutOfBoundsException e) {
       error(new TypeError("Bad row major index " +
                           getRowMajorIndex(subscripts) + "."));

--- a/src/org/armedbear/lisp/SimpleArray_CharBuffer.java
+++ b/src/org/armedbear/lisp/SimpleArray_CharBuffer.java
@@ -117,7 +117,7 @@ public final class SimpleArray_CharBuffer
                                  int index) {
     if (dims.length == 0) {
       try {
-        data.put(index, coerceLispObjectToJavaChar(contents));
+        data.put(index, coerceToJavaChar(contents));
       } catch (IndexOutOfBoundsException e) {
         error(new LispError("Bad initial contents for array."));
         return -1;

--- a/src/org/armedbear/lisp/SimpleArray_IntBuffer.java
+++ b/src/org/armedbear/lisp/SimpleArray_IntBuffer.java
@@ -1,5 +1,5 @@
 /*
- * SimpleArray_CharBuffer.java
+ * SimpleArray_IntBuffer.java
  *
  * Copyright (C) 2020 @easye
  *
@@ -35,61 +35,61 @@ package org.armedbear.lisp;
 import static org.armedbear.lisp.Lisp.*;
 
 import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
+import java.nio.IntBuffer;
 
-public final class SimpleArray_CharBuffer
+public final class SimpleArray_IntBuffer
   extends AbstractArray
 {
   private final int[] dimv;
   private final int totalSize;
+  
+  final IntBuffer data;
+  private boolean directAllocation;
 
-  final CharBuffer data;
-  boolean directAllocation; 
-
-  public SimpleArray_CharBuffer(int[] dimv) {
+  public SimpleArray_IntBuffer(int[] dimv) {
     this(dimv, false);
   }
-  
-  public SimpleArray_CharBuffer(int[] dimv, boolean directAllocation) {
+
+  public SimpleArray_IntBuffer(int [] dimv, boolean directAllocation) {
     this.dimv = dimv;
-    totalSize = computeTotalSize(dimv);
     this.directAllocation = directAllocation;
+    totalSize = computeTotalSize(dimv);
     if (directAllocation) {
-      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 2);
-      data = b.asCharBuffer();
+      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 4);
+      data = b.asIntBuffer();
     } else {
-      data = CharBuffer.allocate(totalSize);
+      data = IntBuffer.allocate(totalSize);
     }
   }
 
-  public SimpleArray_CharBuffer(int[] dimv, LispObject initialContents) {
+  public SimpleArray_IntBuffer(int[] dimv, LispObject initialContents) {
     this(dimv, initialContents, false);
   }
-  
-  public SimpleArray_CharBuffer(int[] dimv, LispObject initialContents, boolean directAllocation) {
+    
+  public SimpleArray_IntBuffer(int[] dimv, LispObject initialContents, boolean directAllocation) {
     this.dimv = dimv;
     final int rank = dimv.length;
+    this.directAllocation = directAllocation;
     LispObject rest = initialContents;
     for (int i = 0; i < rank; i++) {
       dimv[i] = rest.length();
       rest = rest.elt(0);
     }
-    this.directAllocation = directAllocation;
     totalSize = computeTotalSize(dimv);
     if (directAllocation) {
-      ByteBuffer b = ByteBuffer.allocate(totalSize * 2);
-      data = b.asCharBuffer();
-    } else { 
-      data = CharBuffer.allocate(totalSize);
+      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 4);
+      data = b.asIntBuffer();
+    } else {
+      data = IntBuffer.allocate(totalSize);
     }
+
     setInitialContents(0, dimv, initialContents, 0);
   }
 
-  public SimpleArray_CharBuffer(int rank, LispObject initialContents) {
+  public SimpleArray_IntBuffer(int rank, LispObject initialContents) {
     this(rank, initialContents, false);
   }
-
-  public SimpleArray_CharBuffer(int rank, LispObject initialContents, boolean directAllocation) {
+  public SimpleArray_IntBuffer(int rank, LispObject initialContents, boolean directAllocation) {
     if (rank < 2) {
       Debug.assertTrue(false);
     }
@@ -97,19 +97,18 @@ public final class SimpleArray_CharBuffer
     LispObject rest = initialContents;
     for (int i = 0; i < rank; i++) {
       dimv[i] = rest.length();
-      if (rest == NIL || rest.length() == 0) {
+      if (rest == NIL || rest.length() == 0)
         break;
-      }
       rest = rest.elt(0);
     }
-    this.directAllocation = directAllocation;
     totalSize = computeTotalSize(dimv);
     if (directAllocation) {
-      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 2);
-      data = b.asCharBuffer();
+      ByteBuffer b = ByteBuffer.allocateDirect(totalSize * 4);
+      data = b.asIntBuffer();
     } else {
-      data = CharBuffer.allocate(totalSize);
+      data = IntBuffer.allocate(totalSize);
     }
+        
     setInitialContents(0, dimv, initialContents, 0);
   }
 
@@ -117,7 +116,7 @@ public final class SimpleArray_CharBuffer
                                  int index) {
     if (dims.length == 0) {
       try {
-        data.put(index, coerceToJavaChar(contents));
+        data.put(index, (int)(contents.longValue() & 0xffffffffL));
       } catch (IndexOutOfBoundsException e) {
         error(new LispError("Bad initial contents for array."));
         return -1;
@@ -130,14 +129,13 @@ public final class SimpleArray_CharBuffer
         return -1;
       }
       int[] newDims = new int[dims.length-1];
-      for (int i = 1; i < dims.length; i++) {
+      for (int i = 1; i < dims.length; i++)
         newDims[i-1] = dims[i];
-      }
       if (contents.listp()) {
         for (int i = contents.length();i-- > 0;) {
           LispObject content = contents.car();
-          index
-            = setInitialContents(axis + 1, newDims, content, index);
+          index =
+            setInitialContents(axis + 1, newDims, content, index);
           contents = contents.cdr();
         }
       } else {
@@ -145,8 +143,8 @@ public final class SimpleArray_CharBuffer
         final int length = v.length();
         for (int i = 0; i < length; i++) {
           LispObject content = v.AREF(i);
-          index 
-            = setInitialContents(axis + 1, newDims, content, index);
+          index =
+            setInitialContents(axis + 1, newDims, content, index);
         }
       }
     }
@@ -155,7 +153,7 @@ public final class SimpleArray_CharBuffer
 
   @Override
   public LispObject typeOf() {
-    return list(Symbol.SIMPLE_ARRAY, UNSIGNED_BYTE_16, getDimensions());
+    return list(Symbol.SIMPLE_ARRAY, UNSIGNED_BYTE_32, getDimensions());
   }
 
   @Override
@@ -180,9 +178,8 @@ public final class SimpleArray_CharBuffer
   @Override
   public LispObject getDimensions() {
     LispObject result = NIL;
-    for (int i = dimv.length; i-- > 0;) {
+    for (int i = dimv.length; i-- > 0;)
       result = new Cons(Fixnum.getInstance(dimv[i]), result);
-    }
     return result;
   }
 
@@ -190,8 +187,7 @@ public final class SimpleArray_CharBuffer
   public int getDimension(int n) {
     try {
       return dimv[n];
-    }
-    catch (ArrayIndexOutOfBoundsException e) {
+    } catch (ArrayIndexOutOfBoundsException e) {
       error(new TypeError("Bad array dimension " + n + "."));
       return -1;
     }
@@ -199,7 +195,7 @@ public final class SimpleArray_CharBuffer
 
   @Override
   public LispObject getElementType() {
-    return UNSIGNED_BYTE_16;
+    return UNSIGNED_BYTE_32;
   }
 
   @Override
@@ -213,32 +209,22 @@ public final class SimpleArray_CharBuffer
   }
 
   @Override
-  public int aref(int index) {
-    try {
-      return data.get(index);
-    } catch (IndexOutOfBoundsException e) {
-      error(new TypeError("Bad row major index " + index + "."));
-      // Not reached.
-      return 0;
-    }
-  }
-
-  @Override
   public LispObject AREF(int index) {
     try {
-      return Fixnum.getInstance(data.get(index));
-    }
-    catch (IndexOutOfBoundsException e) {
+      return number(((long)data.get(index)) & 0xffffffffL);
+    } catch (IndexOutOfBoundsException e) {
       return error(new TypeError("Bad row major index " + index + "."));
     }
   }
 
   @Override
-  public void aset(int index, LispObject obj) {
+  public void aset(int index, LispObject newValue) {
     try {
-      data.put(index, (char)Fixnum.getValue(obj));
-    }
-    catch (IndexOutOfBoundsException e) {
+      if (newValue.isLessThan(Fixnum.ZERO) || newValue.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+        type_error(newValue, UNSIGNED_BYTE_32);
+      }
+      data.put(index, (int)(newValue.longValue() & 0xffffffffL));
+    } catch (IndexOutOfBoundsException e) {
       error(new TypeError("Bad row major index " + index + "."));
     }
   }
@@ -277,7 +263,7 @@ public final class SimpleArray_CharBuffer
   @Override
   public LispObject get(int[] subscripts) {
     try {
-      return Fixnum.getInstance(data.get(getRowMajorIndex(subscripts)));
+      return number(((long)data.get(getRowMajorIndex(subscripts))) & 0xffffffffL);
     } catch (IndexOutOfBoundsException e) {
       return error(new TypeError("Bad row major index " +
                                  getRowMajorIndex(subscripts) + "."));
@@ -285,10 +271,13 @@ public final class SimpleArray_CharBuffer
   }
 
   @Override
-  public void set(int[] subscripts, LispObject obj) {
+  public void set(int[] subscripts, LispObject newValue) {
     try {
-      data.put(getRowMajorIndex(subscripts), (char) Fixnum.getValue(obj));
-    } catch (ArrayIndexOutOfBoundsException e) {
+      if (newValue.isLessThan(Fixnum.ZERO) || newValue.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+        type_error(newValue, UNSIGNED_BYTE_32);
+      }
+      data.put(getRowMajorIndex(subscripts), (int)(newValue.longValue() & 0xffffffffL));
+    } catch (IndexOutOfBoundsException e) {
       error(new TypeError("Bad row major index " +
                           getRowMajorIndex(subscripts) + "."));
     }
@@ -296,21 +285,17 @@ public final class SimpleArray_CharBuffer
 
   @Override
   public void fill(LispObject obj) {
-    if (!(obj instanceof Fixnum)) {
-      type_error(obj, Symbol.FIXNUM);
+    if (!(obj instanceof LispInteger)) {
+      type_error(obj, Symbol.INTEGER);
       // Not reached.
       return;
     }
-    int n = ((Fixnum) obj).value;
-    if (n < 0 || n > 65535) {
-      type_error(obj, UNSIGNED_BYTE_16);
-      // Not reached.
-      return;
+    if (obj.isLessThan(Fixnum.ZERO) || obj.isGreaterThan(UNSIGNED_BYTE_32_MAX_VALUE)) {
+      type_error(obj, UNSIGNED_BYTE_32);
     }
-    for (int i = totalSize; i-- > 0;) {
-      data.put(i, (char)n);
+    for (int i = totalSize; i-- > 0;)
+      data.put(i, (int) (obj.longValue() & 0xffffffffL));;
     }
-  }
 
   @Override
   public String printObject() {
@@ -325,15 +310,17 @@ public final class SimpleArray_CharBuffer
   public AbstractArray adjustArray(int[] dimv, LispObject initialElement,
                                    LispObject initialContents) {
     if (initialContents != null) {
-      return new SimpleArray_CharBuffer(dimv, initialContents);
+      return new SimpleArray_IntBuffer(dimv, initialContents);
     }
     for (int i = 0; i < dimv.length; i++) {
       if (dimv[i] != this.dimv[i]) {
-        SimpleArray_CharBuffer newArray = new SimpleArray_CharBuffer(dimv);
+        SimpleArray_IntBuffer newArray
+          = new SimpleArray_IntBuffer(dimv, directAllocation);
         if (initialElement != null) {
           newArray.fill(initialElement);
         }
         copyArray(this, newArray);
+
         return newArray;
       }
     }
@@ -342,7 +329,7 @@ public final class SimpleArray_CharBuffer
   }
 
   // Copy a1 to a2 for index tuples that are valid for both arrays.
-  private static void copyArray(AbstractArray a1, AbstractArray a2) {
+  static void copyArray(AbstractArray a1, AbstractArray a2) {
     Debug.assertTrue(a1.getRank() == a2.getRank());
     int[] subscripts = new int[a1.getRank()];
     int axis = 0;
@@ -352,7 +339,7 @@ public final class SimpleArray_CharBuffer
   private static void copySubArray(AbstractArray a1, AbstractArray a2,
                                    int[] subscripts, int axis) {
     if (axis < subscripts.length) {
-      final int limit 
+      final int limit
         = Math.min(a1.getDimension(axis), a2.getDimension(axis));
       for (int i = 0; i < limit; i++) {
         subscripts[axis] = i;
@@ -366,7 +353,7 @@ public final class SimpleArray_CharBuffer
   }
 
   public AbstractArray adjustArray(int[] dimv, AbstractArray displacedTo,
-                                     int displacement) {
+                                   int displacement) {
     return new ComplexArray(dimv, displacedTo, displacement);
   }
 }

--- a/src/org/armedbear/lisp/SimpleArray_UnsignedByte16.java
+++ b/src/org/armedbear/lisp/SimpleArray_UnsignedByte16.java
@@ -87,7 +87,7 @@ public final class SimpleArray_UnsignedByte16 extends AbstractArray
     {
         if (dims.length == 0) {
             try {
-              data[index] = coerceLispObjectToJavaByte(contents); // This has to be wrong!
+              data[index] = coerceToJavaByte(contents); // This has to be wrong!
             }
             catch (ArrayIndexOutOfBoundsException e) {
                 error(new LispError("Bad initial contents for array."));

--- a/src/org/armedbear/lisp/SimpleArray_UnsignedByte32.java
+++ b/src/org/armedbear/lisp/SimpleArray_UnsignedByte32.java
@@ -35,6 +35,32 @@ package org.armedbear.lisp;
 
 import static org.armedbear.lisp.Lisp.*;
 
+/*
+ N.b. this implementation has problems somewhere with converting bytes
+
+      Not fixing currently, as this type is unused with NIO
+
+(let* ((unspecialized
+         #(2025373960 3099658457 3238582529 148439321
+           3099658456 3238582528 3000000000 1000000000
+           2000000000 2900000000 2400000000 2800000000
+           0 1))
+       (array 
+         (make-array (length unspecialized)
+                     :element-type '(unsigned-byte 32) 
+                     :initial-contents unspecialized)))
+  (prove:plan (length array))
+  (loop :for i :below (length array)
+        :doing
+           (let ((x0
+                   (elt unspecialized i))
+                 (x1
+                   (elt array i)))
+           (prove:ok
+            (equal x0 x1)
+            (format nil "~a: ~a equals ~a" i x0 x1)))))
+*/
+
 public final class SimpleArray_UnsignedByte32 extends AbstractArray
 {
     private final int[] dimv;

--- a/src/org/armedbear/lisp/SimpleArray_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/SimpleArray_UnsignedByte8.java
@@ -87,7 +87,7 @@ public final class SimpleArray_UnsignedByte8 extends AbstractArray
     {
         if (dims.length == 0) {
             try {
-                data[index] = coerceLispObjectToJavaByte(contents);
+                data[index] = coerceToJavaByte(contents);
             }
             catch (ArrayIndexOutOfBoundsException e) {
                 error(new LispError("Bad initial contents for array."));
@@ -194,7 +194,7 @@ public final class SimpleArray_UnsignedByte8 extends AbstractArray
     public LispObject AREF(int index)
     {
         try {
-            return coerceJavaByteToLispObject(data[index]);
+            return coerceFromJavaByte(data[index]);
         }
         catch (ArrayIndexOutOfBoundsException e) {
             return error(new TypeError("Bad row major index " + index + "."));
@@ -205,7 +205,7 @@ public final class SimpleArray_UnsignedByte8 extends AbstractArray
     public void aset(int index, LispObject newValue)
     {
         try {
-            data[index] = coerceLispObjectToJavaByte(newValue);
+            data[index] = coerceToJavaByte(newValue);
         }
         catch (ArrayIndexOutOfBoundsException e) {
             error(new TypeError("Bad row major index " + index + "."));
@@ -248,7 +248,7 @@ public final class SimpleArray_UnsignedByte8 extends AbstractArray
     public LispObject get(int[] subscripts)
     {
         try {
-            return coerceJavaByteToLispObject(data[getRowMajorIndex(subscripts)]);
+            return coerceFromJavaByte(data[getRowMajorIndex(subscripts)]);
         }
         catch (ArrayIndexOutOfBoundsException e) {
             return error(new TypeError("Bad row major index " +
@@ -261,7 +261,7 @@ public final class SimpleArray_UnsignedByte8 extends AbstractArray
 
     {
         try {
-            data[getRowMajorIndex(subscripts)] = coerceLispObjectToJavaByte(newValue);
+            data[getRowMajorIndex(subscripts)] = coerceToJavaByte(newValue);
         }
         catch (ArrayIndexOutOfBoundsException e) {
             error(new TypeError("Bad row major index " +

--- a/src/org/armedbear/lisp/make_array.java
+++ b/src/org/armedbear/lisp/make_array.java
@@ -219,7 +219,10 @@ public final class make_array
         }
         defaultInitialElement = NIL;
       }
-      if (initialElementProvided != NIL) {
+      if (nioBuffer != NIL) {
+        // v is fine…
+        ;
+      } else if (initialElementProvided != NIL) {
         // Initial element was specified.
         v.fill(initialElement);
       } else if (initialContents != NIL) {

--- a/t/byte-vectors.lisp
+++ b/t/byte-vectors.lisp
@@ -59,5 +59,23 @@
             (equal x0 x1)
             (format nil "~a: ~a equals ~a" i x0 x1)))))
 
+(prove:plan 1)
+(let*
+    ((java-array
+       (jnew-array-from-array "byte"
+                              #(0 244 2 3)))
+     (nio-buffer
+       (#"allocate" 'java.nio.ByteBuffer
+                    (jarray-length java-array))))
+  (#"put" nio-buffer java-array)
+  (let ((result
+          (make-array 4 :element-type '(unsigned-byte 8)
+                        :nio-buffer nio-buffer)))
+    (prove:ok
+     (equalp result java-array)
+     (format nil "~a EQUALP ~a" result java-array))
+    (values result java-array)))
+
+  
 (prove:finalize)
 


### PR DESCRIPTION
Still further work to do with the byte vector overhaul



- [x]   `nio-buffer` on `(unsigned-byte 8)`
- [ ]  `nio-buffer` on `(unsigned-byte 16)`
- [ ]  `nio-buffer` on `(unsigned-byte 32)`