### PR TITLE
Fix stream-error-stream, make it and type-error-datum throw type-errors

### DIFF
--- a/src/org/armedbear/lisp/StreamError.java
+++ b/src/org/armedbear/lisp/StreamError.java
@@ -161,9 +161,13 @@ public class StreamError extends LispError
         @Override
         public LispObject execute(LispObject arg)
         {
-            if (arg instanceof StreamError)
-                return ((StreamError)arg).getStream();
-            return type_error(arg, Symbol.STREAM_ERROR);
+            final StandardObject obj;
+            if (arg instanceof StandardObject) {
+                obj = (StandardObject) arg;
+            } else {
+                return type_error(arg, Symbol.STANDARD_OBJECT);
+            }
+            return obj.getInstanceSlotValue(Symbol.STREAM);
         }
     };
 }

--- a/src/org/armedbear/lisp/StreamError.java
+++ b/src/org/armedbear/lisp/StreamError.java
@@ -161,12 +161,11 @@ public class StreamError extends LispError
         @Override
         public LispObject execute(LispObject arg)
         {
-            final StandardObject obj;
-            if (arg instanceof StandardObject) {
-                obj = (StandardObject) arg;
-            } else {
-                return type_error(arg, Symbol.STANDARD_OBJECT);
+            if (arg.typep(Symbol.STREAM_ERROR) == NIL) {
+                return type_error(arg, Symbol.STREAM_ERROR);
             }
+
+            StandardObject obj = (StandardObject) arg;
             return obj.getInstanceSlotValue(Symbol.STREAM);
         }
     };

--- a/src/org/armedbear/lisp/TypeError.java
+++ b/src/org/armedbear/lisp/TypeError.java
@@ -191,13 +191,11 @@ public class TypeError extends LispError
         @Override
         public LispObject execute(LispObject arg)
         {
-            final StandardObject obj;
-            if (arg instanceof StandardObject) {
-                obj = (StandardObject) arg;
+            if (arg.typep(Symbol.TYPE_ERROR) == NIL) {
+                return type_error(arg, Symbol.TYPE_ERROR);
             }
-            else {
-                return type_error(arg, Symbol.STANDARD_OBJECT);
-            }
+
+            StandardObject obj = (StandardObject) arg;
             return obj.getInstanceSlotValue(Symbol.DATUM);
         }
     };

--- a/test/lisp/abcl/condition-tests.lisp
+++ b/test/lisp/abcl/condition-tests.lisp
@@ -66,6 +66,11 @@
                #+sbcl    'sb-kernel::object)
   nil)
 
+(deftest stream-error.1
+  (let ((c (make-instance 'stream-error :stream (make-string-input-stream "foo"))))
+    (values (read-line (stream-error-stream c))))
+  "foo")
+
 (deftest type-error.1
   (type-error-datum (make-instance 'type-error :datum 42))
   42)
@@ -308,3 +313,12 @@
                              :format-arguments (list "The bear" "armed"))))
       (write-to-string c :escape nil)))
   "The bear is armed.")
+
+#+(or abcl allegro)
+(deftest define-condition.11
+  (progn
+    (setf (find-class 'test-error) nil)
+    (define-condition test-error (stream-error) ())
+    (let ((c (make-condition 'test-error :stream (make-string-input-stream "foo"))))
+      (values (read-line (stream-error-stream c)))))
+  "foo")


### PR DESCRIPTION
Resolves #388, the function stream-error-stream fails when
applied to subconditions of stream-error:
```lisp
(define-condition foo-error (stream-error)
  ())
(make-condition 'foo-error :stream (make-string-input-stream "foobar"))
(typep * 'stream-error) ;; => T
(stream-error-stream **)
 <THREAD "interpreter" {119C150C}>: Debugger invoked on condition of type TYPE-ERROR
  The value #<FOO-ERROR {2075326}> is not of type STREAM-ERROR.
Restarts:
  0: TOP-LEVEL Return to top level.
```

This change both fixes stream-error-stream and revises type-error-datum by
checking if each arg is typep to its respective condition type. If the typep
fails, the functions signal a type-error. It also adds two unit tests in
condition-tests.lisp to protect against this bug regressing back again.

This change would make both functions conformant to two proposals for
WSCL:
- https://github.com/s-expressionists/wscl/blob/main/wscl-issues/proposed/stream-error-stream-type-error
- https://github.com/s-expressionists/wscl/blob/main/wscl-issues/proposed/type-error-datum-type-error