### PR TITLE
Feature: serialization of functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ abcl
 abcl-test*log
 ext
 scratch
+.idea/
+*.iml
+target/
 \#*\#
 \.\#*

--- a/abcl.asd
+++ b/abcl.asd
@@ -57,7 +57,9 @@
                          #+abcl
                          (:file "runtime-class")
                          #+abcl
-                         (:file "package-local-nicknames-tests")))))
+                         (:file "package-local-nicknames-tests")
+                         #+abcl
+                         (:file "closure-serialization")))))
 
 ;;; FIXME Currently requires ACBL-CONTRIB and QUICKLISP-ABCL to be
 ;;; loaded, but can't seem to put in the :defsystem-depends-on stanza

--- a/build.xml
+++ b/build.xml
@@ -1059,6 +1059,7 @@ ${basedir}/../cl-bench
         <arg value="org.armedbear.lisp.StreamTest"/>
         <arg value="org.armedbear.lisp.SeekableStringWriterTest"/>
         <arg value="org.armedbear.lisp.UtilitiesTest"/>
+        <arg value="org.armedbear.lisp.serialization.SerializationTest"/>
 		<!-- currently hangs(!) the running process
         <arg value="org.armedbear.lisp.util.HttpHeadTest"/>
 		-->

--- a/src/org/armedbear/lisp/ArgumentListProcessor.java
+++ b/src/org/armedbear/lisp/ArgumentListProcessor.java
@@ -805,7 +805,7 @@ public class ArgumentListProcessor implements Serializable {
    * - KeywordParam
    * - AuxParam
    * */
-  public static abstract class Param {
+  public static abstract class Param implements Serializable {
       
       /** Assigns values to be bound to the correcsponding variables to the
        * array, using 'index' as the next free slot, consuming any required

--- a/src/org/armedbear/lisp/ArgumentListProcessor.java
+++ b/src/org/armedbear/lisp/ArgumentListProcessor.java
@@ -34,6 +34,7 @@
 
 package org.armedbear.lisp;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.ArrayList;
 import static org.armedbear.lisp.Lisp.*;
@@ -43,7 +44,7 @@ import static org.armedbear.lisp.Lisp.*;
  * The lambda list may either be of type ORDINARY or MACRO lambda list.
  * All other lambda lists are parsed elsewhere in our code base.
  */
-public class ArgumentListProcessor {
+public class ArgumentListProcessor implements Serializable {
     
   public enum LambdaListType {
       ORDINARY,
@@ -561,7 +562,7 @@ public class ArgumentListProcessor {
   /** Internal class implementing the argument list to lambda list matcher.
    * Because we have two implementations - a fast one and a slower one - we
    * need this abstract super class */
-  private static abstract class ArgumentMatcher {
+  private static abstract class ArgumentMatcher implements Serializable {
       abstract LispObject[] match(LispObject[] args, Environment _environment,
               Environment env, LispThread thread);
   }

--- a/src/org/armedbear/lisp/Binding.java
+++ b/src/org/armedbear/lisp/Binding.java
@@ -33,12 +33,14 @@
 
 package org.armedbear.lisp;
 
+import java.io.Serializable;
+
 /** Used by the environment to capture different kinds of bindings:
  * tags, blocks, functions and variables.
  *
  */
 // Package accessibility.
-final class Binding
+final class Binding implements Serializable
 {
     /** The symbol in case of a variable, block, symbol-macro or
      * non-SETF function binding, the tag (symbol or

--- a/src/org/armedbear/lisp/Closure.java
+++ b/src/org/armedbear/lisp/Closure.java
@@ -229,4 +229,11 @@ public class Closure extends Function
   {
     return arglist.match(args, environment, environment, thread);
   }
+
+  //Serialization
+
+  @Override
+  protected boolean shouldSerializeByName() {
+    return false; //Closures have an environment that we must serialize, even if they're top-level function
+  }
 }

--- a/src/org/armedbear/lisp/ClosureBinding.java
+++ b/src/org/armedbear/lisp/ClosureBinding.java
@@ -33,6 +33,8 @@
 
 package org.armedbear.lisp;
 
+import java.io.Serializable;
+
 /** This class serves merely to store a reference to an
  * object, used in the closure array.
  *
@@ -40,7 +42,7 @@ package org.armedbear.lisp;
  * closures close over bindings and not over values.
  *
  */
-public class ClosureBinding
+public class ClosureBinding implements Serializable
 {
     public LispObject value;
 

--- a/src/org/armedbear/lisp/Environment.java
+++ b/src/org/armedbear/lisp/Environment.java
@@ -33,9 +33,11 @@
 
 package org.armedbear.lisp;
 
+import java.io.Serializable;
+
 import static org.armedbear.lisp.Lisp.*;
 
-public final class Environment extends LispObject
+public final class Environment extends LispObject implements Serializable
 {
   Binding vars;
   FunctionBinding lastFunctionBinding;

--- a/src/org/armedbear/lisp/Function.java
+++ b/src/org/armedbear/lisp/Function.java
@@ -51,7 +51,8 @@ public abstract class Function extends Operator implements Serializable {
 
     protected Function() {
 	LispObject loadTruename = Symbol.LOAD_TRUENAME.symbolValueNoThrow();
-	loadedFrom = loadTruename != null ? loadTruename : NIL;
+	LispObject loadTruenameFasl = Symbol.LOAD_TRUENAME_FASL.symbolValueNoThrow();
+	loadedFrom = loadTruenameFasl != null ? loadTruenameFasl : (loadTruename != null ? loadTruename : NIL);
     }
 
     public Function(String name)

--- a/src/org/armedbear/lisp/FunctionBinding.java
+++ b/src/org/armedbear/lisp/FunctionBinding.java
@@ -33,8 +33,10 @@
 
 package org.armedbear.lisp;
 
+import java.io.Serializable;
+
 // Package accessibility.
-final class FunctionBinding
+final class FunctionBinding implements Serializable
 {
     LispObject name;
     LispObject value;

--- a/src/org/armedbear/lisp/JavaObject.java
+++ b/src/org/armedbear/lisp/JavaObject.java
@@ -35,12 +35,13 @@ package org.armedbear.lisp;
 
 import static org.armedbear.lisp.Lisp.*;
 
+import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.util.*;
 
-public final class JavaObject extends LispObject {
+public final class JavaObject extends LispObject implements Serializable {
     final Object obj;
     private final Class<?> intendedClass;
 

--- a/src/org/armedbear/lisp/MemoryClassLoader.java
+++ b/src/org/armedbear/lisp/MemoryClassLoader.java
@@ -144,7 +144,7 @@ public class MemoryClassLoader extends JavaClassLoader {
         }
     };
 
-    private static final Primitive PUT_MEMORY_FUNCTION = new pf_put_memory_function();
+    public static final Primitive PUT_MEMORY_FUNCTION = new pf_put_memory_function();
     private static final class pf_put_memory_function extends Primitive {
         pf_put_memory_function() {
             super("put-memory-function", PACKAGE_SYS, false, "loader class-name class-bytes");

--- a/src/org/armedbear/lisp/Pathname.java
+++ b/src/org/armedbear/lisp/Pathname.java
@@ -34,10 +34,7 @@ package org.armedbear.lisp;
 
 import static org.armedbear.lisp.Lisp.*;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.FileInputStream;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -50,7 +47,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
 
-public class Pathname extends LispObject {
+public class Pathname extends LispObject implements Serializable {
 
     /** The path component separator used by internally generated
      * path namestrings.

--- a/src/org/armedbear/lisp/Primitives.java
+++ b/src/org/armedbear/lisp/Primitives.java
@@ -36,6 +36,7 @@ package org.armedbear.lisp;
 
 import static org.armedbear.lisp.Lisp.*;
 
+import java.io.Serializable;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import org.armedbear.lisp.util.Finalizer;
@@ -3719,6 +3720,8 @@ public final class Primitives {
     };
 
     // ### block
+    private static class BlockMarker extends LispObject implements Serializable {}
+
     private static final SpecialOperator BLOCK = new sf_block();
     private static final class sf_block extends SpecialOperator {
         sf_block() {
@@ -3735,7 +3738,7 @@ public final class Primitives {
             tag = checkSymbol(args.car());
             LispObject body = ((Cons)args).cdr();
             Environment ext = new Environment(env);
-            final LispObject block = new LispObject();
+            final LispObject block = new BlockMarker();
             ext.addBlock(tag, block);
             LispObject result = NIL;
             final LispThread thread = LispThread.currentThread();

--- a/test/lisp/abcl/closure-serialization.lisp
+++ b/test/lisp/abcl/closure-serialization.lisp
@@ -1,0 +1,36 @@
+;;; compiler-tests.lisp
+;;;
+;;; Copyright (C) 2010 Erik Huelsmann
+;;;
+;;; $Id$
+;;;
+;;; This program is free software; you can redistribute it and/or
+;;; modify it under the terms of the GNU General Public License
+;;; as published by the Free Software Foundation; either version 2
+;;; of the License, or (at your option) any later version.
+;;;
+;;; This program is distributed in the hope that it will be useful,
+;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;;; GNU General Public License for more details.
+;;;
+;;; You should have received a copy of the GNU General Public License
+;;; along with this program; if not, write to the Free Software
+;;; Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+(in-package #:abcl.test.lisp)
+(require '#:java)
+
+(defun f (x)
+  (flet ((g (y) (cons x y)))
+    (let* ((b (java:jnew "java.io.ByteArrayOutputStream"))
+           (o (java:jnew "java.io.ObjectOutputStream" b)))
+      (java:jcall "writeObject" o #'g)
+      (java:jcall "flush" o)
+      (java:jcall "toByteArray" b))))
+
+(deftest serialization-of-closure
+    (let* ((b (java:jnew "java.io.ByteArrayInputStream" (f 3)))
+    	   (i (java:jnew "java.io.ObjectInputStream" b)))
+      (fmakunbound 'f)
+      (java:jcall "readObject" i))
+  T)

--- a/test/lisp/abcl/closure-serialization.lisp
+++ b/test/lisp/abcl/closure-serialization.lisp
@@ -32,5 +32,5 @@
     (let* ((b (java:jnew "java.io.ByteArrayInputStream" (f 3)))
     	   (i (java:jnew "java.io.ObjectInputStream" b)))
       (fmakunbound 'f)
-      (java:jcall "readObject" i))
-  T)
+      (funcall (java:jcall "readObject" i) T))
+  '(3 . T))

--- a/test/src/org/armedbear/lisp/serialization/SerializationTest.java
+++ b/test/src/org/armedbear/lisp/serialization/SerializationTest.java
@@ -45,7 +45,30 @@ public class SerializationTest {
 
         ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
         Object readObject = ois.readObject();
-        assertEquals(readObject, closure);
+        assertTrue(readObject instanceof Closure);
+        assertEquals(NIL, ((Closure) readObject).execute());
+    }
+
+    @Test
+    public void testSerializationOfLocalClosure() throws Exception {
+        Symbol symbol = new Symbol("test");
+        LispObject lambda_expression =
+                new Cons(Symbol.LAMBDA, new Cons(NIL, new Cons(symbol)));
+        LispObject lambda_name =
+                list(Symbol.FLET, new Symbol("test"));
+        Environment env = new Environment();
+        env.bind(symbol, new SimpleString("OK"));
+        Closure closure =
+                new Closure(lambda_name, lambda_expression, env);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(closure);
+
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        Object readObject = ois.readObject();
+        assertTrue(readObject instanceof Closure);
+        assertEquals("OK", ((Closure) readObject).execute().toString());
     }
 
 }

--- a/test/src/org/armedbear/lisp/serialization/SerializationTest.java
+++ b/test/src/org/armedbear/lisp/serialization/SerializationTest.java
@@ -1,0 +1,51 @@
+package org.armedbear.lisp.serialization;
+
+import org.armedbear.lisp.*;
+
+import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+
+import static org.armedbear.lisp.Lisp.NIL;
+import static org.armedbear.lisp.Lisp.list;
+import static org.junit.Assert.*;
+
+public class SerializationTest {
+
+    @Test
+    public void testSerializationOfBuiltInFunction() throws Exception {
+        Field declaredField = Primitives.class.getDeclaredField("CONS");
+        declaredField.setAccessible(true);
+        Object consFunction = declaredField.get(null);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(consFunction);
+
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        Object readObject = ois.readObject();
+        assertEquals(readObject, consFunction);
+    }
+
+    @Test
+    public void testSerializationOfLocalFunction() throws Exception {
+        LispObject lambda_expression =
+                new Cons(Symbol.LAMBDA, new Cons(NIL, NIL));
+        LispObject lambda_name =
+                list(Symbol.FLET, new Symbol("test"));
+        Closure closure =
+                new Closure(lambda_name, lambda_expression, new Environment());
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(closure);
+
+        ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        Object readObject = ois.readObject();
+        assertEquals(readObject, closure);
+    }
+
+}


### PR DESCRIPTION
This implements serialization for functions:
- top-level and local
- interpreted and compiled
- closures included (provided closed-over objects are themselves serializable, of course)

Notable points worth a second look: I changed how loadedFrom is computed for functions loaded from FASLs, recording the fasl truename if present. Using *load-truename* only would break reading function class bytes for serialization (but also for disassembly).

A few (pretty minimal) tests are provided in Java and in Lisp.

What's missing:
- Test serialization/deserialization across ABCL images
  - Inlcuding re-serializing a deserialized function on a different image (could depend from a FASL that doesn't exist on the receiving image/machine, we should simulate that in a test)
- Test serialization/deserialization of mutually recursive local functions

Additional notes: getClassBytes for (local) functions loaded from a FASL depends on such FASL being still present when the function is disassembled or serialized. Top-level functions instead always carry the bytes with them. Maybe we should treat them uniformly according to a flag: *function-bytecode-strategy* which could be :load-time, :lazy or :disabled/nil. This could be used to reduce the footprint of functions that you don't want to disassemble or serialize, or to pre-load the bytes (saving disk reads) if you intend to serialize a function from the start.