### PR TITLE
Fix class annotations on JDK17 and newer

### DIFF
--- a/src/org/armedbear/lisp/jvm-class-file.lisp
+++ b/src/org/armedbear/lisp/jvm-class-file.lisp
@@ -1686,9 +1686,17 @@ appropriate reflective APIs.")
   (dolist (ann (annotations-list annotations))
     (finalize-annotation ann class)))
 
+;; See https://github.com/openjdk/jdk/blob/8758b554a089af98fdc3be4201d61278d5f01af3/src/java.base/share/classes/sun/reflect/generics/parser/SignatureParser.java#L295-L312
+(defun class-name->type-signature (class-name)
+  (concatenate 'string
+               '(#\L)
+               (substitute #\/ #\. class-name)
+               '(#\;)))
+
 (defun finalize-annotation (ann class)
   (setf (annotation-type ann)
-        (pool-add-class (class-file-constants class) (annotation-type ann)))
+        (pool-add-utf8 (class-file-constants class)
+                       (class-name->type-signature (annotation-type ann))))
   (dolist (elem (annotation-elements ann))
     (finalize-annotation-element elem class)))
 

--- a/test/lisp/abcl/runtime-class.lisp
+++ b/test/lisp/abcl/runtime-class.lisp
@@ -73,3 +73,14 @@
      0
      20)
   "#<FooList [Foo, Foo,")
+
+
+;; class annotations
+(deftest runtime-class.class-annotations
+  (let* ((class (java:jnew-runtime-class
+                "Foo"
+                :annotations '("java.lang.Deprecated")))
+         (annotations (java:jcall "getAnnotations" class)))
+    (assert (java:jinstance-of-p (aref annotations 0) "java.lang.Deprecated"))
+    t)
+  t)


### PR DESCRIPTION
JDK 17 Removed some obsolete class file format in regards to runtime visible annotations.

Now, the annotation parser *requires* a class type signature, i.e. has *stopped* accepting a class, in the constant pool.

See the JDK commit "Remove vestiages of intermediate JSR 175 annotation format"
(https://github.com/openjdk/jdk/commit/8758b554#diff-50de65a27d09a727c0b6ea40ce7ebd97bf7ead098ff910d7757ae0dd781fc2c8R240)

fix #473 