### PR TITLE
First working stepper for ABCL!

### DIFF
--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -618,12 +618,12 @@ public static synchronized final void handleInterrupt()
       Package pkg;
       switch (userInput.charAt(0)) {
       case '?':
-        System.out.println("Type 'l' for see the values of bindings on the local environment");
-        System.out.println("Type 'c' for resume the evaluation until the end without the stepper");
-        System.out.println("Type 'n' for resume the evaluation until the next form previously selected to step in");
-        System.out.println("Type 's' for step into the form");
-        System.out.println("Type 'i' for inspect the current value of a variable or symbol");
-        System.out.println("Type 'q' for quit the evaluation and return NIL");
+        System.out.println("Type 'l' to see the values of bindings on the local environment");
+        System.out.println("Type 'c' to resume the evaluation until the end without the stepper");
+        System.out.println("Type 'n' to resume the evaluation until the next form previously selected to step in");
+        System.out.println("Type 's' to step into the form");
+        System.out.println("Type 'i' to inspect the current value of a variable or symbol");
+        System.out.println("Type 'q' to quit the evaluation and return NIL");
         break;
       case 'l':
         setSteppingOff();
@@ -635,12 +635,12 @@ public static synchronized final void handleInterrupt()
         LispObject[] argsEnv = new LispObject[1];
         argsEnv[0] = env;
         LispObject resultVars = funcall(environmentAllVariables, argsEnv, currentThread);
-        System.out.println("Showing the values for variable bindings.");
-        System.out.println("From inner to outer bindings:");
+        System.out.println("Showing the values of variable bindings.");
+        System.out.println("From inner to outer scopes:");
         Environment.pprintListLocals(resultVars);
         LispObject resultFuncs = funcall(environmentAllFunctions, argsEnv, currentThread);
-        System.out.println("Showing the values for functions bindings.");
-        System.out.println("From inner to outer bindings:");
+        System.out.println("Showing the values of functions bindings.");
+        System.out.println("From inner to outer scopes:");
         Environment.pprintListLocals(resultFuncs);
         setSteppingOnAfterInit();
         break;

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -623,6 +623,7 @@ public static synchronized final void handleInterrupt()
         System.out.println("Type 'n' for resume the evaluation until the next form previously selected to step in");
         System.out.println("Type 's' for step into the form");
         System.out.println("Type 'i' for inspect the current value of a variable or symbol");
+        System.out.println("Type 'q' for quit the evaluation and return NIL");
         break;
       case 'l':
         setSteppingOff();

--- a/src/org/armedbear/lisp/boot.lisp
+++ b/src/org/armedbear/lisp/boot.lisp
@@ -175,6 +175,7 @@
 (load-system-file "arrays")
 (load-system-file "compiler-macro")
 (load-system-file "subtypep")
+(load-system-file "stepper")
 (load-system-file "typep")
 (load-system-file "signal")
 (load-system-file "list")
@@ -212,5 +213,3 @@
   (unless *noinform*
     (%format t "Startup completed in ~A seconds.~%"
              (float (/ (ext:uptime) 1000)))))
-
-

--- a/src/org/armedbear/lisp/compile-system.lisp
+++ b/src/org/armedbear/lisp/compile-system.lisp
@@ -198,7 +198,7 @@
                          combos
                          :key #'first)))
            (filter-setf-combos (combos)
-             (filter-combos 
+             (filter-combos
               (remove-multi-combo-symbols
                (remove-if (lambda (x) (member x '("clos") :test #'string=)) combos :key #'first))))
            (symbols-pathspec (filespec)
@@ -308,6 +308,7 @@
       (load (do-compile "early-defuns.lisp"))
       (load (do-compile "typep.lisp"))
       (load (do-compile "subtypep.lisp"))
+      (load (do-compile "stepper.lisp"))
       (load (do-compile "find.lisp"))
       (load (do-compile "print.lisp"))
       (load (do-compile "pprint-dispatch.lisp"))
@@ -517,10 +518,9 @@
          (home (pathname *lisp-home*))
          (src (format nil "~A**/*.*" home))
          (java (format nil "~A../../../**/*.*" home)))
-    (with-open-file (s system :direction :output 
+    (with-open-file (s system :direction :output
                        :if-exists :supersede)
       (pprint `(setf (logical-pathname-translations "sys")
                     '(("SYS:SRC;**;*.*" ,src)
                       ("SYS:JAVA;**;*.*" ,java)))
        s))))
-      


### PR DESCRIPTION
Hi guys

I just completed a working stepper for ABCL (more details below)

See #264 

I think it can help ABCL users even knowing that is an initial attempt.
I've been starting to working in make it compatible with Sly/Slime but it was not trivial and I couldn't
complete a successful integration for now (if someone can do it would be awesome).

If you have some time, please take a look at it, and try to test it.
An maybe we could merge it if you think is ready enougth to be our first stepper.

It can be of course improved, but IMO it can be seen as a working starting point.

I'm attaching a simple session here.

Happy hacking!

Some characteristics:

- For intepreted code
- For plain REPL only, it is still not working with Sly/Slime
When called inside Sly/Slime it will only show print a message and return the form without any stepping
- ? will print a minimal help
- Can inspect variables and symbols in the current package with 'i'
- 'c' will resume the evaluation until the end without the stepper
- 's' will resume the evaluation until the next form to be analyzed
- case-insensitive when inspecting

[stepper-session.txt](https://github.com/armedbear/abcl/files/9667294/stepper-session.txt)

