### PR TITLE
Fix printing of `RANDOM-STATE`.

### DIFF
--- a/src/org/armedbear/lisp/Symbol.java
+++ b/src/org/armedbear/lisp/Symbol.java
@@ -3237,6 +3237,8 @@ public class Symbol extends LispObject implements java.io.Serializable
     PACKAGE_SYS.addInternalSymbol("READERS");
   public static final Symbol REQUIRED_ARGS =
     PACKAGE_SYS.addInternalSymbol("REQUIRED-ARGS");
+  public static final Symbol READ_RANDOM_STATE =
+    PACKAGE_SYS.addInternalSymbol("READ-RANDOM-STATE");
   // DEPRECATED: to be removed with abcl-1.7
   public static final Symbol _SOURCE =
     PACKAGE_SYS.addInternalSymbol("%SOURCE");


### PR DESCRIPTION
Not a particularly nice byte vector representation though, but it gets the job done:

```
CL-USER> (write (make-random-state))
#<RANDOM-STATE {301D7DA5}>

CL-USER> (write (make-random-state) :readably T)
#.(SYSTEM::READ-RANDOM-STATE #(-84 -19 ... -69 39 120))

CL-USER> (setf *read-eval* NIL)
NIL
CL-USER> (let ((*read-eval* NIL)) (write (make-random-state) :readably T))
#<RANDOM-STATE {3B023252}> cannot be printed readably.
   [Condition of type PRINT-NOT-READABLE]
...
```

[From CLHS](http://clhs.lisp.se/Body/v_pr_rda.htm):
> If `*read-eval*` is false and `*print-readably*` is true, any such method that would output a reference to the ``#.'' reader macro will either output something else or will signal an error (as described above).

Based on that this should be conforming and users will not be able to print a random state if they don't have `*read-eval*` on. Alternatively a different reader implementation would have to be done, e.g. via `#S` like the example in the documentation.