### PR TITLE
Support use of Project Loom virtual threads

### DIFF
--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2429,6 +2429,22 @@ public final class Lisp
             platformVersion = javaVersion;
           }
       }
+      // We wish to declare an integer Java version, but
+      // specialized builds can prefix further information in the
+      // java.version property
+      try {
+	Integer.parseInt(javaVersion);
+      } catch (NumberFormatException e) {
+	for (int i = 0; i < javaVersion.length(); i++) {
+	  char c = javaVersion.charAt(i); // Unicode?
+	  if (!Character.isDigit(c)) {
+	    // Push the non-conforming keyword for completeness
+	    featureList.push(internKeyword("JAVA-" + javaVersion));
+	    platformVersion = javaVersion.substring(0, i);
+	    break;
+	  }
+	}
+      }
       featureList = featureList.push(internKeyword("JAVA-" + platformVersion));
     }
 

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -39,6 +39,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
+import java.lang.reflect.Method;
 import java.math.BigInteger;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -2485,6 +2486,13 @@ public final class Lisp
         featureList = featureList.push(internKeyword(osArch));
       }
     }
+
+    // Available Threading models
+
+    if (LispThread.virtualThreadingAvailable()) {
+      featureList = featureList.push(internKeyword("VIRTUAL-THREADS"));
+    }
+    
     Symbol.FEATURES.initializeSpecial(featureList);
   }
 

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2429,9 +2429,9 @@ public final class Lisp
             platformVersion = javaVersion;
           }
       }
-      // We wish to declare an integer Java version, but
-      // specialized builds can prefix further information in the
-      // java.version property
+      // We wish to declare an integer Java version, but specialized
+      // builds can suffix further information upon the java.version
+      // property.
       try {
 	Integer.parseInt(javaVersion);
       } catch (NumberFormatException e) {

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2437,9 +2437,9 @@ public final class Lisp
       } catch (NumberFormatException e) {
 	for (int i = 0; i < javaVersion.length(); i++) {
 	  char c = javaVersion.charAt(i); // Unicode?
-	  if (!Character.isDigit(c)) {
-	    // Push the non-conforming keyword for completeness
-	    featureList.push(internKeyword("JAVA-" + javaVersion));
+          if (!Character.isDigit(c)) {
+            // Push the non-conforming keyword for completeness
+            featureList.push(internKeyword("JAVA-" + javaVersion));
 	    platformVersion = javaVersion.substring(0, i);
 	    break;
 	  }

--- a/src/org/armedbear/lisp/Symbol.java
+++ b/src/org/armedbear/lisp/Symbol.java
@@ -3267,6 +3267,9 @@ public class Symbol extends LispObject implements java.io.Serializable
   // THREADS
   public static final Symbol THREAD =
     PACKAGE_THREADS.addExternalSymbol("THREAD");
+  public static final Symbol _THREADING_MODEL =
+    PACKAGE_THREADS.addExternalSymbol("*THREADING-MODEL*");
+    
 
   // JVM
   public static final Symbol _RESIGNAL_COMPILER_WARINGS_ =


### PR DESCRIPTION
Thanks to no-defun-allowed for clueing me into that this would be
somewhat easily done.

When the underlying JVM supports virtual threads, :VIRTUAL-THREADS
will be present in CL:&ast;FEATURES&ast;.

The special variable THREADS:&ast;THREADING-MODEL&ast; contains the type of
threads being spawned by the implementation: it will be :NATIVE for
the default, which is usually a one-to-one mapping from each Java
thread to a native thread, and will be :VIRTUAL if using the
lightweight threads present in Project Loom JVMs.

Tested on "OpenJDK_64-Bit_Server_VM-Oracle_Corporation-16-loom+9-316".

Netbeans 12.2 has problems running the debugger with this change due
to some sort of bad interaction with the JDWP protocol.

Project Loom documentation of java.lang.Thread
<https://download.java.net/java/early_access/loom/docs/api/java.base/java/lang/Thread.html>

Overview of Project Loom
<https://cr.openjdk.java.net/~rpressler/loom/loom/sol1_part1.html#migration-from-threads-to-virtual-threads>

Early Access binaries for openjdk16-loom
<https://jdk.java.net/loom/>