### PR TITLE
Fix VECTOR-PUSH-EXTEND for (UNSIGNED-BYTE 8)

### DIFF
--- a/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
@@ -373,6 +373,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
           newBuffer = ByteBuffer.allocateDirect(minCapacity);
         } else { 
           newBuffer = ByteBuffer.allocate(minCapacity);
+        }
         newBuffer.put(elements); 
         elements = newBuffer;
         capacity = minCapacity;
@@ -397,7 +398,6 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
         array = null;
         displacement = 0;
         isDisplaced = false;
-      }
       }
     }
   }


### PR DESCRIPTION
Fixes ANSI test VECTOR-PUSH-EXTEND.26 which was broken in the overhaul
of specialized byte arrays.