### PR TITLE
Fix running openjdk11 compilation on openjdk8

### DIFF
--- a/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
@@ -87,7 +87,7 @@ public final class BasicVector_ByteBuffer
   public BasicVector_ByteBuffer(ByteBuffer buffer, boolean directAllocation) {
     elements = buffer;
     this.directAllocation = directAllocation;
-    capacity = buffer.limit();  
+    capacity = ((java.nio.Buffer)buffer).limit();  
   }
 
   @Override
@@ -155,7 +155,7 @@ public final class BasicVector_ByteBuffer
     try {
       return (((int)elements.get(index) & 0xff)); // XXX Hmmm
     } catch (IndexOutOfBoundsException e) {
-      badIndex(index, elements.limit()); 
+      badIndex(index, ((java.nio.Buffer)elements).limit()); 
       // Not reached.
       return 0;
     }
@@ -166,7 +166,7 @@ public final class BasicVector_ByteBuffer
     try {
       return coerceFromJavaByte(elements.get(index));
     } catch (IndexOutOfBoundsException e) {
-      badIndex(index, elements.limit()); 
+      badIndex(index, ((java.nio.Buffer)elements).limit()); 
       return NIL; // Not reached.
     }
   }
@@ -194,8 +194,8 @@ public final class BasicVector_ByteBuffer
     // ??? Do we need to check that start, end are valid?
     BasicVector_ByteBuffer v = new BasicVector_ByteBuffer(end - start, directAllocation);
     ByteBuffer view = elements.asReadOnlyBuffer();
-    view.position(start);
-    view.limit(end);
+    ((java.nio.Buffer)view).position(start);
+    ((java.nio.Buffer)view).limit(end);
     try {
       v.elements.put(view);
       return v;
@@ -230,7 +230,7 @@ public final class BasicVector_ByteBuffer
     // use the java.nio.Buffer limit pointer.  Not totally sure that
     // this strategy will work out…
     if (n < length()) {
-        elements.limit(n);
+        ((java.nio.Buffer)elements).limit(n);
         capacity = n;
         return;
     }

--- a/src/org/armedbear/lisp/BasicVector_CharBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_CharBuffer.java
@@ -76,13 +76,13 @@ public final class BasicVector_CharBuffer
   public BasicVector_CharBuffer(ByteBuffer buffer, boolean directAllocation) {
     elements = buffer.asCharBuffer();
     this.directAllocation = directAllocation;
-    capacity = buffer.limit();
+    capacity = ((java.nio.Buffer)buffer).limit();
   }
 
   public BasicVector_CharBuffer(CharBuffer buffer, boolean directAllocation) {
     elements = buffer;
     this.directAllocation = directAllocation;
-    capacity = buffer.limit();
+    capacity = ((java.nio.Buffer)buffer).limit();
   }
 
   @Override
@@ -151,7 +151,7 @@ public final class BasicVector_CharBuffer
     try {
       return elements.get(index);
     } catch (ArrayIndexOutOfBoundsException e) {
-      badIndex(index, elements.limit()); // FIXME should implement method for length() contract
+      badIndex(index, ((java.nio.Buffer)elements).limit()); // FIXME should implement method for length() contract
       // Not reached.
       return 0;
     }
@@ -163,7 +163,7 @@ public final class BasicVector_CharBuffer
     try {
       return Fixnum.getInstance(elements.get(index));
     } catch (IndexOutOfBoundsException e) {
-      badIndex(index, elements.limit());  // FIXME limit() --> capacity?
+      badIndex(index, ((java.nio.Buffer)elements).limit());  // FIXME limit() --> capacity?
       return NIL; // Not reached.
     }
   }
@@ -230,7 +230,7 @@ public final class BasicVector_CharBuffer
     // shouldn't touch, so use the java.nio.Buffer limit pointer.
     // Not totally sure that this strategy will work out…
     if (n < length()) {
-      elements.limit(n);
+      ((java.nio.Buffer)elements).limit(n);
       capacity = n;
       return;
     }

--- a/src/org/armedbear/lisp/BasicVector_IntBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_IntBuffer.java
@@ -79,13 +79,13 @@ public final class BasicVector_IntBuffer
   public BasicVector_IntBuffer(ByteBuffer buffer, boolean directAllocation) {
     this.directAllocation = directAllocation;
     elements = buffer.asIntBuffer();
-    capacity = buffer.limit();
+    capacity = ((java.nio.Buffer)buffer).limit();
   }
 
   public BasicVector_IntBuffer(IntBuffer buffer) {
     this.directAllocation = directAllocation;
     elements = buffer;
-    capacity = buffer.limit();
+    capacity = ((java.nio.Buffer)buffer).limit();
   }
 
   @Override
@@ -154,7 +154,7 @@ public final class BasicVector_IntBuffer
       // FIXME: this shouldn't be used?  
       return number(((long)elements.get(index)) & 0xffffffffL).intValue(); 
     } catch (IndexOutOfBoundsException e) {
-      badIndex(index, elements.limit()); 
+      badIndex(index, ((java.nio.Buffer)elements).limit()); 
       return -1; // Not reached.
     }
   }
@@ -164,7 +164,7 @@ public final class BasicVector_IntBuffer
     try {
       return ((long)elements.get(index)) & 0xffffffffL;
     } catch (IndexOutOfBoundsException e) {
-      badIndex(index, elements.limit());
+      badIndex(index, ((java.nio.Buffer)elements).limit());
       return -1; // Not reached.
     }
   }
@@ -174,7 +174,7 @@ public final class BasicVector_IntBuffer
     try {
       return number(((long)elements.get(index)) & 0xffffffffL);
     } catch (IndexOutOfBoundsException e) {
-      badIndex(index, elements.limit());
+      badIndex(index, ((java.nio.Buffer)elements).limit());
       return NIL; // Not reached.
     }
   }
@@ -228,7 +228,7 @@ public final class BasicVector_IntBuffer
       // the elements field may refer to malloc()d memory that we
       // shouldn't touch, so use the java.nio.Buffer limit pointer.
       // Not totally sure that this strategy will work out…
-      elements.limit(n);
+      ((java.nio.Buffer)elements).limit(n);
       capacity = n;
       return;
     }

--- a/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
@@ -249,7 +249,7 @@ public final class ComplexArray_ByteBuffer
       return;
     }
     if (data != null) {
-      for (int i = data.limit(); i-- > 0;)
+      for (int i = ((java.nio.Buffer)data).limit(); i-- > 0;)
         data.put(i, (byte) n); // FIXME Faster!!
     } else {
       for (int i = totalSize; i-- > 0;)
@@ -278,7 +278,7 @@ public final class ComplexArray_ByteBuffer
 
   // FIXME move me to someplace more general
   public static void fill(ByteBuffer buffer, byte value) {
-    for (int i = 0; i < buffer.limit(); i++) {
+    for (int i = 0; i < ((java.nio.Buffer)buffer).limit(); i++) {
       buffer.put(value);
     }
   }

--- a/src/org/armedbear/lisp/ComplexArray_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_IntBuffer.java
@@ -239,7 +239,7 @@ public final class ComplexArray_IntBuffer
       type_error(obj, UNSIGNED_BYTE_32);
     }
     if (data != null) {
-      for (int i = data.limit(); i-- > 0;) {
+      for (int i = ((java.nio.Buffer)data).limit(); i-- > 0;) {
         data.put(i, (int) (obj.longValue() & 0xffffffffL));;
       }
     } else {

--- a/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
@@ -191,7 +191,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
       try {
         return coerceFromJavaByte(elements.get(index));
       } catch (ArrayIndexOutOfBoundsException e) {
-        badIndex(index, elements.limit());
+        badIndex(index, ((java.nio.Buffer)elements).limit());
         return NIL; // Not reached.
       }
     } else {
@@ -228,7 +228,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
       try {
         elements.put(index, coerceToJavaByte(newValue));
       } catch (IndexOutOfBoundsException e) {
-        badIndex(index, elements.limit());
+        badIndex(index, ((java.nio.Buffer)elements).limit());
       }
     } else {
       array.aset(index + displacement, newValue);
@@ -272,11 +272,11 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
     // One cannot shrink the underlying ByteBuffer physically, so
     // use the limit marker to denote the length
     if (n < length()) {
-      elements.limit(n);
+      ((java.nio.Buffer)elements).limit(n);
       this.capacity = n;
       return;
     }
-    if (n == elements.limit()) { 
+    if (n == ((java.nio.Buffer)elements).limit()) { 
       return;
     }
     error(new LispError());

--- a/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
@@ -184,7 +184,7 @@ public final class ComplexVector_IntBuffer
       try {
         return number(((long)elements.get(index)) & 0xffffffffL);
       } catch (IndexOutOfBoundsException e) {
-        badIndex(index, elements.limit());
+        badIndex(index, ((java.nio.Buffer)elements).limit());
         return NIL; // Not reached.
       }
     } else {
@@ -206,7 +206,7 @@ public final class ComplexVector_IntBuffer
       try {
         elements.put(index, (int)(newValue.longValue() & 0xffffffffL));
       } catch (IndexOutOfBoundsException e) {
-        badIndex(index, elements.limit());
+        badIndex(index, ((java.nio.Buffer)elements).limit());
       }
     } else {
       // Displaced array.
@@ -252,11 +252,11 @@ public final class ComplexVector_IntBuffer
     // One cannot shrink the underlying ByteBuffer physically, so
     // use the limit marker to denote the length
     if (n < length()) {
-      elements.limit(n);
+      ((java.nio.Buffer)elements).limit(n);
       this.capacity = n;
       return;
     }
-    if (n == elements.limit()) {
+    if (n == ((java.nio.Buffer)elements).limit()) {
       return;
     }
     error(new LispError());

--- a/src/org/armedbear/lisp/util/DecodingReader.java
+++ b/src/org/armedbear/lisp/util/DecodingReader.java
@@ -84,7 +84,7 @@ public class DecodingReader
         this.cd.onMalformedInput(CodingErrorAction.REPLACE);
         this.ce = cs.newEncoder();
         bbuf = ByteBuffer.allocate(size);
-        bbuf.flip();  // mark the buffer as 'needs refill'
+        ((java.nio.Buffer)bbuf).flip();  // mark the buffer as 'needs refill'
     }
 
     /** Change the Charset used to decode bytes from the input stream
@@ -173,23 +173,23 @@ public class DecodingReader
         ByteBuffer tb = // temp buffer
             ce.encode(CharBuffer.wrap(cbuf, off, len));
 
-        if (tb.limit() > bbuf.position()) {
+        if (tb.limit() > ((java.nio.Buffer)bbuf).position()) {
             // unread bbuf into the pushback input stream
             // in order to free up space for the content of 'tb'
-            for (int i = bbuf.limit(); i-- > bbuf.position(); )
+	    for (int i = ((java.nio.Buffer)bbuf).limit(); i-- > ((java.nio.Buffer)bbuf).position(); )
                 stream.unread(bbuf.get(i));
 
-            bbuf.clear();
+            ((java.nio.Buffer)bbuf).clear();
             ce.encode(CharBuffer.wrap(cbuf, off, len), bbuf, true);
-            bbuf.flip();
+            ((java.nio.Buffer)bbuf).flip();
         } else {
             // Don't unread bbuf, since tb will fit in front of the
             // existing data
-            int j = bbuf.position() - 1;
-            for (int i = tb.limit(); i-- > 0; j--) // two-counter loop
+	  int j = ((java.nio.Buffer)bbuf).position() - 1;
+            for (int i = ((java.nio.Buffer)tb).limit(); i-- > 0; j--) // two-counter loop
                 bbuf.put(j, tb.get(i));
 
-            bbuf.position(j+1);
+            ((java.nio.Buffer)bbuf).position(j+1);
         }
     }
 
@@ -214,12 +214,12 @@ public class DecodingReader
             int c = stream.read(by);
 
             if (c < 0) {
-                bbuf.flip();  // prepare bbuf for reading
+	        ((java.nio.Buffer)bbuf).flip();  // prepare bbuf for reading
                 return false;
             }
 
             bbuf.put(by, 0, c);
-            bbuf.flip();
+            ((java.nio.Buffer)bbuf).flip();
         }
         return true;
     }


### PR DESCRIPTION
Seemingly, the openjdk11 compiler optimizes the call to
java.nio.Buffer.flip() in to be directly on the java.nio.ByteBuffer
type.  We fixed other instances of java.nio.Buffer interfaces to the
point of being able to run the ANSI-TEST suite.


This caused errors such as:

      Exception in thread "interpreter" java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
      at org.armedbear.lisp.util.DecodingReader.<init>(DecodingReader.java:87)
      at org.armedbear.lisp.Stream.<init>(Stream.java:165)
      at org.armedbear.lisp.Stream.<init>(Stream.java:148)