### PR TITLE
build:  Maven now abcl to build and test ABCL

### DIFF
--- a/README
+++ b/README
@@ -71,7 +71,7 @@ To install Quicklisp for ABCL in the Docker container run:
 
 See <file:Dockerfile> for the build instructions.
 
-[podman]: https://podman.io/releases/2022/02/22/podman-release-v4.0.0.html
+[podman]: https://podman.io/releases/
 [Docker Engine]: https://www.docker.com/products/docker-engine
 
 
@@ -82,8 +82,9 @@ After you have downloaded a binary release from either [the
 distributed Maven POM graph][maven-abcl] or from
 [abcl.org][abcl.org-release] archive unpack it into its own
 directory. To run ABCL directly from this directory, make sure the
-Java executable (`java`) (Java 6, 7, 8, 11, 13, 14, 15, 16, 17, 18,
-and 19 are supported by ABCL 1.9.1) is in your shell's path.
+Java executable (`java`) is in your shell's path.  Java 8, 11, 17 are
+strongly supported by ABCL, but others may work with a little elbow
+grease.
 
 [maven-abcl]:          <https://mvnrepository.com/artifact/org.abcl/abcl/1.9.0>
 [maven-abcl-contrib]:  <https://mvnrepository.com/artifact/org.abcl/abcl-contrib/1.9.0>
@@ -114,7 +115,8 @@ BUILDING FROM SOURCE RELEASE
 
 ABCL may be built from its source code by executing the build
 instructions <file:build.xml> expressed by the venerable Apache Ant
-tool.
+tool.  Alternately, one may use the Apache Maven tool as a facade to
+Ant.
 
 To build, one must have a Java 6, 7, 8, 11, 13, 14, 15, 16 or 17 Java
 Development Kit (openjdk) installed locally. Just the Java Runtime
@@ -125,11 +127,18 @@ Download a binary distribution [Ant version 1.7.1 or greater][ant].
 Unpack the files somewhere convenient, ensuring that the 'ant' (or
 'ant.bat' under Windows) executable is in your path and executable.
 
-[ant]: http://ant.apache.org/bindownload.cgi
+[ant]: https://ant.apache.org/bindownload.cgi
 
 Then simply executing 
 
     cmd$ ant
+
+To use [Maven], download it, ensure the `mvn` executable is in your
+PATH and then
+
+    cmd$ mvn -Dmaven.test.skip=true install 
+
+[Maven]: https://maven.apache.org/download.cgi
 
 from the directory containing the <file:build.xml> instructions will
 create an executable wrapper ('abcl' under UNIX, 'abcl.bat' under
@@ -149,9 +158,9 @@ or from the shell as
 
     bash ci/create-abcl-properties.bash openjdk17
 
-Currently supported platforms are 'openjdk6', 'openjdk7', 'openjdk8',
-'openjdk11', 'openjdk13', 'openjdk14', 'openjdk15', 'openjd16',
-'openjdk17', 'openjdk18', and 'openjdk19'.
+Currently supported platforms are 'openjdk8', 'openjdk11',
+'openjdk13', 'openjdk14', 'openjdk15', 'openjd16', 'openjdk17',
+'openjdk18', and 'openjdk19'.
 
 
 USING APACHE NETBEANS
@@ -170,7 +179,7 @@ linked SLIME `swank.asd` ASDF configuration
 <file:~/.config/common-lisp/source-registry.conf.d/> to connect a REPL
 to the NetBeans debug process.
 
-[netbeans]: http://netbeans.org/downloads/
+[netbeans]: https://netbeans.org/downloads/
 
 
 SLIME

--- a/build.xml
+++ b/build.xml
@@ -1111,17 +1111,6 @@ ${basedir}/../cl-bench
       <java fork="true" dir="${basedir}"
             classpathref="abcl.classpath.dist"
             classname="org.armedbear.lisp.Main">
-        <!-- Run in 64bit mode-->
-        <jvmarg value="-d64"/> 
-
-        <!-- Enable JVM assertions -->
-        <jvmarg value="-ea"/>  
-        
-        <!-- (Possibly) unload classes when reference count reaches zero -->
-        <jvmarg value="-XX:+CMSClassUnloadingEnabled"/> 
-
-        <!-- Increase the size of the space used to store JVM class metadata. -->
-        <jvmarg value="-XX:MaxPermSize=768m"/> 
 
         <arg value="--noinit"/> 
         <arg value="--eval"/><arg value="(require (quote asdf))"/>
@@ -1159,6 +1148,8 @@ ${basedir}/../cl-bench
             classname="org.armedbear.lisp.Main">
         <arg value="--noinit"/> 
         <arg value="--eval"/><arg value="(require (quote asdf))"/>
+        <arg value="--eval"/><arg value="(require (quote abcl-contrib))"/>
+        <arg value="--eval"/><arg value="(asdf:make :quicklisp-abcl)"/>
         <arg value="--eval"/>
           <arg value="(asdf:initialize-source-registry `(:source-registry (:directory ,*default-pathname-defaults*) :inherit-configuration))"/>
         <arg value="--eval"/><arg value="(asdf:test-system :abcl/test/cl-bench)"/>

--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -14,7 +14,7 @@
   </parent>
   <groupId>org.abcl</groupId>
   <artifactId>abcl-contrib</artifactId>
-  <version>1.9.0</version>
+  <version>1.9.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Armed Bear Common Lisp (ABCL) Contribs</name>
   <description>Extra contributions for ABCL code not necessarily

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-
-Since the 'tools.jar' on which the Apache antrun Maven plugin depends
-doesn't exist in post-openjdk8 distributions, this artifact CANNOT
-BUILD ABCL UNLESS run with a JDK that maven-antrun-plugin can find.
-
-
---> 
-
 <project
    xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
    xmlns="https://maven.apache.org/POM/4.0.0"
@@ -21,7 +12,7 @@ BUILD ABCL UNLESS run with a JDK that maven-antrun-plugin can find.
   </parent>
   <groupId>org.abcl</groupId>
   <artifactId>abcl</artifactId>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
   <packaging>jar</packaging>
   <name>ABCL - Armed Bear Common Lisp</name>
   <description>Common Lisp implementation running on the JVM</description>
@@ -67,29 +58,13 @@ BUILD ABCL UNLESS run with a JDK that maven-antrun-plugin can find.
   </developers>
   <dependencies/>
   <build>
-    <!--
-    N.b. this ain't gonna work other than for openjdk8 builds, as it
-    will error on a message akin to the following:
-
-[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (clean) on project abcl: Execution clean of goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run failed: Plugin org.apache.maven.plugins:maven-antrun-plugin:3.1.0 or one of its dependencies could not be resolved: Could not find artifact com.sun:tools:jar:1.5.0 at specified path /Library/Java/JavaVirtualMachines/jdk-19.0.1+10/Contents/Home/../lib/tools.jar -> [Help 1]
-
--->
-
     <directory>${project.basedir}/build</directory>
     <sourceDirectory>${project.basedir}/src</sourceDirectory>
     <plugins>
       <plugin>
 	<artifactId>maven-antrun-plugin</artifactId>
 	<version>3.1.0</version>
-	<!-- <https://stackoverflow.com/questions/34713222/wrapping-ant-in-maven-java-home-points-to-the-jre-but-works-with-just-ant> -->
-	<dependencies>
-	  <dependency>
-	    <groupId>com.sun</groupId>
-	    <artifactId>tools</artifactId>
-	    <version>1.5.0</version>
-	    <scope>system</scope>
-	    <systemPath>${java.home}/../lib/tools.jar</systemPath>
-	  </dependency>
+	<dependencies> 
 	</dependencies>
 	<executions>
 	  <execution>
@@ -122,6 +97,31 @@ BUILD ABCL UNLESS run with a JDK that maven-antrun-plugin can find.
 	    <configuration>
 	      <target>
 		<ant antfile="build.xml" target="abcl.wrapper"/>
+                <ant antfile="build.xml" target="abcl.contrib"/>
+	      </target>
+	    </configuration>
+	    <goals>
+	      <goal>run</goal>
+	    </goals>      
+	  </execution>
+          <execution>
+	    <id>test</id>
+	    <phase>test</phase>
+	    <configuration>
+	      <target>
+                <ant antfile="build.xml" target="test.abcl"/>
+
+                <!-- test.ansi.compiled requires
+                     <git+https://gitlab.common-lisp.net/ansi-test/ansi-test/>
+                     to be cloned locally as <file:../ansi-test/>
+                -->
+                <ant antfile="build.xml" target="test.ansi.compiled"/>
+
+                <!-- test.cl-bench requires
+                     <git+https://gitlab.common-lisp.net/ansi-test/cl-bench/>
+                     to be cloned locally as <file:../cl-bench/>
+                -->
+                <ant antfile="build.xml" target="test.cl-bench"/>
 	      </target>
 	    </configuration>
 	    <goals>


### PR DESCRIPTION
No longer needing to support openjdk6 enables us to use the Maven Ant run plugin to delegate common Maven lifecycle points to the canonical build instructions.

The following Maven invocation now work:

   mvn compile
   mvn install
   mvn test

Tests via ANSI-TEST and CL-BENCH still need to be cloned locally manually in order for the full testing suite to pass.

Maven will install Ant "on its own" if it isn't already present.