### PR TITLE
Gray streams/GitHub/issue/512

### DIFF
--- a/src/org/armedbear/lisp/BroadcastStream.java
+++ b/src/org/armedbear/lisp/BroadcastStream.java
@@ -238,15 +238,16 @@ public final class BroadcastStream extends Stream
         {
             Stream[] streams = new Stream[args.length];
             for (int i = 0; i < args.length; i++) {
-                if (args[i] instanceof Stream) {
-                    if (((Stream)args[i]).isOutputStream()) {
-                        streams[i] = (Stream) args[i];
+                Stream s = checkStream(args[i]);
+                if (s instanceof Stream) {
+                    if (s.isOutputStream()
+                        || (s instanceof CLOSProxyStream)) {
+                        streams[i] = s;
                         continue;
-                    } else
-                        return type_error(args[i],
-                                          list(Symbol.SATISFIES, Symbol.OUTPUT_STREAM_P));
-                } else
-                    return type_error(args[i], Symbol.STREAM);
+                    }
+                }
+                return type_error(args[i],
+                                  list(Symbol.SATISFIES, Symbol.OUTPUT_STREAM_P));
             }
             // All is well.
             return new BroadcastStream(streams);

--- a/src/org/armedbear/lisp/BuiltInClass.java
+++ b/src/org/armedbear/lisp/BuiltInClass.java
@@ -192,8 +192,9 @@ public class BuiltInClass extends LispClass
   public static final LispClass CONCATENATED_STREAM =
     addClass(Symbol.CONCATENATED_STREAM,
              new StructureClass(Symbol.CONCATENATED_STREAM, list(SYSTEM_STREAM)));
-
-
+  public static final LispClass CLOS_STREAM =
+    addClass(Symbol.CLOS_STREAM,
+             new StructureClass(Symbol.CLOS_STREAM, list(SYSTEM_STREAM)));
 
     // Implementation defined streams
   public static final LispClass SOCKET_STREAM =

--- a/src/org/armedbear/lisp/CLOSProxyStream.java
+++ b/src/org/armedbear/lisp/CLOSProxyStream.java
@@ -1,0 +1,14 @@
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+public class CLOSProxyStream
+  extends Stream
+{
+  LispObject clos = null;
+
+  public CLOSProxyStream(LispObject clos) {
+    super(Symbol.CLOS_STREAM);
+    this.clos = clos;
+  }
+}

--- a/src/org/armedbear/lisp/ConcatenatedStream.java
+++ b/src/org/armedbear/lisp/ConcatenatedStream.java
@@ -253,16 +253,16 @@ public final class ConcatenatedStream extends Stream
         {
             LispObject streams = NIL;
             for (int i = 0; i < args.length; i++) {
-                if (args[i] instanceof Stream) {
-                    Stream stream = (Stream) args[i];
-                    if (stream.isInputStream()) {
-                        //                         streams[i] = (Stream) args[i];
-                        streams = new Cons(stream, streams);
-                        continue;
+                Stream s = checkStream(args[i]);
+                if (s instanceof Stream) {
+                    if (s.isInputStream()
+                        || (s instanceof CLOSProxyStream)) {
+                            streams = new Cons(s, streams);
+                            continue;
                     }
                 }
                 error(new TypeError(String.valueOf(args[i]) +
-                                     " is not an input stream."));
+                                    " is not an input stream."));
             }
             return new ConcatenatedStream(streams.nreverse());
         }

--- a/src/org/armedbear/lisp/EchoStream.java
+++ b/src/org/armedbear/lisp/EchoStream.java
@@ -248,11 +248,9 @@ public final class EchoStream extends Stream
         public LispObject execute(LispObject first, LispObject second)
 
         {
-            if (!(first instanceof Stream))
-                return type_error(first, Symbol.STREAM);
-            if (!(second instanceof Stream))
-                return type_error(second, Symbol.STREAM);
-            return new EchoStream((Stream) first, (Stream) second);
+            Stream input = checkStream(first);
+            Stream output = checkStream(second);
+            return new EchoStream(input, output);
         }
     };
 

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -1755,10 +1755,15 @@ public static synchronized final void handleInterrupt()
   public static final Stream checkStream(LispObject obj)
 
   {
-      if (obj instanceof Stream)
-                  return (Stream) obj;
-          return (Stream) // Not reached.
-        type_error(obj, Symbol.STREAM);
+    if (obj instanceof Stream) {
+      return (Stream) obj;
+    }
+    if (obj.typep(Symbol.STREAM).equal(T)) {
+      Stream result = new CLOSProxyStream(obj);
+      return result;
+    }
+    return (Stream) // Not reached.
+    type_error(obj, Symbol.STREAM);
   }
 
   public static final Stream checkCharacterInputStream(LispObject obj)

--- a/src/org/armedbear/lisp/Stream.java
+++ b/src/org/armedbear/lisp/Stream.java
@@ -2686,5 +2686,4 @@ public class Stream extends StructureObject {
     public PushbackReader getWrappedReader() {
         return reader;
     }
-
 }

--- a/src/org/armedbear/lisp/StructureObject.java
+++ b/src/org/armedbear/lisp/StructureObject.java
@@ -40,6 +40,11 @@ public class StructureObject extends LispObject
   private final StructureClass structureClass;
   final LispObject[] slots;
 
+  public StructureObject() {
+    structureClass = null;
+    slots = null;
+  }
+
   public StructureObject(Symbol symbol)
 
   {

--- a/src/org/armedbear/lisp/Symbol.java
+++ b/src/org/armedbear/lisp/Symbol.java
@@ -3070,6 +3070,8 @@ public class Symbol extends LispObject implements java.io.Serializable
     PACKAGE_SYS.addExternalSymbol("AUTOCOMPILE");
   public static final Symbol CLASS_BYTES =
     PACKAGE_SYS.addExternalSymbol("CLASS-BYTES");
+  public static final Symbol CLOS_STREAM =
+    PACKAGE_SYS.addExternalSymbol("CLOS-STREAM");
   public static final Symbol _CLASS_SLOTS =
     PACKAGE_SYS.addExternalSymbol("%CLASS-SLOTS");
   public static final Symbol COMPILED_LISP_FUNCTION_P =

--- a/src/org/armedbear/lisp/TwoWayStream.java
+++ b/src/org/armedbear/lisp/TwoWayStream.java
@@ -229,12 +229,16 @@ public class TwoWayStream extends Stream
         {
             final Stream in = checkStream(first);
             final Stream out = checkStream(second);
-            if (!in.isInputStream())
-                return type_error(in, list(Symbol.SATISFIES,
-                                                 Symbol.INPUT_STREAM_P));
-            if (!out.isOutputStream())
+            if (!in.isInputStream()
+                && !(in instanceof CLOSProxyStream)) {
+                 return type_error(in, list(Symbol.SATISFIES,
+                                            Symbol.INPUT_STREAM_P));
+            }
+            if (!out.isOutputStream()
+                && !(out instanceof CLOSProxyStream)) {
                 return type_error(out, list(Symbol.SATISFIES,
                                                   Symbol.OUTPUT_STREAM_P));
+            }
             return new TwoWayStream(in, out);
         }
     };

--- a/t/gray-streams.lisp
+++ b/t/gray-streams.lisp
@@ -1,0 +1,36 @@
+;;;; Tests for <https://github.com/armedbear/abcl/issues/512>
+(in-package :cl-user)
+
+(unless (ignore-errors 
+         (asdf:make :trivial-gray-streams))
+  (asdf:make :abcl-quicklisp)
+  (ql:quickload :trivial-gray-streams))
+
+
+(defclass out-stream
+    (trivial-gray-streams:fundamental-character-output-stream)
+  ())
+
+(defclass in-stream
+    (trivial-gray-streams:fundamental-character-input-stream)
+  ())
+
+(prove:plan 4)
+
+(prove:ok
+ (make-two-way-stream (make-instance 'in-stream) (make-instance 'out-stream))
+ "Create TWO-WAY-STREAM from Gray streams")
+
+(prove:ok 
+ (make-broadcast-stream (make-instance 'out-stream))
+ "Create BROADCAST-STREAM from Gray stream")
+
+(prove:ok
+ (make-concatenated-stream (make-instance 'in-stream))
+ "Create CONCATENATED-STREAM from Gray stream")
+
+(prove:ok
+ (make-echo-stream (make-instance 'in-stream) (make-instance 'out-stream))
+ "Create ECHO-STREAM from Gray streams")
+
+(prove:finalize)


### PR DESCRIPTION
The stupidest implementation possible for <https://github.com/armedbear/abcl/issues/512>: create an intermediate CLOSProxyStream object, have Lisp.checkStream() return this proxy when passed a CLOS object whose type predicate machinery indicates it is descended from STREAM.

See how this does with the test suites.