### PR TITLE
ci: shuffle tests to place completely failing CL+SSL last

### DIFF
--- a/.github/workflows/abcl-test.yml
+++ b/.github/workflows/abcl-test.yml
@@ -59,14 +59,8 @@ jobs:
       - name: Test ABCL-PROVE
         run: ./abcl --batch --load ./ci/test-abcl-prove.lisp
 
-      - name: Test STATIC-VECTORS
-        run: ./abcl --batch --load ./ci/test-static-vectors.lisp
-
-      - name: Test CFFI
-        run: ./abcl --batch --load ./ci/test-cffi.lisp
-
-      - name: Test CL+SSL
-        run: ./abcl --batch --load ./ci/test-cl+ssl.lisp
+      - name: Test ABCL
+        run: ./abcl --batch --load ./ci/test-abcl.lisp
 
       - name: Test ABCL-INTROSPECT
         run: ./abcl --batch --load ./ci/test-abcl-introspect.lisp
@@ -74,8 +68,11 @@ jobs:
       - name: Test Jeannie
         run: ./abcl --batch --load ./ci/test-jeannie.lisp
 
-      - name: Test ABCL
-        run: ./abcl --batch --load ./ci/test-abcl.lisp
+      - name: Test CFFI
+        run: ./abcl --batch --load ./ci/test-cffi.lisp
+
+      - name: Test STATIC-VECTORS
+        run: ./abcl --batch --load ./ci/test-static-vectors.lisp
 
       - name: Test IRONCLAD
         run: ./abcl --batch --load ./ci/test-ironclad.lisp
@@ -83,7 +80,8 @@ jobs:
       - name: Run ANSI-TEST suite
         run: ./abcl --batch --load ./ci/test-ansi.lisp
 
-
+      - name: Test CL+SSL
+        run: ./abcl --batch --load ./ci/test-cl+ssl.lisp
           
 
             

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,20 +74,20 @@ install:
 
 script:
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-prove.lisp
-  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-static-vectors.lisp
-  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cffi.lisp
-  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cl+ssl.lisp
-  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-introspect.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl.lisp
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-abcl-introspect.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-jeannie.lisp
-  # IRONCLAD takes a long time to test, so we place it near the end
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cffi.lisp
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-static-vectors.lisp
+  # IRONCLAD takes a long time to test
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-ironclad.lisp
   - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-ansi.lisp
-  
+  - ${ABCL_ROOT}/abcl --batch --load ${ABCL_ROOT}/ci/test-cl+ssl.lisp
+
   # This would build a release, which needs an installed TeX which is judged too
   # "expensive" to leave as the standard CI process
   # - pushd ${ABCL_ROOT} && ant abcl.release abcl.wrapper && popd
-  
+
   # Print the hashes and sizes of build artifacts
   - pushd ${ABCL_ROOT} && ./abcl --batch --load ./ci/release.lisp  && popd
   


### PR DESCRIPTION
CL+SSL fails under openjdk17 with a segmentation violation for the bad
cert test, so place it at the end.