### PR TITLE
Explicitly scope java.lang.Thread.yield() invocation

### DIFF
--- a/src/org/armedbear/lisp/java/swing/REPLConsole.java
+++ b/src/org/armedbear/lisp/java/swing/REPLConsole.java
@@ -141,7 +141,7 @@ public class REPLConsole extends DefaultStyledDocument {
         public void run() {
           while(true) {
             replWrapper.execute();
-            yield();
+            java.lang.Thread.yield();
           }
         }
       };


### PR DESCRIPTION
Apparently needed for the FreeBSD version of openjdk15.