### PR TITLE
Implement jnew-runtime-class array types

### DIFF
--- a/src/org/armedbear/lisp/jvm-class-file.lisp
+++ b/src/org/armedbear/lisp/jvm-class-file.lisp
@@ -243,13 +243,19 @@ type, or a `class-name' structure identifying a class or interface."
       (map-primitive-type field-type)
       (class-name-internal field-type)))
 
+(defun map-array-type (field-type)
+  (assert (eql :array (first field-type)))
+  (concatenate 'string "["
+   (internal-field-ref (second field-type))))
+
 (defun internal-field-ref (field-type)
   "Returns a string containing the JVM-internal representation of a reference
 to `field-type', which should either be a symbol identifying a primitive
 type, or a `class-name' structure identifying a class or interface."
-  (if (symbolp field-type)
-      (map-primitive-type field-type)
-      (class-ref field-type)))
+  (etypecase field-type
+    (symbol (map-primitive-type field-type))
+    (cons (map-array-type field-type))
+    (jvm-class-name (class-ref field-type))))
 
 (defun descriptor (return-type &rest argument-types)
   "Returns a string describing the `return-type' and `argument-types'

--- a/src/org/armedbear/lisp/runtime-class.lisp
+++ b/src/org/armedbear/lisp/runtime-class.lisp
@@ -171,6 +171,7 @@
   (cond
     ((stringp type) (make-jvm-class-name type))
     ((keywordp type) type)
+    ((consp type) type)
     (t (error "Unrecognized Java type: ~A" type))))
 
 (defun java::emit-unbox-and-return (return-type)


### PR DESCRIPTION
Example using [rabbitmq](https://rabbitmq.github.io/rabbitmq-java-client/api/4.x.x/com/rabbitmq/client/DefaultConsumer.html):

```lisp
(j:jnew-runtime-class
 "LispConsumer"
 :superclass "com.rabbitmq.client.DefaultConsumer"
 :constructors '((("com.rabbitmq.client.Channel")
                  (lambda (this channel)
                    (declare (ignore this channel)))
                  (1)))
 :methods '(("handleDelivery" :void
             ("java.lang.String"
              "com.rabbitmq.client.Envelope"
              "com.rabbitmq.client.AMQP$BasicProperties"
              (:array :byte))
             (lambda (this consumer-tag envelope properties body)
               (handler consumer-tag envelope properties body)))))
```

Fixes #516 