### PR TITLE
Allow JAVA:JCLASS to work for non-primitive arrays suffixed with "[]"

### DIFF
--- a/src/org/armedbear/lisp/Java.java
+++ b/src/org/armedbear/lisp/Java.java
@@ -1393,7 +1393,9 @@ public final class Java
         } else if (className.startsWith("boolean")) {
           return Class.forName("[Z");
         } else {
-          return Class.forName(className); // Not going to work well
+          final String arrayTypeName
+            = "[L" + className.substring(0, className.length() - 2) + ";";
+          return Class.forName(arrayTypeName); 
         }
       }
     } catch (ClassNotFoundException e) {


### PR DESCRIPTION
This allows constructs like (jclass "java.lang.Integer[]") to work.

Supersedes #374 