### PR TITLE
This patch makes defstructs able to be redefined. 

### DIFF
--- a/src/org/armedbear/lisp/LispClass.java
+++ b/src/org/armedbear/lisp/LispClass.java
@@ -38,7 +38,7 @@ import static org.armedbear.lisp.Lisp.*;
 
 public abstract class LispClass extends StandardObject
 {
-  private static final ConcurrentHashMap<Symbol, LispObject> map
+  public static final ConcurrentHashMap<Symbol, LispObject> map
           = new ConcurrentHashMap<Symbol, LispObject>();
 
   public static <T extends LispClass> T addClass(Symbol symbol, T c)

--- a/src/org/armedbear/lisp/StructureClass.java
+++ b/src/org/armedbear/lisp/StructureClass.java
@@ -125,4 +125,33 @@ public class StructureClass extends SlotClass
             return c;
         }
     };
+      // ### reinitialize-structure-class name direct-slots slots include => class
+    private static final Primitive REINITIALIZE_STRUCTURE_CLASS =
+        new Primitive("reinitialize-structure-class", PACKAGE_SYS, false)
+    {
+        @Override
+        public LispObject execute(LispObject first, LispObject second,
+                                  LispObject third, LispObject fourth)
+
+        {
+            Symbol symbol = checkSymbol(first);
+            LispObject directSlots = checkList(second);
+            LispObject slots = checkList(third);
+            Symbol include = checkSymbol(fourth);
+
+            StructureClass c = (StructureClass)LispClass.map.get(symbol);
+            if (include != NIL) {
+                LispClass includedClass = LispClass.findClass(include);
+                if (includedClass == null)
+                    return error(new SimpleError("Class " + include +
+                                                  " is undefined."));
+                c.setCPL(new Cons(c, includedClass.getCPL()));
+            } else
+                c.setCPL(c, BuiltInClass.STRUCTURE_OBJECT, BuiltInClass.CLASS_T);
+            c.setDirectSlotDefinitions(directSlots);
+            c.setSlotDefinitions(slots);
+            c.setFinalized(true);
+            return c;
+        }
+    };
 }


### PR DESCRIPTION
Currently, ABCL catches the case where the defstruct has been changed and throws an
error. The main issue with defstruct is that when compiling, the
accessors are inlined as position-based accessors. So

(defstruct a b)

will compile a-b into lispObject.getSlotValue_0().

If another slot is added at the beginning
(defstruct a first b)

Then using a-b will get the value of the slot first instead of b.

The mechanism that ABCL uses to do inline is a source
transform. Allowing redefinition prevents that source transformation
from being created. Without the source transform, the compiled accessors
get the correct slot, at the cost of some performance.

Redefinition is controlled by a global variable
*allow-defstruct-redefinition* and a new option to defstruct :optimize.
If *allow-defstruct-redefinition* is t then

(defstruct (a :optimize nil) b)

Will prevent the source transform from being created. Otherwise the
current ABCL behavior is replicated.

The way ABCL detects that a change has been made is by saving the slot
definitions in the structure class, in a map of class names to
class-object defined in LispClass. The class object has a copy of the
slot definitions. One change is that we make is to make that map public.
There's an accessor findClass, but the result can't be cast to a
StructureClass, which the it needs to be in order to do the redefinition.

Then we add a new java function in StructureClass.java
reinitialize-structure-class, which replicates most of the logic of
make-structure-class, except that it reuses the old structure class
object. It's necessary to use the old value so that generic methods
specialized on the class will still work.

In defstruct.lisp there are changes to recognize the new option, to
check it before defining source transforms, and to call reinitialize-structure-class
instead of make-structure-class if the defstruct is already defined.

In the case that a defstruct is first created without the :optimize
option then subseqently modified to use :optimize nil, a warning is
given that previously compiled functions that use the accessors may need
to be recompiled and the previously defined source transforms are removed.
However, as long as the order of previously defined slots in the newly
defined defstruct remains the same as the order in the old structure,
inlined accessors will continue to work and recompilation is not
necessary.

The intended use of redefinition is during development, where structures
may evolve. There's no reason to use this mechanism in production code.