### PR TITLE
build: make building and running a local ABCL easier

### DIFF
--- a/abcl.properties.in
+++ b/abcl.properties.in
@@ -8,9 +8,9 @@ abcl.build.incremental=true
 
 ## javac compiler options for ABCL build
 # generate class files for this target JVM
-abcl.javac.target=1.8
+#ant.build.javac.target=1.8
 # specify Java source compatiblity level
-abcl.javac.source=1.6
+#ant.build.javac.source=1.6
 
 ## Additional site specific startup code to be merged in 'system.lisp' at build time
 #abcl.startup.file=${basedir}/startup.lisp

--- a/build.xml
+++ b/build.xml
@@ -193,11 +193,18 @@ For help on the automatic tests available, use the Ant target 'help.test'.
       </echo>
     </target>
 
-    <!-- For compiling beyond openjdk11, one needs to increment these values in <file:abcl.properties> -->
-    <property name="abcl.javac.target"
-              value="1.6"/>
-    <property name="abcl.javac.source"
-              value="1.6"/>
+    <!-- The Java compilation options are perhaps underspecified in
+         terms of the target JVM in order to support a developer who
+         simply wants to compile and run locally with least hassles.
+	 
+	 When preparing ABCL binaries for wider distribution, the
+	 values of the abcl.build.target.javac and
+	 abcl.build.source.java become more important.  
+
+         The 'abcl.properties.autoconfigure.*' targets use the
+         ci/create-build-properties.bash script to set these options
+         for various openjdk platforms.
+    -->
 
     <target name="abcl.compile.java" 
             depends="abcl.init,abcl.java.warning">
@@ -205,8 +212,6 @@ For help on the automatic tests available, use the Ant target 'help.test'.
       <mkdir dir="${build.classes.dir}"/>
       <javac destdir="${build.classes.dir}"
              debug="true"
-             target="${abcl.javac.target}"
-             source="${abcl.javac.source}"
              includeantruntime="false"
              encoding="UTF-8"
              failonerror="true">
@@ -1218,7 +1223,7 @@ JVM System Properties
 </target>
 
     <target name="abcl.release" 
-            depends="abcl.clean,abcl.binary.tar,abcl.source.tar,abcl.binary.zip,abcl.source.zip">
+            depends="abcl.clean,abcl.properties.autoconfigure.openjdk.8,abcl.binary.tar,abcl.source.tar,abcl.binary.zip,abcl.source.zip,abcl.wrapper">
       <copy file="${abcl.jar.path}"
             tofile="${dist.dir}/abcl-${abcl.version}.jar"/>
       <copy file="${abcl-contrib.jar}"

--- a/ci/create-abcl-properties.awk
+++ b/ci/create-abcl-properties.awk
@@ -1,4 +1,4 @@
 /^java.options/ {print $0 " " options; next}
-/^abcl.javac.target/ {print "abcl.javac.target=" target; next}
-/^abcl.javac.source/ {print "abcl.javac.source=" source; next}
+/ant.build.javac.target/ {print "ant.build.javac.target=" target; next}
+/ant.build.javac.source/ {print "ant.build.javac.source=" source; next}
 {print $0}

--- a/ci/create-abcl-properties.bash
+++ b/ci/create-abcl-properties.bash
@@ -18,52 +18,52 @@ abcl_javac_source=1.8
 case $jdk in
     6|openjdk6)
         options="-d64 -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=1g -XX:+UseConcMarkSweepGC"
-        abcl_javac_target=1.6
-	abcl_javac_source=1.6
+        ant_build_javac_target=1.6
+	ant_build_javac_source=1.6
         ;;
     7|openjdk7)
 	options="-d64 -XX:+UseG1GC"
-        abcl_javac_target=1.7
-	abcl_javac_source=1.7
+        ant_build_javac_target=1.7
+	ant_build_javac_source=1.7
 	;;
     8|openjdk8)
         options="-XX:+UseG1GC -XX:+AggressiveOpts -XX:CompileThreshold=10"
-	abcl_javac_target=1.8
-	abcl_javac_source=1.8
+	ant_build_javac_target=1.8
+	ant_build_javac_source=1.8
         ;;
     11|openjdk11)
         options="-XX:CompileThreshold=10"
-	abcl_javac_target=11
-	abcl_javac_source=1.8
+	ant_build_javac_target=11
+	ant_build_javac_source=1.8
         ;;
     # untested: weakly unsupported 
     12|openjdk12)
         options="-XX:CompileThreshold=10"
-	abcl_javac_target=12
-	abcl_javac_source=1.8
+	ant_build_javac_target=12
+	ant_build_javac_source=1.8
         ;;
     13|openjdk13)
         options="-XX:CompileThreshold=10"
-	abcl_javac_target=13
-	abcl_javac_source=1.8
+	ant_build_javac_target=13
+	ant_build_javac_source=1.8
         ;;
     14|openjdk14)
         options="-XX:CompileThreshold=10 ${zgc}"
-	abcl_javac_target=14
-	abcl_javac_source=1.8
+	ant_build_javac_target=14
+	ant_build_javac_source=1.8
         ;;
     15|openjdk15)
         options="-XX:CompileThreshold=10 ${zgc}"
-	abcl_javac_target=15
-	abcl_javac_source=1.8
+	ant_build_javac_target=15
+	ant_build_javac_source=1.8
         ;;
 esac
 
 cat ${root}/abcl.properties.in \
     | awk -F = \
 	  -v options="$options" \
-	  -v target="$abcl_javac_target" \
-	  -v source="$abcl_javac_source" \
+	  -v target="$ant_build_javac_target" \
+	  -v source="$ant_build_javac_source" \
        -f ${DIR}/create-abcl-properties.awk \
   > ${root}/abcl.properties
 


### PR DESCRIPTION
(From a suggestion by Slyrus)

Replace use of abcl.javac.{source,target} with the "magic"
ant.build.javac,{source,target} properties.

Explicitly configure 'abcl.release' target to use openjdk8 compilation.

The Java compilation options are perhaps underspecified in terms of
the target JVM in order to support a developer who simply wants to
compile and run locally with least hassles.

When preparing ABCL binaries for wider distribution, the values of the
abcl.build.target.javac and abcl.build.source.java become more
important.

The 'abcl.properties.autoconfigure.*' targets use the
ci/create-build-properties.bash script to set these options for
various openjdk platforms.
* * *
build: build the wrapper with the release

N.b. the wrapper is a local artifact, not supposed to be shipped with
the release.