### PR TITLE
Implement vector-to-vector `replace` as a primitive

### DIFF
--- a/src/org/armedbear/lisp/AbstractVector.java
+++ b/src/org/armedbear/lisp/AbstractVector.java
@@ -307,4 +307,28 @@ public abstract class AbstractVector extends AbstractArray
     {
       return adjustArray(dims[0], displacedTo, displacement);
   }
+
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    int i, j;
+
+    // If we are copying around in the same vector, be careful not to copy the
+    // same elements over repeatedly. We do this by copying backwards. The spec
+    // allows us to ignore the case where structure is shared via displacement.
+    if (this == source && targetStart > sourceStart) {
+      int nelts = Math.min(targetEnd - targetStart, sourceEnd - sourceStart);
+      for (i = targetStart + nelts - 1, j = sourceStart + nelts - 1;
+           i >= targetStart && j >= sourceStart;
+           --i, --j)
+        aset(i, source.AREF(j));
+    } else {
+      for (i = targetStart, j = sourceStart;
+           i < targetEnd && j < sourceEnd;
+           ++i, ++j)
+        aset(i, source.AREF(j));
+    }
+    return this;
+  }
 }

--- a/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_ByteBuffer.java
@@ -325,4 +325,22 @@ public final class BasicVector_ByteBuffer
                                     int displacement) {
     return new ComplexVector(newCapacity, displacedTo, displacement);
   }
+
+  @Override
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    if (source instanceof BasicVector_ByteBuffer) {
+      ByteBuffer view = ((BasicVector_ByteBuffer)source).elements.asReadOnlyBuffer();
+      view.position(sourceStart);
+      view.limit(sourceEnd);
+      elements.position(targetStart);
+      elements.put(view);
+      elements.position(0);
+      return this;
+    } else {
+      return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+    }
+  }
 }

--- a/src/org/armedbear/lisp/BasicVector_CharBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_CharBuffer.java
@@ -303,6 +303,24 @@ public final class BasicVector_CharBuffer
                                     int displacement) {
     return new ComplexVector(newCapacity, displacedTo, displacement);
   }
+
+  @Override
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    if (source instanceof BasicVector_CharBuffer) {
+      CharBuffer view = ((BasicVector_CharBuffer)source).elements.asReadOnlyBuffer();
+      view.position(sourceStart);
+      view.limit(sourceEnd);
+      elements.position(targetStart);
+      elements.put(view);
+      elements.position(0);
+      return this;
+    } else {
+      return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+    }
+  }
 }
 
 

--- a/src/org/armedbear/lisp/BasicVector_IntBuffer.java
+++ b/src/org/armedbear/lisp/BasicVector_IntBuffer.java
@@ -308,4 +308,22 @@ public final class BasicVector_IntBuffer
                                      int displacement) {
     return new ComplexVector(newCapacity, displacedTo, displacement);
   }
+
+  @Override
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    if (source instanceof BasicVector_IntBuffer) {
+      IntBuffer view = ((BasicVector_IntBuffer)source).elements.asReadOnlyBuffer();
+      view.position(sourceStart);
+      view.limit(sourceEnd);
+      elements.position(targetStart);
+      elements.put(view);
+      elements.position(0);
+      return this;
+    } else {
+      return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+    }
+  }
 }

--- a/src/org/armedbear/lisp/BasicVector_UnsignedByte16.java
+++ b/src/org/armedbear/lisp/BasicVector_UnsignedByte16.java
@@ -296,4 +296,19 @@ public final class BasicVector_UnsignedByte16 extends AbstractVector
     {
         return new ComplexVector(newCapacity, displacedTo, displacement);
     }
+
+    @Override
+    public AbstractVector replace(AbstractVector source,
+                                  int targetStart, int targetEnd,
+                                  int sourceStart, int sourceEnd)
+    {
+        if (source instanceof BasicVector_UnsignedByte16) {
+            System.arraycopy(((BasicVector_UnsignedByte16)source).elements, sourceStart,
+                             elements, targetStart,
+                             Math.min(targetEnd - targetStart, sourceEnd - sourceStart));
+            return this;
+        } else {
+            return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+        }
+    }
 }

--- a/src/org/armedbear/lisp/BasicVector_UnsignedByte32.java
+++ b/src/org/armedbear/lisp/BasicVector_UnsignedByte32.java
@@ -310,4 +310,19 @@ public final class BasicVector_UnsignedByte32 extends AbstractVector
   {
     return new ComplexVector(newCapacity, displacedTo, displacement);
   }
+
+  @Override
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    if (source instanceof BasicVector_UnsignedByte32) {
+      System.arraycopy(((BasicVector_UnsignedByte32)source).elements, sourceStart,
+                       elements, targetStart,
+                       Math.min(targetEnd - targetStart, sourceEnd - sourceStart));
+      return this;
+    } else {
+      return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+    }
+  }
 }

--- a/src/org/armedbear/lisp/BasicVector_UnsignedByte8.java
+++ b/src/org/armedbear/lisp/BasicVector_UnsignedByte8.java
@@ -318,4 +318,19 @@ public final class BasicVector_UnsignedByte8 extends AbstractVector
   {
     return new ComplexVector(newCapacity, displacedTo, displacement);
   }
+
+  @Override
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    if (source instanceof BasicVector_UnsignedByte8) {
+      System.arraycopy(((BasicVector_UnsignedByte8)source).elements, sourceStart,
+                       elements, targetStart,
+                       Math.min(targetEnd - targetStart, sourceEnd - sourceStart));
+      return this;
+    } else {
+      return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+    }
+  }
 }

--- a/src/org/armedbear/lisp/Primitives.java
+++ b/src/org/armedbear/lisp/Primitives.java
@@ -5900,4 +5900,50 @@ public final class Primitives {
         }
     }
     
+    private static final Primitive _VECTOR_REPLACE
+            = new pf_vector_replace();
+    private static class pf_vector_replace extends Primitive {
+        pf_vector_replace() {
+            super("%vector-replace", PACKAGE_SYS, false);
+        }
+
+        @Override
+        public LispObject execute(LispObject target, LispObject source,
+                                  LispObject targetStart, LispObject targetEnd,
+                                  LispObject sourceStart, LispObject sourceEnd) {
+          if (!(target instanceof AbstractVector))
+            return type_error(target, Symbol.VECTOR);
+          if (!(source instanceof AbstractVector))
+            return type_error(source, Symbol.VECTOR);
+          if (!(targetStart instanceof Fixnum))
+            return type_error(targetStart, Symbol.FIXNUM);
+          if (!(targetEnd instanceof Fixnum))
+            return type_error(targetEnd, Symbol.FIXNUM);
+          if (!(sourceStart instanceof Fixnum))
+            return type_error(sourceStart, Symbol.FIXNUM);
+          if (!(sourceEnd instanceof Fixnum))
+            return type_error(sourceEnd, Symbol.FIXNUM);
+
+          int sStart = sourceStart.intValue();
+          int sEnd   = sourceEnd.intValue();
+          int tStart = targetStart.intValue();
+          int tEnd   = targetEnd.intValue();
+
+          // TODO: Better error messages? These are user-facing.
+          if (!(0 <= tStart && tStart <= tEnd && tEnd <= target.length()))
+            error(new LispError("Bad target sequence bounds."));
+          if (!(0 <= sStart && sStart <= sEnd && sEnd <= source.length()))
+            error(new LispError("Bad source sequence bounds."));
+
+          // Clamp here so we don't have to repeat this in every method.
+          sStart = Math.max(0, sStart);
+          sEnd   = Math.min(sEnd, source.length());
+          tStart = Math.max(0, tStart);
+          tEnd   = Math.min(tEnd, target.length());
+
+          int nelts = Math.min(sEnd - sStart, tEnd - tStart);
+
+          return ((AbstractVector)target).replace(((AbstractVector)source), tStart, tStart + nelts, sStart, sStart + nelts);
+        }
+    }
 }

--- a/src/org/armedbear/lisp/SimpleString.java
+++ b/src/org/armedbear/lisp/SimpleString.java
@@ -491,6 +491,21 @@ public final class SimpleString extends AbstractString
     }
 
     @Override
+    public AbstractVector replace(AbstractVector source,
+                                  int targetStart, int targetEnd,
+                                  int sourceStart, int sourceEnd)
+    {
+        if (source instanceof SimpleString) {
+            System.arraycopy(((SimpleString)source).chars, sourceStart,
+                             chars, targetStart,
+                             Math.min(targetEnd - targetStart, sourceEnd - sourceStart));
+            return this;
+        } else {
+            return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+        }
+    }
+
+    @Override
     public String toString()  {
         return String.valueOf(chars);
     }

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -363,6 +363,21 @@ public final class SimpleVector extends AbstractVector
     return new ComplexVector(newCapacity, displacedTo, displacement);
   }
 
+  @Override
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    if (source instanceof SimpleVector) {
+      System.arraycopy(((SimpleVector)source).data, sourceStart,
+                       data, targetStart,
+                       Math.min(targetEnd - targetStart, sourceEnd - sourceStart));
+      return this;
+    } else {
+      return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+    }
+  }
+
   // ### svref
   // svref simple-vector index => element
   private static final Primitive SVREF =

--- a/src/org/armedbear/lisp/replace.lisp
+++ b/src/org/armedbear/lisp/replace.lisp
@@ -43,27 +43,10 @@
 
 (eval-when (:compile-toplevel :execute)
 
-  ;;; If we are copying around in the same vector, be careful not to copy the
-  ;;; same elements over repeatedly.  We do this by copying backwards.
   (defmacro mumble-replace-from-mumble ()
-    `(if (and (eq target-sequence source-sequence) (> target-start source-start))
-         (let ((nelts (min (- target-end target-start) (- source-end source-start))))
-           (do ((target-index (+ (the fixnum target-start) (the fixnum nelts) -1)
-                              (1- target-index))
-                (source-index (+ (the fixnum source-start) (the fixnum nelts) -1)
-                              (1- source-index)))
-               ((= target-index (the fixnum (1- target-start))) target-sequence)
-             (declare (fixnum target-index source-index))
-             (setf (aref target-sequence target-index)
-                   (aref source-sequence source-index))))
-         (do ((target-index target-start (1+ target-index))
-              (source-index source-start (1+ source-index)))
-             ((or (= target-index (the fixnum target-end))
-                  (= source-index (the fixnum source-end)))
-              target-sequence)
-           (declare (fixnum target-index source-index))
-           (setf (aref target-sequence target-index)
-                 (aref source-sequence source-index)))))
+    `(%vector-replace target-sequence source-sequence
+                      target-start target-end
+                      source-start source-end))
 
   (defmacro list-replace-from-list ()
     `(if (and (eq target-sequence source-sequence) (> target-start source-start))


### PR DESCRIPTION
This patch turns vector-to-vector `replace` into a primitive with very fast copies between sequences of the same underlying types (and a slightly faster fallback in Java, although this is primarily for convenience). The current `(setf aref)` loop implementation is very slow, especially for ub8 vectors; code that stitches byte buffers together currently spends a lot of time in `replace` in my experience and a 100MB copy that currently takes ~75s takes ~35ms after this patch.

I'm not too familiar with the ABCL codebase, so some things probably still have to be fixed up. I'm especially unsure whether it's fine to do all the error checking in the primitive and leave the underlying methods unguarded. I'll be in `#abcl` for a while if things are more convenient that way.