### PR TITLE
Make `(log x 0)` return 0 (as per the spec)

### DIFF
--- a/src/org/armedbear/lisp/MathFunctions.java
+++ b/src/org/armedbear/lisp/MathFunctions.java
@@ -524,6 +524,8 @@ public final class MathFunctions
                 else
                     return new SingleFloat((float)d);
             }
+	    /* The spec says, "If base is zero, log returns zero." */
+	    if (base.zerop()) return Fixnum.ZERO;
             return log(number).divideBy(log(base));
         }
     };

--- a/test/lisp/abcl/math-tests.lisp
+++ b/test/lisp/abcl/math-tests.lisp
@@ -401,6 +401,30 @@
   (log 17d0 10d0)
   1.2304489213782739d0)
 
+(deftest log.8
+  (log -2 0)
+  0)
+
+(deftest log.9
+  (log 2 0.0)
+  0)
+
+(deftest log.10
+  (log 1.0 0)
+  0)
+
+(deftest log.11
+  (log 1.0 0.0)
+  0)
+
+(deftest log.12
+  (log -1 0.0)
+  0)
+
+(deftest log.13
+  (log #C(1 2) 0)
+  0)
+
 (deftest pi.1
   pi
   #+clisp 3.1415926535897932385l0


### PR DESCRIPTION
The spec says that

_"If base is zero, log returns zero."_

But ABCL was not checking for zero, so a divide by zero error was generated.

This patch makes it return zero when the base is zero.