### PR TITLE
ci: build with openjdk17

### DIFF
--- a/.github/workflows/abcl-test.yml
+++ b/.github/workflows/abcl-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        jdk: [openjdk8, openjdk11, openjdk16]
+        jdk: [openjdk8, openjdk11, openjdk17]
         
     steps:
       - name: Set path for build scripts

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
 env:
   - ABCL_JDK=openjdk8  ABCL_ROOT=${TRAVIS_BUILD_DIR}
   - ABCL_JDK=openjdk11 ABCL_ROOT=${TRAVIS_BUILD_DIR}
-  - ABCL_JDK=openjdk16 ABCL_ROOT=${TRAVIS_BUILD_DIR}
+  - ABCL_JDK=openjdk17 ABCL_ROOT=${TRAVIS_BUILD_DIR}
 
 install:
   - echo PWD=$(pwd) && echo ABCL_ROOT=${ABCL_ROOT}

--- a/ci/install-openjdk.bash
+++ b/ci/install-openjdk.bash
@@ -35,7 +35,12 @@ function determine_openjdk() {
                 openjdk16)
                     topdir=jdk-16.0.2+7
                     dist="https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_mac_hotspot_16.0.2_7.tar.gz"
-esac
+                    ;;
+                openjdk17)
+                    topdir="jdk-17+35"
+                    dist="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_mac_hotspot_17_35.tar.gz"
+                    ;;
+            esac
             ;;
         Linux)
             case $jdk in
@@ -58,6 +63,11 @@ esac
                 openjdk16)
                     topdir=jdk-16.0.2+7
                     dist="https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz"
+                    ;;
+                openjdk17)
+                    topdir="jdk-17+35"
+                    dist="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17%2B35/OpenJDK17-jdk_x64_linux_hotspot_17_35.tar.gz"
+                    ;;
 esac
             ;;
         *)


### PR DESCRIPTION
Use the released LTS Java editions for testing: openjdk8, openjdk11,
and openjdk17.

TODO: figure out how to signal non-zero condition for individual test
suites so they "go green/red" for easier inspection.