### PR TITLE
Return 0 with appropriate inexactness from log

### DIFF
--- a/src/org/armedbear/lisp/MathFunctions.java
+++ b/src/org/armedbear/lisp/MathFunctions.java
@@ -524,8 +524,10 @@ public final class MathFunctions
                 else
                     return new SingleFloat((float)d);
             }
-	    /* The spec says, "If base is zero, log returns zero." */
-	    if (base.zerop()) return Fixnum.ZERO;
+	    /* The spec says, "If base is zero, log returns zero."
+	       The multiplication below is to automatically take care
+	       of inexactness contagion. */
+	    if (base.zerop()) return base.multiplyBy(number);
             return log(number).divideBy(log(base));
         }
     };


### PR DESCRIPTION
A previous commit would return `Fixnum.ZERO` for `(log b n)` if `b` is zero; this commit makes it return `b * n`, that will automatically return the correct zero (`0`, `0.0` or `0.0d0`), according to the inexactness contagion rules.

(Sorry for having missed this in the other PR)