### PR TITLE
ci: move to Adoptium for openjdk download

### DIFF
--- a/.github/workflows/abcl-test.yml
+++ b/.github/workflows/abcl-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        jdk: [openjdk8, openjdk11, openjdk15]
+        jdk: [openjdk8, openjdk11, openjdk16]
         
     steps:
       - name: Set path for build scripts
@@ -29,8 +29,8 @@ jobs:
       - name: Setup jenv
         run: bash -x ./ci/ensure-jenv-is-present.bash && ant abcl.diagnostic
         
-      - name: Install AdoptJDK
-        run: bash -x ./ci/install-adoptjdk.bash ${JDK_VERSION}
+      - name: Install OpenJDK
+        run: bash -x ./ci/install-openjdk.bash ${JDK_VERSION}
 
       - name: Set abcl.properties for build
         run: bash -x ./ci/create-abcl-properties.bash ${JDK_VERSION}

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ addons:
 env:
   - ABCL_JDK=openjdk8  ABCL_ROOT=${TRAVIS_BUILD_DIR}
   - ABCL_JDK=openjdk11 ABCL_ROOT=${TRAVIS_BUILD_DIR}
-  - ABCL_JDK=openjdk15 ABCL_ROOT=${TRAVIS_BUILD_DIR}
+  - ABCL_JDK=openjdk16 ABCL_ROOT=${TRAVIS_BUILD_DIR}
 
 install:
   - echo PWD=$(pwd) && echo ABCL_ROOT=${ABCL_ROOT}
-  - bash -x ${ABCL_ROOT}/ci/install-adoptjdk.bash ${ABCL_JDK}
+  - bash -x ${ABCL_ROOT}/ci/install-openjdk.bash ${ABCL_JDK}
 
   # Ensure we can invoke ant
   - . ${ABCL_ROOT}/ci/ensure-jenv-is-present.bash && ant abcl.diagnostic

--- a/abcl.rdf
+++ b/abcl.rdf
@@ -193,6 +193,7 @@ abcl:jss
   rdf:_13  openjdk:13 ;
   rdf:_14  openjdk:14 ;
   rdf:_15  openjdk:15 ;
+  rdf:_16  openjdk:16 ;
   rdfs:comment "Compatible Java runtimes" .
 
 [abcl:run _:options]
@@ -202,6 +203,8 @@ abcl:jss
     openjdk:11 "-XX:CompileThreshold=10" ;
     openjdk:13 "-XX:CompileThreshold=10" ;
     openjdk:14 "-XX:CompileThreshold=10" ;
+    openjdk:15 "-XX:CompileThreshold=10" ;
+    openjdk:16 "-XX:CompileThreshold=10" ;
     rdfs:comment "Java platform runtime options" .
 
 [abcl:build _:options]
@@ -222,7 +225,8 @@ abcl:jss
    rdf:_11  openjdk:11 ;
    rdf:_13  openjdk:13 ;
    rdf:_14  openjdk:14 ;
-   rdf:_14  openjdk:15 ;
+   rdf:_15  openjdk:15 ;
+   rdf:_16  openjdk:16 ;
    rdfs:comment "Supported build platforms" .
 
 

--- a/ci/install-openjdk.bash
+++ b/ci/install-openjdk.bash
@@ -12,46 +12,52 @@ fi
 # lexically scoped in their modification.
 topdir=
 dist=
-function determine_adoptjdk() {
+function determine_openjdk() {
     case $(uname) in
         Darwin)
             case $jdk in
                 openjdk8)
-                    topdir=jdk8u265-b01
-                    dist="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01/OpenJDK8U-jdk_x64_mac_hotspot_8u265b01.tar.gz"
+                    topdir=jdk8u302-b08
+                    dist="https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_mac_hotspot_8u302b08.tar.gz"
                     ;;
                 openjdk11)
-                    topdir=jdk-11.0.8+10
-                    dist="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jdk_x64_mac_hotspot_11.0.8_10.tar.gz"
+                    topdir=jdk-11.0.12+7
+                    dist="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.12%2B7/OpenJDK11U-jdk_x64_mac_hotspot_11.0.12_7.tar.gz"
                     ;;
-                openjdk14)
+                openjdk14)  # Need version from adoptium
                     topdir=jdk-14.0.2+12
                     dist="https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_mac_hotspot_14.0.2_12.tar.gz"
                     ;;
-                openjdk15)
+                openjdk15) # Need version from adoptium
                     topdir=jdk-15+36
                     dist="https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15%2B36/OpenJDK15U-jdk_x64_mac_hotspot_15_36.tar.gz"
                     ;;
+                openjdk16)
+                    topdir=jdk-16.0.2+7
+                    dist="https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_mac_hotspot_16.0.2_7.tar.gz"
 esac
             ;;
         Linux)
             case $jdk in
                 openjdk8)
-                    topdir=jdk8u265-b01
-                    dist="https://github.com/AdoptOpenJDK/openjdk8-binaries/releases/download/jdk8u265-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u265b01.tar.gz"
+                    topdir=jdk8u302-b08
+                    dist="https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u302-b08/OpenJDK8U-jdk_x64_linux_hotspot_8u302b08.tar.gz"
                     ;;
                 openjdk11)
                     topdir=jdk-11.0.8+10
                     dist="https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.8_10.tar.gz"
                     ;;
-                openjdk14)
+                openjdk14) # Need version from adoptium
                     topdir=jdk-14.0.2+12
                     dist="https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%2B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz"
                     ;;
-                openjdk15)
+                openjdk15) # Need version from adoptium
                     topdir=jdk-15+36
                     dist="https://github.com/AdoptOpenJDK/openjdk15-binaries/releases/download/jdk-15%2B36/OpenJDK15U-jdk_x64_linux_hotspot_15_36.tar.gz"
                     ;;
+                openjdk16)
+                    topdir=jdk-16.0.2+7
+                    dist="https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz"
 esac
             ;;
         *)
@@ -82,7 +88,7 @@ function add_jdk() {
     esac
 }
 
-determine_adoptjdk
+determine_openjdk
 download_and_extract
 add_jdk
 


### PR DESCRIPTION
The CIs now build and test with openjdk8, openjdk11, and openjdk16.