### PR TITLE
Signal error for malformed #b/#o/#x/#r reader macros

### DIFF
--- a/src/org/armedbear/lisp/Stream.java
+++ b/src/org/armedbear/lisp/Stream.java
@@ -1514,6 +1514,9 @@ public class Stream extends StructureObject {
         String s = sb.toString();
         if (s.indexOf('/') >= 0)
             return makeRatio(s, radix);
+        if (s.length() == 0) {
+          return error(new ReaderError("Malformed number in a #b/#o/#x/#r macro."));
+        }
         // Integer.parseInt() below handles a prefixed '-' character correctly, but
         // does not accept a prefixed '+' character, so we skip over it here
         if (s.charAt(0) == '+')


### PR DESCRIPTION
Without this, #b/#o/#x/#r reader macros bomb out in Java making for a substandard user experience.