### PR TITLE
Update with-slots.lisp

### DIFF
--- a/src/org/armedbear/lisp/with-slots.lisp
+++ b/src/org/armedbear/lisp/with-slots.lisp
@@ -34,6 +34,7 @@
 (defmacro with-slots (slots instance &body body)
   (let ((in (gensym)))
     `(let ((,in ,instance))
+       (declare (ignorable ,in))
        (symbol-macrolet
         ,(mapcar (lambda (slot-entry)
                    (let ((var-name


### PR DESCRIPTION
In macro forms that use with-slots, none of the slots might be used, which leads to a warning about the gensym not being used.