### PR TITLE
Fix VECTOR-PUSH-EXTEND for unsigned-byte specializations

### DIFF
--- a/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
@@ -374,6 +374,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
         } else { 
           newBuffer = ByteBuffer.allocate(minCapacity);
         }
+        elements.position(0);
         newBuffer.put(elements); 
         elements = newBuffer;
         capacity = minCapacity;

--- a/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
@@ -354,6 +354,7 @@ public final class ComplexVector_IntBuffer
         } else {
           newBuffer = IntBuffer.allocate(minCapacity);
         }
+        elements.position(0);
         newBuffer.put(elements);
         elements = newBuffer;
         capacity = minCapacity;


### PR DESCRIPTION
Addresses <https://github.com/armedbear/abcl/issues/345>.

Somehow the position marker on our specialized buffers is getting
"advanced" from zero under some condition that I can't immediately
find from looking through the code.

TODO figure out what is advancing the position, reset the underlying
buffer position to zero.