### PR TITLE
Fix MAPC/MAPCAR for circular lists

### DIFF
--- a/src/org/armedbear/lisp/Primitives.java
+++ b/src/org/armedbear/lisp/Primitives.java
@@ -2910,36 +2910,43 @@ public final class Primitives {
         }
         @Override
         public LispObject execute(final LispObject[] args)
-
         {
             final int numArgs = args.length;
-            if (numArgs < 2)
+            if (numArgs < 2) {
                 return error(new WrongNumberOfArgumentsException(this, 2, -1));
-            int commonLength = -1;
-            for (int i = 1; i < numArgs; i++) {
-                if (!args[i].listp())
-                    type_error(args[i], Symbol.LIST);
-                int len = args[i].length();
-                if (commonLength < 0)
-                    commonLength = len;
-                else if (commonLength > len)
-                    commonLength = len;
             }
             final LispThread thread = LispThread.currentThread();
-            LispObject[] results = new LispObject[commonLength];
             final int numFunArgs = numArgs - 1;
             final LispObject[] funArgs = new LispObject[numFunArgs];
-            for (int i = 0; i < commonLength; i++) {
-                for (int j = 0; j < numFunArgs; j++)
-                    funArgs[j] = args[j+1].car();
-                results[i] = funcall(args[0], funArgs, thread);
-                for (int j = 1; j < numArgs; j++)
-                    args[j] = args[j].cdr();
-            }
+	    LispObject result = NIL;
+	    LispObject tail = NIL;
+	    boolean done = false; 
+            while (!done) {
+	      for (int j = 1; j < numArgs; j++) {
+		if (args[j] == NIL) {
+		  done = true;
+                }
+              }
+	      if (!done) {
+                for (int j = 0; j < numFunArgs; j++) {
+                  funArgs[j] = args[j+1].car();
+                }
+		  
+                LispObject one = funcall(args[0], funArgs, thread);
+
+                if (result == NIL) {
+                  result = new Cons(one,NIL);
+                  tail = result;
+                } else {
+                  tail.setCdr(new Cons(one,NIL));
+                  tail = tail.cdr();
+                }
+                for (int j = 1; j < numArgs; j++) {
+                  args[j] = args[j].cdr();
+                }
+              }
+	    }
             thread._values = null;
-            LispObject result = NIL;
-            for (int i = commonLength; i-- > 0;)
-                result = new Cons(results[i], result);
             return result;
         }
     };
@@ -2989,29 +2996,30 @@ public final class Primitives {
 
         {
             final int numArgs = args.length;
-            if (numArgs < 2)
-                return error(new WrongNumberOfArgumentsException(this, 2, -1));
-            int commonLength = -1;
-            for (int i = 1; i < numArgs; i++) {
-                if (!args[i].listp())
-                    type_error(args[i], Symbol.LIST);
-                int len = args[i].length();
-                if (commonLength < 0)
-                    commonLength = len;
-                else if (commonLength > len)
-                    commonLength = len;
+            if (numArgs < 2) {
+              return error(new WrongNumberOfArgumentsException(this, 2, -1));
             }
             final LispThread thread = LispThread.currentThread();
-            LispObject result = args[1];
             final int numFunArgs = numArgs - 1;
+	    LispObject result = args[1];
+	    boolean done = false;
             final LispObject[] funArgs = new LispObject[numFunArgs];
-            for (int i = 0; i < commonLength; i++) {
-                for (int j = 0; j < numFunArgs; j++)
+            while (!done) {
+	      for (int j = 1; j < numArgs; j++) {
+		if (args[j] == NIL) {
+		  done = true;
+                }
+              }
+	      if (!done) {
+                for (int j = 0; j < numFunArgs; j++) {
                     funArgs[j] = args[j+1].car();
+                }
                 funcall(args[0], funArgs, thread);
-                for (int j = 1; j < numArgs; j++)
-                    args[j] = args[j].cdr();
-            }
+                for (int j = 1; j < numArgs; j++) {
+                  args[j] = args[j].cdr();
+                }
+              }
+	    }
             thread._values = null;
             return result;
         }


### PR DESCRIPTION
(Alan Ruttenberg)

<https://github.com/mnepveu> reported issues with using circular lists in ABCL with data structures for an application which works in SBCL/CCL but would cause ABCL to hang.

The following test case no longer causes ABCL to hang:

     (setq *print-circle* t)

     (defun number-of-items (rtype datefrom dateto)
       10)

     (defun circularlist (items)
       (setf (cdr (last items)) items)
       items)

     (mapcar #'number-of-items
             '("abîmé" "administratif" "autre" "client insatisfait" "coin défecteux"
               "couleur / profil" "défectueux" "erreur créaction" "erreur du client"
               "erreur expédition" "impression" "mesure" "offset" "qualité" "transport"
               "égratignée")
             (circularlist (list "2023-07-31"))
             (circularlist (list "2023-08-07")))

Implementation from
<https://github.com/armedbear/abcl/issues/612#issuecomment-1667066101>.

See also <https://github.com/armedbear/abcl/issues/611>.

Addresses <https://github.com/armedbear/abcl/issues/612>.