### PR TITLE
Compiler wide/20221208a

### DIFF
--- a/t/compiler.lisp
+++ b/t/compiler.lisp
@@ -35,5 +35,23 @@
    (t (e) (prove:diag (format nil "Compilation failed signalling ~a" e))))
  "Able to compile tagbody not found form.")
 
+(prove:plan 1)
+(prove:ok
+ (let* ((instructions
+          (list
+           (jvm::make-instruction 58 '(5))
+           (jvm::make-instruction 58 '(2 4 :wide-prefix))))
+        (code
+          (make-array (length instructions)
+                      :initial-contents instructions))
+        (bytes
+          (jvm::code-bytes code)))
+   (eq (length bytes) 6))
+ "Compilation of wide ASTORE instruction.")
+
+
+ 
+   
+
 (prove:finalize)
 


### PR DESCRIPTION
Starts to fix the CFFI tests, which used to fail complaining about not be able to compile a JVM `ASTORE` form.  Now, other things fail, and the test cores, but perhaps that is progress.