### PR TITLE
Easye/fasl loading/20201110a

### DIFF
--- a/t/eg/without-use-cl.lisp
+++ b/t/eg/without-use-cl.lisp
@@ -1,0 +1,14 @@
+(cl:defpackage :without-use-cl)
+(cl:in-package :without-use-cl)
+
+(cl:defvar *foo* cl:nil "A var")
+
+(cl:defun test ()
+  (cl:let* ((p1 (cl:make-pathname))
+         (p2 cl:*default-pathname-defaults*)
+         (p3 (cl:merge-pathnames p1)))
+    (cl:values (cl:pathname-device p2) (cl:pathname-device p3))))
+
+(cl:eval-when (:compile-toplevel :load-toplevel)
+  (cl:let ((a 2))
+    (cl:defparameter *a* a)))

--- a/t/without-use-cl.lisp
+++ b/t/without-use-cl.lisp
@@ -1,0 +1,25 @@
+(in-package :cl-user)
+
+(prove:plan 1)
+(prove:ok
+ (let ((*package* (defpackage :without-use-cl)))
+   (cl:load (cl:compile-file
+             (asdf:system-relative-pathname :abcl
+                                            "t/eg/without-use-cl.lisp")))
+   "Compiling in a package without a (:USE :CL) clause"))
+
+(prove:plan 1)
+(let ((source (make-pathname :type "lisp"
+                             :defaults (uiop:with-temporary-file (:pathname o) o))))
+  (with-open-file (o source :direction :output :if-exists :supersede)
+    (write '(cl:format cl:t "~&I am in package ~s.~%" cl:*package*) :stream o))
+  (let ((output (compile-file source)))
+    (prove:ok 
+     (let ((*package* (defpackage :without-use-cl)))
+       (cl:load cl-user::output))
+     "Loading a fasl from a package without a (:USE :CL) clause.")))
+
+(prove:finalize)
+
+
+            


### PR DESCRIPTION
Starts to address situations where symbols in the fasl loader aren't in the current package when `cl:load` is invoked.  

Fails to fix loading a fasl when the current package doesn't `(use :cl)`