### PR TITLE
Patches and CI changes for running on openjdk15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
 env:
   - ABCL_JDK=openjdk8  ABCL_ROOT=${TRAVIS_BUILD_DIR}
   - ABCL_JDK=openjdk11 ABCL_ROOT=${TRAVIS_BUILD_DIR}
-  - ABCL_JDK=openjdk14 ABCL_ROOT=${TRAVIS_BUILD_DIR}
+  - ABCL_JDK=openjdk15 ABCL_ROOT=${TRAVIS_BUILD_DIR}
 
 install:
   - echo PWD=$(pwd) && echo ABCL_ROOT=${ABCL_ROOT}

--- a/build.xml
+++ b/build.xml
@@ -1270,7 +1270,15 @@ JVM System Properties
         <arg value="openjdk14"/>
       </exec>
     </target>
-  
+
+    <target name="abcl.properties.autoconfigure.openjdk.15">
+      <exec executable="/usr/bin/env">
+        <arg value="bash"/>
+        <arg value="ci/create-abcl-properties.bash"/>
+        <arg value="openjdk15"/>
+      </exec>
+    </target>
+
     <import file="etc/ant/netbeans-build.xml"
             optional="true"/> 
     <import file="etc/ant/build-snapshot.xml"

--- a/ci/create-abcl-properties.bash
+++ b/ci/create-abcl-properties.bash
@@ -52,6 +52,11 @@ case $jdk in
 	abcl_javac_target=14
 	abcl_javac_source=1.8
         ;;
+    15|openjdk15)
+        options="-XX:CompileThreshold=10 ${zgc}"
+	abcl_javac_target=15
+	abcl_javac_source=1.8
+        ;;
 esac
 
 cat ${root}/abcl.properties.in \

--- a/ci/install-adoptjdk.bash
+++ b/ci/install-adoptjdk.bash
@@ -28,7 +28,11 @@ function determine_adoptjdk() {
                     topdir=jdk-14.0.2+12
                     dist="https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_mac_hotspot_14.0.2_12.tar.gz"
                     ;;
-            esac
+                openjdk15)
+                    topdir=jdk-15+36
+                    dist="https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15%2B36/OpenJDK15U-jdk_x64_mac_hotspot_15_36.tar.gz"
+                    ;;
+esac
             ;;
         Linux)
             case $jdk in
@@ -44,7 +48,11 @@ function determine_adoptjdk() {
                     topdir=jdk-14.0.2+12
                     dist="https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz"
                     ;;
-            esac
+                openjdk15)
+                    topdir=jdk-15+36
+                    dist="https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15%2B36/OpenJDK15U-jdk_x64_linux_hotspot_15_36.tar.gz"
+                    ;;
+esac
             ;;
         *)
             echo No known dist for $(uname)
@@ -81,10 +89,3 @@ add_jdk
 . ${DIR}/set-jdk.bash
 
 jenv doctor
-
-
-
-
-
-
-

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2415,7 +2415,11 @@ public final class Lisp
           platformVersion = javaVersion.substring(2, i);
         } else {
           int i = javaVersion.indexOf(".");
-          platformVersion = javaVersion.substring(0, i);
+          if (i >= 0) {
+            platformVersion = javaVersion.substring(0, i);
+          } else {
+            platformVersion = javaVersion;
+          }
       }
       featureList = featureList.push(internKeyword("JAVA-" + platformVersion));
     }


### PR DESCRIPTION
Use openjdk15 as latest version instead of openjdk14 under Travis CI.

Allow for java.version that reports an integer without a patchlevel
which is needed for running openjdk15.