### PR TITLE
build: add configuration targets more openjdks

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1252,6 +1252,24 @@ JVM System Properties
             tofile="${dist.dir}/asdf.pdf"/>
     </target>
 
+    <target name="abcl.properties.autoconfigure.openjdk.6">
+      <exec executable="/usr/bin/env">
+        <arg value="bash"/>
+        <arg value="ci/create-abcl-properties.bash"/>
+        <arg value="openjdk6"/>
+      </exec>
+    </target>
+
+
+    <target name="abcl.properties.autoconfigure.openjdk.7">
+      <exec executable="/usr/bin/env">
+        <arg value="bash"/>
+        <arg value="ci/create-abcl-properties.bash"/>
+        <arg value="openjdk7"/>
+      </exec>
+    </target>
+
+
     <target name="abcl.properties.autoconfigure.openjdk.8">
       <exec executable="/usr/bin/env">
         <arg value="bash"/>
@@ -1281,6 +1299,14 @@ JVM System Properties
         <arg value="bash"/>
         <arg value="ci/create-abcl-properties.bash"/>
         <arg value="openjdk15"/>
+      </exec>
+    </target>
+
+    <target name="abcl.properties.autoconfigure.openjdk.16">
+      <exec executable="/usr/bin/env">
+        <arg value="bash"/>
+        <arg value="ci/create-abcl-properties.bash"/>
+        <arg value="openjdk16"/>
       </exec>
     </target>
 

--- a/ci/create-abcl-properties.bash
+++ b/ci/create-abcl-properties.bash
@@ -57,6 +57,11 @@ case $jdk in
 	ant_build_javac_target=15
 	ant_build_javac_source=1.8
         ;;
+    16|openjdk16)
+        options="-XX:CompileThreshold=10 ${zgc}"
+	ant_build_javac_target=16
+	ant_build_javac_source=1.8
+        ;;
 esac
 
 cat ${root}/abcl.properties.in \


### PR DESCRIPTION
Add support for configuring openjdk6, openjdk7, and openjdk16 within
CI via adding targets for Ant.

TODO: macroize this stuff in Ant to add all supported platforms.  But
we now at least configure the ones we (sorta) actively test.