### PR TITLE
Change CL:DIRECTORY to use CL:PATHNAME-MATCH-P

### DIFF
--- a/src/org/armedbear/lisp/directory.lisp
+++ b/src/org/armedbear/lisp/directory.lisp
@@ -96,6 +96,14 @@
                             resolve-symlinks)))))))
                      entries)))))
 
+;;; The extension to ANSI via :RESOLVE-SYMLINKS was added as
+;;; <https://abcl.org/trac/ticket/340>, in which it was argued that
+;;; symlinks should be considered contents of a directory, and that in
+;;; any event, performing a DIRECTORY on a dangling symlink should not
+;;; signal an error.
+;;;
+;;; See <https://abcl.org/trac/changeset/14624> for additional
+;;; information on implementation decision.
 (defun directory (pathspec &key (resolve-symlinks nil))
   "Determines which, if any, files that are present in the file system have names matching PATHSPEC, and returns a fresh list of pathnames corresponding to the potential truenames of those files.  
 
@@ -132,16 +140,9 @@ error to its caller."
                              (concatenate 'string device ":" namestring))))))
                 (let ((entries (list-directories-with-wildcards 
                                 namestring nil resolve-symlinks))
-                      (matching-entries ()))
+                      matching-entries)
                   (dolist (entry entries)
-                    (when 
-                        (or 
-                         (and 
-                          (file-directory-p entry :wild-error-p nil)
-                          (pathname-match-p (file-namestring (pathname-as-file entry)) 
-                                            (file-namestring pathname)))
-                         (pathname-match-p (or (file-namestring entry) "") 
-                                           (file-namestring pathname)))
+                    (when (pathname-match-p entry pathname)
                       (push 
                        (if resolve-symlinks
                            (truename entry) 

--- a/src/org/armedbear/lisp/pathnames.lisp
+++ b/src/org/armedbear/lisp/pathnames.lisp
@@ -55,11 +55,13 @@
   (let ((testfunc (if ignore-case #'equalp #'equal)))
     (labels ((split-string (delim str)
 	       (flet ((finder (char) (find char delim)))
-		 (loop  for x = (position-if-not #'finder str) then
-		      (position-if-not #'finder str :start (or y (length str)))
-		    for y = (position-if #'finder str :start x) then
-		      (position-if #'finder str :start (or x (length str))) while x 
-		    collect (subseq str x y))))
+		 (loop
+                   :for x = (position-if-not #'finder str)
+                     :then (position-if-not #'finder str :start (or y (length str)))
+		   :for y = (position-if #'finder str :start (or x (length str)))
+                     :then (position-if #'finder str :start (or x (length str)))
+                   :while x 
+		    :collect (subseq str x y))))
 	     (positions-larger (thing substrings previous-pos)
 	       (let ((new-pos (search (car substrings) 
 				      thing 


### PR DESCRIPTION
CL:DIRECTORY was only matching on the name and type portions of a file
which was just wrong.

Fix the internally used SYS::COMPONENT-MATCH-WILD-P to work on
wildcards constisting of only #\* characters.

<https://abcl.org/trac/ticket/472>