### PR TITLE
Create POSIX-SYSCALLS contrib to set environment variables

### DIFF
--- a/contrib/posix-syscalls/getenv.lisp
+++ b/contrib/posix-syscalls/getenv.lisp
@@ -1,0 +1,33 @@
+(in-package :system/posix-syscalls)
+
+(defun c-library-reference ()
+  (#"getInstance" 'com.sun.jna.NativeLibrary "c"))
+
+(defun getenv (variable)
+  (let ((found (#"invokePointer"
+                (#"getFunction" (c-library-reference) "getenv")
+                (java:jnew-array-from-list "java.lang.Object" (list variable)))))
+    (when found
+      (#"getString" found 0))))
+
+(defun putenv (variable value)
+  (let ((variable=value
+          (java:jnew-array-from-list "java.lang.Object"
+                                     (list
+                                      (format nil "~a=~a"
+                                              variable  value)))))
+          (#"invokeInt"
+           (#"getFunction" (c-library-reference) "putenv")
+           variable=value)))
+
+(defun unsetenv (variable)
+  (when
+      (= 0
+         (#"invokeInt"
+          (#"getFunction" (c-library-reference) "unsetenv")
+          (java:jnew-array-from-list "java.lang.Object" (list variable))))
+    t))
+      
+  
+
+

--- a/contrib/posix-syscalls/package.lisp
+++ b/contrib/posix-syscalls/package.lisp
@@ -1,0 +1,8 @@
+(defpackage system/posix-syscalls
+  (:nicknames #:sys/posix-syscalls)
+  (:use :common-lisp)
+  (:export
+   #:getenv
+   #:putenv
+   #:unsetenv))
+

--- a/contrib/posix-syscalls/posix-syscalls.asd
+++ b/contrib/posix-syscalls/posix-syscalls.asd
@@ -1,0 +1,14 @@
+(defsystem posix-syscalls
+  :depends-on (jna)
+  :components ((:module package :pathname ""
+                :components ((:file "package")))
+               (:module source :pathname ""
+                :depends-on (package)
+                :components ((:file "getenv")))
+               (:module shim-system :pathname ""
+                :depends-on (source)
+                :components ((:file "system")))))
+
+                
+
+

--- a/contrib/posix-syscalls/posix-syscalls.org
+++ b/contrib/posix-syscalls/posix-syscalls.org
@@ -1,0 +1,53 @@
+#+title: POSIX SYSCALLS
+
+* POSIX_SYSCALLS contrib
+
+Created to respond to <https://mailman.common-lisp.net/pipermail/armedbear-devel/2023-April/004308.html>.
+
+This ABCL contrib provides and demonstrates the scaffolding for
+extending the implementation by use of direct syscalls via the foreign
+function interface (FFI) afforded by the JNA library.
+
+On loading this system, new implementations of the EXT:GETENV and
+UIOP/OS:GETENV functions are provided which use FFI to directly call
+the setenv() and getenv() library functions.  The setenv()
+functionality is provided by DEFSETF expander.
+
+** Usage
+
+*** Initialization 
+#+begin_src lisp
+  (require :abcl-contrib)
+  (asdf:load-system :posix-syscalls)
+#+end_src
+
+*** Example
+
+#+begin_src 
+CL-USER> (uiop/os:getenv "PATH")
+"/opt/local/bin:/opt/local/sbin:/usr/bin:/bin:/usr/sbin:/sbin"
+CL-USER> (setf (uiop/os:getenv "PATH") "/usr/sbin")
+"/usr/sbin"
+CL-USER> (uiop/os:getenv "PATH")
+"/usr/sbin"
+CL-USER> 
+#+end_src
+
+** Notes
+
+CFFI isn't used to minimize dependencies.
+
+Posix syscalls is perhaps a terrible name.
+
+This isn't expected work on Windows (untested).
+
+
+* Colophon  
+  #+begin_example
+    Mark <evenson@not.org>
+    Created: 24-MAY-2023
+    Revised: <2023-05-25 Thu 08:38>
+  #+end_example
+
+
+

--- a/contrib/posix-syscalls/system.lisp
+++ b/contrib/posix-syscalls/system.lisp
@@ -1,0 +1,35 @@
+(in-package :system/posix-syscalls)
+
+;;; Currently unused, but save original symbol functions
+(defvar *ext--getenv*
+  #'ext:getenv)
+(defvar *uiop/os--getenv*
+  #'uiop/os:getenv)
+
+(eval-when (:load-toplevel)
+  (when
+      (c-library-reference)
+    (defun ext:getenv (variable)
+      (getenv variable))
+    (defsetf ext:getenv (variable) (value)
+      `(progn
+         (when (= (putenv ,variable ,value)
+                0)
+           ,value)))
+    (setf (symbol-function 'uiop/os:getenv)
+          'getenv)
+    ;;; XXX figure out how to reuse the ext:getenv expander?
+    (defsetf uiop/os:getenv (variable) (value)
+      `(progn
+         (when (= (putenv ,variable ,value)
+                  0)
+           ,value)))))
+
+         
+
+
+
+
+      
+
+    

--- a/doc/manual/abcl.tex
+++ b/doc/manual/abcl.tex
@@ -14,7 +14,7 @@
 \title{Armed Bear Common Lisp User Manual}
 \date{Version 1.9.2 DRAFT\\
 \smallskip
-February 2023}
+Unreleased}
 \author{Mark Evenson \and Erik H\"{u}lsmann \and Rudolf Schlatte \and
   Alessio Stalla \and Ville Voutilainen}
 
@@ -1533,6 +1533,15 @@ following behavior to the execution of \code{REQUIRE} on these symbols:
       See \ref{section:named-readtables} on
       \pageref{section:named-readtables} for further information.
 
+    \item[\code{posix-syscalls}] Provides and demonstrates the
+      scaffolding for extending the implementation by use of direct
+      syscalls via the foreign function interface (FFI) afforded by
+      the JNA library.  Upon loading this system, new implementations
+      of the \code{EXT:GETENV} and \code{UIOP/OS:GETENV} functions are
+      installed which use FFI to directly call the \sc{posix} syscalls
+      where available, which allows environment variables to be set.
+      \index{POSIX-SYSCALLS}
+      
     \end{description}
 \end{description}
 


### PR DESCRIPTION
Based on code provided by Alan Ruttenberg in
<https://github.com/alanruttenberg/lsw2/blob/owlapiv4/util/setenv.lisp>.

See
<https://mailman.common-lisp.net/pipermail/armedbear-devel/2023-April/004308.html> ff.

See <file:contrib/posix-syscalls/posix-syscalls.org>.