### PR TITLE
Remove inadvertent references to SIMPLE-PROGRAM-ERROR

### DIFF
--- a/src/org/armedbear/lisp/clos.lisp
+++ b/src/org/armedbear/lisp/clos.lisp
@@ -2088,7 +2088,7 @@ compare the method combination name to the symbol 'standard.")
                                (early-method-lambda-list method)
                                (method-lambda-list method)))
     (flet ((lose (string &rest args)
-                 (error 'simple-program-error
+                 (error 'program-error
                         :format-control "~@<attempt to add the method~2I~_~S~I~_~
                         to the generic function~2I~_~S;~I~_~
                         but ~?~:>"

--- a/src/org/armedbear/lisp/precompiler.lisp
+++ b/src/org/armedbear/lisp/precompiler.lisp
@@ -547,7 +547,7 @@
   (let* ((args (cdr form))
          (len (length args)))
     (when (oddp len)
-      (error 'simple-program-error
+      (error '  compiler-error
              :format-control "Odd number of arguments to SETQ."))
     (if (= len 2)
         (let* ((sym (%car args))

--- a/src/org/armedbear/lisp/precompiler.lisp
+++ b/src/org/armedbear/lisp/precompiler.lisp
@@ -382,9 +382,9 @@
   (let ((op (car form)))
     (when (and (consp op) (eq (%car op) 'LAMBDA))
       (return-from precompile-function-call
-	(or (precompile-function-position-lambda op (cdr form))
-	    (cons (precompile-lambda op)
-		  (mapcar #'precompile1 (cdr form))))))
+        (or (precompile-function-position-lambda op (cdr form))
+            (cons (precompile-lambda op)
+                  (mapcar #'precompile1 (cdr form))))))
     (when (or (not *in-jvm-compile*) (notinline-p op))
       (return-from precompile-function-call (precompile-cons form)))
     (when (source-transform op)
@@ -402,35 +402,35 @@
 
 (defun precompile-function-position-lambda (lambda args)
   (let* ((arglist (second lambda))
-	 (body (cddr lambda))
-	 (simple-arglist? (not (or (memq '&KEY arglist) (memq '&OPTIONAL arglist) (memq '&REST arglist)))))
+         (body (cddr lambda))
+         (simple-arglist? (not (or (memq '&KEY arglist) (memq '&OPTIONAL arglist) (memq '&REST arglist)))))
     (or
      ;;give a chance for someone to transform single-form function bodies
      (and (= (length body) 1)
           (consp (car body))
           (symbolp (caar body))
           (get (caar body) 'sys::function-position-lambda-transform)
-	  (funcall (get (caar body) 'sys::function-position-lambda-transform)
+          (funcall (get (caar body) 'sys::function-position-lambda-transform)
                    (caar body) (car body) (mapcar #'precompile1 args)))
      (and simple-arglist?
-	  (let ((arglist-length (if (memq '&aux arglist) (position '&aux arglist) (length arglist))))
-	    (if (= (length args) arglist-length)
-		;; simplest case - we have a simple arglist with as many
-		;; arguments as call args. Transform to let.
-		(return-from precompile-function-position-lambda
-		  `(let* ,(append
-			    (loop for arg-name in arglist
-				  for arg in (mapcar #'precompile1 args)
-				  until (eq arg-name '&aux)
-				  collect (list arg-name arg))
-			    (subseq arglist (1+ arglist-length)))
-		      ,@body))
-		(error "Argument mismatch for lambda in function position: ~a applied to ~a" `(lambda ,arglist body) args)))))))
+          (let ((arglist-length (if (memq '&aux arglist) (position '&aux arglist) (length arglist))))
+            (if (= (length args) arglist-length)
+                ;; simplest case - we have a simple arglist with as many
+                ;; arguments as call args. Transform to let.
+                (return-from precompile-function-position-lambda
+                  `(let* ,(append
+                            (loop for arg-name in arglist
+                                  for arg in (mapcar #'precompile1 args)
+                                  until (eq arg-name '&aux)
+                                  collect (list arg-name arg))
+                            (subseq arglist (1+ arglist-length)))
+                      ,@body))
+                (error "Argument mismatch for lambda in function position: ~a applied to ~a" `(lambda ,arglist body) args)))))))
 
 (defmacro define-function-position-lambda-transform (body-function-name (arglist form args) &body body)
   `(put ',body-function-name 'sys::function-position-lambda-transform 
-	#'(lambda(,arglist ,form ,args)
-	    ,@body)))
+        #'(lambda(,arglist ,form ,args)
+            ,@body)))
 
 (defun precompile-locally (form)
   (let ((*inline-declarations* *inline-declarations*))
@@ -523,13 +523,13 @@
   (let ((place (second form)))
     (cond ((and (consp place)
                 (eq (%car place) 'VALUES))
-	   (setf form
-		 (list* 'SETF
-			(list* 'VALUES
-			       (mapcar #'precompile1 (%cdr place)))
-			(cddr form)))
-	   (precompile1 (expand-macro form)))
-	  ((symbolp place)
+           (setf form
+                 (list* 'SETF
+                        (list* 'VALUES
+                               (mapcar #'precompile1 (%cdr place)))
+                        (cddr form)))
+           (precompile1 (expand-macro form)))
+          ((symbolp place)
            (multiple-value-bind
                  (expansion expanded)
                ;; Expand once in case the form expands
@@ -847,7 +847,7 @@
     (dolist (local locals)
       ;; we can use the non-precompiled locals, because the function body isn't used
       (environment-add-function-definition *precompile-env*
-					   (car local) (cddr local)))
+                                           (car local) (cddr local)))
     (when (eq operator 'LABELS)
        ;; LABELS functions *do* shadow within their own LABELS form
        (setf precompiled-locals
@@ -1004,7 +1004,7 @@
                                   'precompiler))))
     (unless (and handler (fboundp handler))
       (error "No handler for ~S." (let ((*package* (find-package :keyword)))
-				    (format nil "~S" symbol))))
+                                    (format nil "~S" symbol))))
     (setf (get symbol 'precompile-handler) handler)))
 
 (defun install-handlers ()
@@ -1068,8 +1068,8 @@
 
                   (THREADS:SYNCHRONIZED-ON
                                         precompile-threads-synchronized-on)
-		  
-		  (JVM::WITH-INLINE-CODE precompile-identity)))
+                  
+                  (JVM::WITH-INLINE-CODE precompile-identity)))
     (install-handler (first pair) (second pair))))
 
 (install-handlers)
@@ -1195,38 +1195,38 @@
                            ,@decls
                            ,@(when doc `(,doc))
                            (block ,block-name ,@body))))
-	(cond ((and (boundp 'jvm::*file-compilation*)
-		    ;; when JVM.lisp isn't loaded yet, this variable isn't bound
-		    ;; meaning that we're not trying to compile to a file:
-		    ;; Both COMPILE and COMPILE-FILE bind this variable.
-		    ;; This function is also triggered by MACROEXPAND, though.
-		    jvm::*file-compilation*)
-	       `(progn
-		  (fset ',name ,lambda-expression)
-		  ;; the below matter, for example when loading a
-		  ;; compiled defun that is inside some other form
-		  ;; (e.g. flet)
-		  (record-source-information-for-type ',(if (consp name) (second name) name) '(:function ,name))
-		  (%set-arglist (fdefinition ',name) ',(third lambda-expression))
-		  ,@(when doc
-		      `((%set-documentation ',name 'function ,doc)))
-		  ',name))
-	      (t
-	       (when (and env (empty-environment-p env))
-		 (setf env nil))
-	       (when (null env)
-		 (setf lambda-expression (precompiler:precompile-form lambda-expression nil)))
-	       (let ((sym (if (consp name) (second name) name)))
-		 `(prog1
-		      (%defun ',name ,lambda-expression)
-		    (record-source-information-for-type ',sym '(:function ,name))
-		    (%set-arglist (fdefinition ',name) ',(third lambda-expression))
-		    ;; don't do this. building abcl fails autoloading
-		    ;; stuff it shouldn't yet
-		    ;;(%set-arglist (symbol-function ',name) ,(format nil "~{~s~^ ;; ~}" (third lambda-expression)))
-		    ,@(when doc
-			`((%set-documentation ',name 'function ,doc)))
-		    )))))))
+        (cond ((and (boundp 'jvm::*file-compilation*)
+                    ;; when JVM.lisp isn't loaded yet, this variable isn't bound
+                    ;; meaning that we're not trying to compile to a file:
+                    ;; Both COMPILE and COMPILE-FILE bind this variable.
+                    ;; This function is also triggered by MACROEXPAND, though.
+                    jvm::*file-compilation*)
+               `(progn
+                  (fset ',name ,lambda-expression)
+                  ;; the below matter, for example when loading a
+                  ;; compiled defun that is inside some other form
+                  ;; (e.g. flet)
+                  (record-source-information-for-type ',(if (consp name) (second name) name) '(:function ,name))
+                  (%set-arglist (fdefinition ',name) ',(third lambda-expression))
+                  ,@(when doc
+                      `((%set-documentation ',name 'function ,doc)))
+                  ',name))
+              (t
+               (when (and env (empty-environment-p env))
+                 (setf env nil))
+               (when (null env)
+                 (setf lambda-expression (precompiler:precompile-form lambda-expression nil)))
+               (let ((sym (if (consp name) (second name) name)))
+                 `(prog1
+                      (%defun ',name ,lambda-expression)
+                    (record-source-information-for-type ',sym '(:function ,name))
+                    (%set-arglist (fdefinition ',name) ',(third lambda-expression))
+                    ;; don't do this. building abcl fails autoloading
+                    ;; stuff it shouldn't yet
+                    ;;(%set-arglist (symbol-function ',name) ,(format nil "~{~s~^ ;; ~}" (third lambda-expression)))
+                    ,@(when doc
+                        `((%set-documentation ',name 'function ,doc)))
+                    )))))))
 (export '(precompile))
 
 ;;(provide "PRECOMPILER")

--- a/src/org/armedbear/lisp/precompiler.lisp
+++ b/src/org/armedbear/lisp/precompiler.lisp
@@ -547,7 +547,7 @@
   (let* ((args (cdr form))
          (len (length args)))
     (when (oddp len)
-      (error '  compiler-error
+      (error 'compiler-error
              :format-control "Odd number of arguments to SETQ."))
     (if (= len 2)
         (let* ((sym (%car args))

--- a/src/org/armedbear/lisp/psetf.lisp
+++ b/src/org/armedbear/lisp/psetf.lisp
@@ -44,7 +44,7 @@
            (do ((a args (cddr a)))
                ((endp a))
              (when (endp (cdr a))
-               (error 'simple-program-error
+               (error 'program-error
                       :format-control "Odd number of arguments to PSETF."))
              (multiple-value-bind
                (dummies vals newval setter getter)


### PR DESCRIPTION
Unlike SBCL or CCL, ABCL doesn't have a SIMPLE-PROGRAM-ERROR
condition.  Presumably these inadvertent references were present in
patches adapted from those implementations.

Supersedes #451, #452, and #453