### PR TITLE
Interning new keywords if specified with 'keyword:new-keyword' as in SBCL, CCL, Lispworks & Allegro

### DIFF
--- a/src/org/armedbear/lisp/Stream.java
+++ b/src/org/armedbear/lisp/Stream.java
@@ -1197,10 +1197,15 @@ public class Stream extends StructureObject {
                                                  new SimpleString(symbolName),
                                                  new SimpleString(packageName)));
                 } else {
+                  if (packageName.equals("KEYWORD")) {
+                    return pkg.intern(symbolName);
+                  }
+                  else {
                     return error(new ReaderError("The symbol \"~A\" was not found in package ~A.",
                                                  this,
                                                  new SimpleString(symbolName),
                                                  new SimpleString(packageName)));
+                  }
                 }
             }
         } else {                // token.length == 0


### PR DESCRIPTION
I noticed that ABCL (as in ECL and CLISP) raises an error when one tries to specify a keyword using the package prefix

For example: _keyword:world_

In SBCL, CCL , Lispworks & Allegro CL this is allowed and a new keyword symbol is automatically interned.
After reading the CL standard I'm not sure if this an issue solved in these implementations or just
an extension implemented by them.
But, in any case, I think is more comfortable for the user to allow it (even knowing that normally the package prefix is not used for specify keywords)

So, this PR implements this behavior for ABCL, interning automatically every new keyword symbol when using "keyword" as package prefix.
