### PR TITLE
arrays: fix fail to reset position after relative access

### DIFF
--- a/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
@@ -80,7 +80,7 @@ public final class BasicVector_ByteBuffer
     }
     for (int i = array.length; i-- > 0;) {
       // Faster please!
-      elements.put((byte)coerceToJavaByte(array[i]));
+      elements.put(i, (byte)coerceToJavaByte(array[i]));
     }
   }
 
@@ -198,6 +198,7 @@ public final class BasicVector_ByteBuffer
     ((java.nio.Buffer)view).limit(end);
     try {
       v.elements.put(view);
+      v.elements.position(0);
       return v;
     } catch (BufferOverflowException e) {
       return error(new TypeError("Could not form a subseq from " + start + " to " + end));

--- a/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexArray_ByteBuffer.java
@@ -279,7 +279,7 @@ public final class ComplexArray_ByteBuffer
   // FIXME move me to someplace more general
   public static void fill(ByteBuffer buffer, byte value) {
     for (int i = 0; i < ((java.nio.Buffer)buffer).limit(); i++) {
-      buffer.put(value);
+      buffer.put(i, value);
     }
   }
 

--- a/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_ByteBuffer.java
@@ -374,6 +374,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
         } else { 
           newBuffer = ByteBuffer.allocate(minCapacity);
         }
+        elements.position(0);
         newBuffer.put(elements); 
         elements = newBuffer;
         capacity = minCapacity;
@@ -459,7 +460,7 @@ public final class ComplexVector_ByteBuffer extends AbstractVector
       if (initialElement != null) {
         byte b = coerceToJavaByte(initialElement);
         for (int i = capacity; i < newCapacity; i++) {
-          elements.put(b);
+          elements.put(i, b);
         }
       }
     }

--- a/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
+++ b/src/org/armedbear/lisp/ComplexVector_IntBuffer.java
@@ -354,6 +354,7 @@ public final class ComplexVector_IntBuffer
         } else {
           newBuffer = IntBuffer.allocate(minCapacity);
         }
+        elements.position(0);
         newBuffer.put(elements);
         elements = newBuffer;
         capacity = minCapacity;
@@ -436,6 +437,7 @@ public final class ComplexVector_IntBuffer
         }
         newElements.put(elements.array(),
                         0, Math.min(capacity, newCapacity));
+        newElements.position(0);
         elements = newElements;
       }
       // Initialize new elements (if aapplicable).


### PR DESCRIPTION
The position of all buffers should always be zero.

Fixes <https://github.com/armedbear/abcl/issues/345> without need to
reset buffers.

We fix new types specializing (or (unsigned-byte 8) (unsigned-byte
32)) in BasicVector_ByteBuffer, ComplexArray_ByteBuffer,
ComplexVector_ByteBuffer, and ComplexVector_IntBuffer for relative
accesses which always advance the position of the
underlying java.nio.Buffer subclass.

--

Fixes more comprehensively than <https://github.com/armedbear/abcl/pull/346>
