### PR TITLE
abcl-introspect: add convenience method to read class files

### DIFF
--- a/contrib/abcl-introspect/util.lisp
+++ b/contrib/abcl-introspect/util.lisp
@@ -5,9 +5,24 @@
   "Write the Java byte[] array CLASS-BYTES to PATHNAME."
   (with-open-file (stream pathname
                           :direction :output
-                          :element-type '(signed-byte 8))
+                          :element-type '(unsigned-byte 8))
     (dotimes (i (java:jarray-length class-bytes))
       (write-byte (java:jarray-ref class-bytes i) stream))))
 
-(export '(write-class) :extensions)
+(defun read-class (pathname)
+  "Read the file at PATHNAME as a Java byte[] array"
+  (with-open-file (stream pathname
+                          :direction :input
+                          :element-type '(unsigned-byte 8))
+    (let* ((length
+             (file-length stream))
+           (array
+             (make-array length :element-type '(unsigned-byte 8))))
+      (read-sequence array stream :end length)
+      (java:jnew-array-from-array "byte" array))))
+  
+  
+(export '(write-class
+          read-class)
+        :extensions)
 


### PR DESCRIPTION
e.g.

    (abcl-introspect/jvm/tools/javap:disassemble-class-bytes
        (ext:read-class
                "~//work/abcl/build/classes/org/armedbear/lisp/run_program_60.cls"))

TODO:  shorten into generic method