### PR TITLE
Fix gray-stream-element-type missing for binary streams

### DIFF
--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -246,6 +246,10 @@
 
 (defclass fundamental-binary-stream (fundamental-stream) ())
 
+(defmethod gray-stream-element-type ((s fundamental-binary-stream))
+  (declare (ignore s))
+  '(unsigned-byte 8))
+
 (defgeneric stream-read-byte (stream))
 (defgeneric stream-write-byte (stream integer))
 


### PR DESCRIPTION
(Uthar)

Addresses <https://github.com/armedbear/abcl/issues/511>.