### PR TITLE
jna: update to jna-5.9.0

### DIFF
--- a/contrib/mvn/jna.asd
+++ b/contrib/mvn/jna.asd
@@ -2,11 +2,11 @@
 
 ;;;; Need to have jna.jar present for CFFI to work.
 (defsystem jna 
-  :long-description  "<urn:abcl.org/release/1.8.0/contrib/jna#5.6.0>"
-  :version "5.6.0"
+  :long-description  "<urn:abcl.org/release/1.8.0/contrib/jna#5.9.0>"
+  :version "5.9.0"
   :defsystem-depends-on (jss abcl-asdf)
-  :components ((:mvn "net.java.dev.jna/jna/5.6.0"
-                :alternate-uri "http://repo1.maven.org/maven2/net/java/dev/jna/jna/5.6.0/jna-5.6.0.jar"
+  :components ((:mvn "net.java.dev.jna/jna/5.9.0"
+                :alternate-uri "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.9.0/jna-5.9.0.jar"
                 :classname "com.sun.jna.Native")))
 
                          


### PR DESCRIPTION
This version includes the necessary native shared object trampoline
for working under macOS/aarch64 (aka "M1" aka "Apple Silcon".