### PR TITLE
Start out with the actual Class in print-object on java:java-object

### DIFF
--- a/src/org/armedbear/lisp/java.lisp
+++ b/src/org/armedbear/lisp/java.lisp
@@ -459,7 +459,7 @@ is equivalent to the following Java code:
 (defmethod print-object ((obj java:java-object) stream)
   (if (jnull-ref-p obj)
       (write-string "#<null>" stream)
-      (print-java-object-by-class (intern (jclass-name (jobject-class obj)) 'keyword) obj stream)))
+      (print-java-object-by-class (jobject-class obj) obj stream)))
 
 ;;define extensions by eql methods on class name interned in keyword package
 ;;e.g. (defmethod java::print-java-object-by-class ((class (eql ':|uk.ac.manchester.cs.owl.owlapi.concurrent.ConcurrentOWLOntologyImpl|)) obj stream) 

--- a/test/lisp/abcl/runtime-class.lisp
+++ b/test/lisp/abcl/runtime-class.lisp
@@ -53,3 +53,23 @@
                   :fields '(("name" "java.lang.String" :getter NIL)))
                  "Someone"))
   "Someone")
+
+;; print-object
+(deftest runtime-class.print-object
+    (subseq
+     (with-output-to-string (stream)
+       (print-object
+        (java:jnew
+         (java:jnew-runtime-class
+          "FooList"
+          :superclass "java.util.AbstractList"
+          :methods '(("get" "java.lang.Object" (:int)
+                      (lambda (this index)
+                        "Foo"))
+                     ("size" :int ()
+                      (lambda (this)
+                        15)))))
+        stream))
+     0
+     20)
+  "#<FooList [Foo, Foo,")


### PR DESCRIPTION
related ticket: 
fix #470 

This prevents `jclass-superclass` from failing on names (keywords) of classes generated by `jnew-runtime-class` (it fails because they are created in a different ClassLoader and it can't find them). By passing an actual Class it doesn't have to do a lookup by name. The fail occured on the first iteration of the loop in `print-java-object-by-class`. 

NB: Yes, `jcall` works on keywords. So this is working code:
  ```
  (jcall "getName" :|java.util.List|)
  (jclass-superclass :|java.util.HashMap|)
 ```

The inheritance mechanism of `print-java-object-by-class` is unchanged, because it internally converts the classes found by `jclass-superclass` into a keyword in order to `find-method`. Before this change, it also worked because of the above fact that `jcall getName` works on keywords. 

For `jnew-runtime-class` hierarchies this is fine as well, since the programmers specialize `print-java-object-by-class` themselves on any keywords they want, so they are responsible for any bugs in that. I.E ABCL's catch-all `print-java-object-by-class` **never** calls `jclass-superclass` on a keyword, because the `super` loop variable there is always `java.lang.Class` or `nil` (that's what `jclass-superclass` returns). Before this patch, it was a keyword on the first iteration, then a `java.lang.Class` in the rest of the iterations.

Passing a Class is better than passing in a keyword and making it look up the Class by name (an information loss at the start of the function - it goes back to  looping on actual Classes after the first iteration anyway) because it fixes the case of printing instances of `jnew-runtime-class` generated classes without having to play around with classloaders.
