### PR TITLE
Allow for java.version that reports an integer

### DIFF
--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2415,7 +2415,11 @@ public final class Lisp
           platformVersion = javaVersion.substring(2, i);
         } else {
           int i = javaVersion.indexOf(".");
-          platformVersion = javaVersion.substring(0, i);
+          if (i >= 0) {
+            platformVersion = javaVersion.substring(0, i);
+          } else {
+            platformVersion = javaVersion;
+          }
       }
       featureList = featureList.push(internKeyword("JAVA-" + platformVersion));
     }


### PR DESCRIPTION
Needed for running openjdk15 GA release <https://jdk.java.net/15/>.

Use configuration options for openjdk14.  

Subjectively seems rather zippier.  