### PR TITLE
jss: fix instrospecting abcl.jar under openjdk1[67]

### DIFF
--- a/contrib/jss/jss.asd
+++ b/contrib/jss/jss.asd
@@ -2,7 +2,7 @@
 (defsystem jss
   :author "Alan Ruttenberg, Mark Evenson"
   :long-description "<urn:abcl.org/release/1.8.0/contrib/jss#>"
-  :version "3.6.0" 
+  :version "3.7.0" 
   :components ((:module base 
                         :pathname "" :serial t 
                         :components ((:file "packages")


### PR DESCRIPTION
Start port to openjdk1[67]

Use JAR-PATHNME for implementing through jar entries in order to work
on openjdk16/openjdk17.  The new implementation is roughly four times
slower than the previous version probably because it conses around 100
times more memory.