### PR TITLE
Avoid NIL in simple LOOP from FORMAT directives

### DIFF
--- a/src/org/armedbear/lisp/format.lisp
+++ b/src/org/armedbear/lisp/format.lisp
@@ -598,7 +598,8 @@
       (multiple-value-bind (form new-directives)
         (expand-directive (car remaining-directives)
                           (cdr remaining-directives))
-        (push form results)
+        (when form
+          (push form results))
         (setf remaining-directives new-directives)))
     (reverse results)))
 

--- a/test/lisp/abcl/misc-tests.lisp
+++ b/test/lisp/abcl/misc-tests.lisp
@@ -152,3 +152,17 @@
 (deftest package-error-package.1
     (package-error-package (nth-value 1 (ignore-errors (intern "FOO" :bar))))
   :bar)
+
+;;; Simple LOOP requires only compound forms. Hence NIL is not
+;;; permitted. Some FORMAT directives (like newline) return NIL
+;;; as the form when they have nothing to add to the body.
+;;; Normally this is fine since BLOCK accepts NIL as a form. On
+;;; the other hand, when the newline directive is inside of an
+;;; iteration directive this will produce something like
+;;; (LOOP (fu) nil (bar)) which is not acceptable. To verify
+;;; that this is not happening we make sure we are not getting
+;;; (BLOCK NIL NIL) since this is easier to test for.
+(deftest format-no-nil-form.1
+    (third (second (macroexpand-1 '(formatter "~
+"))))
+  (block nil))


### PR DESCRIPTION
(Tarn W. Burton) <https://github.com/yitzchak>

Simple LOOP requires only compound forms. Hence NIL is not permitted. Some FORMAT directives (like newline) return NIL as the form when they have nothing to add to the body. Normally this is fine since BLOCK accepts NIL as a form. On the other hand, when the newline directive is inside of an iteration directive this will produce something like

    (LOOP (fu) nil (bar))

This is probably mostly a spec compliance issue. It does not show up as a bug since ABCL's Loop implementation isn't strict in this sense. Loading an alternate LOOP implementation which is more strict like Khazern will cause FORMAT to fail.

PRs have already been submitted and merged for some of the other CMUCL-based FORMAT implementations like Clasp and ECL.

Via <https://github.com/armedbear/abcl/pull/559>.