### PR TITLE
Correct ENCODE-UNIVERSAL-TIME for dates after 2037

### DIFF
--- a/src/org/armedbear/lisp/time.lisp
+++ b/src/org/armedbear/lisp/time.lisp
@@ -128,19 +128,6 @@
 	 (hours (+ hour (* days 24))))
     (cond (time-zone
            (+ second (* (+ minute (* (+ hours time-zone) 60)) 60)))
-          ((> year 2037)
-           (labels ((leap-year-p (year)
-                      (cond ((zerop (mod year 400)) t)
-                            ((zerop (mod year 100)) nil)
-                            ((zerop (mod year 4)) t)
-                            (t nil))))
-             (let* ((fake-year (if (leap-year-p year) 2036 2037))
-                    (fake-time (encode-universal-time second minute hour
-                                                      date month fake-year)))
-               (+ fake-time
-                 (* 86400 (+ (* 365 (- year fake-year))
-                             (- (leap-years-before year)
-                                (leap-years-before fake-year))))))))
           (t
            (let* ((tz-guess (ext:get-time-zone (* hours 3600)))
 		  (guess (+ second (* 60 (+ minute (* 60 (+ hours tz-guess))))))


### PR DESCRIPTION
The code removed in this patch seems to be attempting to adjust for
times which occurred after a 32-bit representation of the UNIX epoch
would wrap around to zero.  This doesn't make much sense as Common
Lisp times are clearly defined as an integer number of seconds after
1900.

The ansi-test DECODE-UNIVERSAL-TIME.5 now passes.

c.f. <https://abcl.org/trac/ticket/443>.