### PR TITLE
build: include git commit id in version when building from source

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="antlib:org.apache.tools.ant"
+         xmlns:if="ant:if"
+         xmlns:unless="ant:unless"
          name="abcl-master" default="abcl.wrapper" basedir=".">
     <description>Compiling, testing, and packaging Armed Bear Common Lisp</description>
 
@@ -49,10 +51,10 @@ For help on the automatic tests available, use the Ant target 'help.test'.
               value="${abcl.jar.path}"/>
 
     <!-- TODO verify me -->
-    <fail message="Please build using Ant 1.7.1 or higher.">
+    <fail message="Please build using Ant 1.9.1 or later.">
         <condition>
             <not>
-                <antversion atleast="1.7.1"/>
+                <antversion atleast="1.9.1"/>
             </not>
         </condition>
     </fail>
@@ -358,7 +360,7 @@ from ${abcl.home.dir}
         <or>
             <available
                 file="svnversion.exe"
-                filepath="${env.Path}"/>
+                filepath="${env.PATH}"/>
             <available
                 file="svnversion.exe"
                 filepath="${env.PATH}"/>
@@ -372,7 +374,24 @@ from ${abcl.home.dir}
       </and>
     </condition>
 
-    <target name="abcl.version.src" depends="abcl.version.src.3"/>
+    <condition property="abcl.version.git.p">
+      <and>
+        <available
+            file="${basedir}/.git"
+            type="dir"/>
+        <or>
+            <available
+                file="git"
+                filepath="${env.PATH}"/>
+            <available
+                file="git.exe"
+                filepath="${env.PATH}"/>
+        </or>
+      </and>
+    </condition>
+
+    <target name="abcl.version.src"
+            depends="abcl.version.src.3"/>
 
     <target name="abcl.version.src.0" if="windows">
       <exec
@@ -383,14 +402,23 @@ from ${abcl.home.dir}
     </target>
 
     <target name="abcl.version.src.1" depends="abcl.version.src.0">
-      <exec 
+      <exec
+          if:set="abcl.version.svn.p"
           executable="svnversion"
           outputproperty="abcl.version.svn.raw"
           failifexecutionfails="false"
           searchpath="true" />
+      <exec
+          if:set="abcl.version.git.p"
+          executable="git"
+          outputproperty="abcl.version.git.raw"
+          failifexecutionfails="false"
+          searchpath="true">
+        <arg line="rev-parse --short HEAD"/>
+      </exec>
     </target>
 
-    <target name="abcl.version.src.2" 
+    <target name="abcl.version.src.svn" 
             depends="abcl.version.src.1"
             if="abcl.version.svn.p">
 
@@ -408,12 +436,47 @@ from ${abcl.home.dir}
                 value="svn-${abcl.version.svn}"/>
     </target>
 
+    <target name="abcl.version.src.git"
+            depends="abcl.version.src.1"
+            if="abcl.version.git.p">
+
+      <!-- Transform all occurances of ":" ==> "-" in the version string -->
+      <tempfile property="version-tmp.path"/>
+      <echo message="${abcl.version.git.raw}"
+            file="${version-tmp.path}"/>
+      <replace file="${version-tmp.path}"
+               token=":" value="-"/>
+      <loadfile property="abcl.version.git" srcFile="${version-tmp.path}"/>
+      <delete file="${version-tmp.path}"/>
+
+      <echo>abcl.version.git: ${abcl.version.git}</echo>
+      <property name="abcl.version.src"
+                value="git-${abcl.version.git}"/>
+    </target>
+
+
+    <target name="abcl.src.not-under-version-control">
+      <condition property="abcl.src.not-under-version-control.p">
+        <and>
+          <not>
+            <isset property="abcl.version.svn.p"/>
+          </not>
+          <not>
+            <isset property="abcl.version.git.p"/>
+          </not>
+        </and>
+      </condition>
+    </target>
+      
+    
     <target name="abcl.version.src.3"
-            depends="abcl.version.src.2"
-            unless="abcl.version.svn.p">
+            depends="abcl.version.src.svn,abcl.version.src.git"
+            if="abcl.src.not-under-version-control.p">
       <property name="abcl.version.src"
                 value=""/>
     </target>
+
+    
 
     <property name="abcl.home.dir"
               value="${src.dir}/org/armedbear/lisp/"/>
@@ -466,15 +529,15 @@ Mercurial and Git.
     </target>
 
     <target name="abcl.stamp.version.1"
-            depends="abcl.stamp.version.0"
-            unless="abcl.version.svn.p">
+            depends="abcl.stamp.version.0,abcl.src.not-under-version-control"
+            if="abcl.src.not-under-version-control.p">
       <property name="abcl.implementation.version"
                 value="${abcl.version}"/>
     </target>
 
     <target name="abcl.stamp.version.2" 
             depends="abcl.stamp.version.0"
-            if="abcl.version.svn.p">
+            unless="abcl.src.not-under-version-control.p">
       <property name="abcl.implementation.version"
                 value="${abcl.version}-${abcl.version.src}"/>
     </target>
@@ -726,7 +789,8 @@ will compile (if necessary) and load JSS.
       </java>
     </target>
 
-    <target name="abcl.clean">
+    <target name="abcl.clean"
+            depends="abcl.clean.version">
       <delete dir="${build.dir}"/>
       <delete file="${abcl.jar.path}"/>
       <delete file="abcl"/>


### PR DESCRIPTION
Require Apache Ant 1.9.1, even though it looks like 1.10.x would be ok.

TODO: test that the svn and without source control logic still works

TODO: optimize/rename the Ant targets a bit to make things easier to understand.