### PR TITLE
Fix for procyon decompiler (for cl:disassemble)

### DIFF
--- a/contrib/abcl-introspect/README.org
+++ b/contrib/abcl-introspect/README.org
@@ -17,7 +17,7 @@ ABCL-INTROSPECT also contains a number of ASDF systems which provide
 modules to install as implementations for the JVM code analysis
 provided by CL:DISASSEMBLE.
 
-#+TABLE: Currently available decompilers as ASDF systems 
+#+TABLE: Currently available decompilers as ASDF systems
 |------------+--------------------------+-----------------------------------------------------------------------------|
 | ASDF       | status                   | URI                                                                         |
 |------------+--------------------------+-----------------------------------------------------------------------------|
@@ -25,7 +25,7 @@ provided by CL:DISASSEMBLE.
 | javap      | working                  | <<https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javap.html> |
 | cfr        | working                  | <https://www.benf.org/other/cfr>                                            |
 | jad        | fails ABCL-BUILD/install | <http://www.javadecompilers.com/jad/>                                       |
-| procyon    | loading                  | <https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler>             |
+| procyon    | working                  | <https://bitbucket.org/mstrobel/procyon/wiki/Java%20Decompiler>             |
 | fernflower | loading                  | <https://github.com/fesh0r/fernflower>                                      |
 
 
@@ -104,7 +104,7 @@ the SYS:*DISASSEMBLERS* variable.
     ;       LocalVariableTable:
     ;         Start  Length  Slot  Name   Signature
     ;             0      10     0  this   Lorg/armedbear/lisp/Primitives$pf_cons;
-    ; 
+    ;
     ;   public org.armedbear.lisp.LispObject execute(org.armedbear.lisp.LispObject, org.armedbear.lisp.LispObject);
     ;     descriptor: (Lorg/armedbear/lisp/LispObject;Lorg/armedbear/lisp/LispObject;)Lorg/armedbear/lisp/LispObject;
     ;     flags: ACC_PUBLIC
@@ -125,8 +125,8 @@ the SYS:*DISASSEMBLERS* variable.
     ;             0      10     2 second   Lorg/armedbear/lisp/LispObject;
     ; }
     ; SourceFile: "Primitives.java"
-#+end_src    
-    
+#+end_src
+
 * Colophon
 
 #+caption: Metadata Colophon

--- a/contrib/abcl-introspect/procyon.lisp
+++ b/contrib/abcl-introspect/procyon.lisp
@@ -4,9 +4,22 @@
      #:disassemble-class-bytes))
 (in-package :abcl-introspect/jvm/tools/procyon)
 
+
+(defun bytes->temp-file (bytes)
+  (let* ((create-temp-file-method
+           (java:jmethod "java.io.File" "createTempFile"
+                         "java.lang.String" "java.lang.String" "java.io.File"))
+         (write-method (java:jmethod "java.io.FileOutputStream" "write" "byte[]"))
+         (temp-file (java:jstatic create-temp-file-method "java.io.File"
+                                  (symbol-name (gensym "classfile")) ".class" java:+null+))
+         (temp-file-output-stream (java:jnew "java.io.FileOutputStream" temp-file))
+         (to-string-method (java:jmethod "java.lang.Object" "toString")))
+    (java:jcall write-method temp-file-output-stream bytes)
+    (java:jcall to-string-method temp-file)))
+
 (defun disassemble-class-bytes (object)
   #|
-  <https://bitbucket.org/mstrobel/procyon/wiki/Decompiler%20API> 
+  <https://bitbucket.org/mstrobel/procyon/wiki/Decompiler%20API>
 
     final DecompilerSettings settings = DecompilerSettings.javaDefaults();
 
@@ -23,27 +36,19 @@
         // handle error
     }
   |#
-  (let* ((settings
-           (#"javaDefaults" 'DecompilerSettings))
-         (writer
-           (jss:new 'java.io.StringWriter)))
-    (#"decompile" 'Decompiler
-                  ;;; !!! need to reference as a type in the current VM
-                  ;;; c.f.<https://github.com/Konloch/bytecode-viewer/blob/master/src/the/bytecode/club/bytecodeviewer/decompilers/ProcyonDecompiler.java>
-                  object
-                  (jss:new 'PlainTextOutput writer)
-                  settings)
-    (write (#"toString writer"))))
+  (let ((decompile-method (java:jmethod "com.strobel.decompiler.Decompiler"
+                                        "decompile" "java.lang.String"
+                                        "com.strobel.decompiler.ITextOutput"))
+        (string-writer (java:jnew "java.io.StringWriter")))
+    (java:jstatic decompile-method
+                  "com.strobel.decompiler.Decompiler"
+                  (bytes->temp-file object)
+                  (java:jnew "com.strobel.decompiler.PlainTextOutput" string-writer))
+    (java:jcall (java:jmethod "java.io.StringWriter" "toString") string-writer)))
+
+
 
 (eval-when (:load-toplevel :execute)
   (pushnew `(:procyon . abcl-introspect/jvm/tools/procyon::disassemble-class-bytes)
            sys::*disassemblers*)
   (format cl:*load-verbose* "~&; ~a: Successfully added procyon disassembler.~%" *package*))
-
-
-
-
-
-
-  
-  


### PR DESCRIPTION
- This makes procyon disassembler work in ABCL, internally it is using a temp file for the byte array received, then the temp file is passed to the decompiler.
- Updated decompiler status info

See #423 