### PR TITLE
Fix to fix to #606

### DIFF
--- a/src/org/armedbear/lisp/compiler-pass2.lisp
+++ b/src/org/armedbear/lisp/compiler-pass2.lisp
@@ -1301,9 +1301,8 @@ of the other types."
                        (return-from sh-str-helper nil)
                        (setf (gethash obj circularity-hashtable) t))))
                (cond
-                 ((atom obj)
-                  (when (assoc obj *externalized-objects* :test #'eq)
-                    (return-from shared-structure-p t)))
+                 ((and (atom obj) (not (eq obj 'quote)))
+                  (return-from shared-structure-p nil))
                  ((listp obj)
                   (when (assoc obj *externalized-objects* :test #'eq)
                     (return-from shared-structure-p t))

--- a/test/lisp/abcl/compiler-tests.lisp
+++ b/test/lisp/abcl/compiler-tests.lisp
@@ -578,3 +578,17 @@
       (prog1 (abcl/test/lisp::cp5d)
         (fmakunbound 'abcl/test/lisp::cp5d)))
   nil)
+
+#+abcl
+(deftest compiler.5e
+    (let ((tmpfile (ext::make-temp-file))
+          (code
+             "(defmacro cp5e (codelist)
+               `(list '(list) ,codelist))"))
+      (with-open-file (s tmpfile :direction :output)
+        (format s "~A" code))
+      (prog1
+          (load (compile-file tmpfile))
+        (delete-file tmpfile)
+        (fmakunbound 'abcl/test/lisp::cp5e)))
+  t)


### PR DESCRIPTION
Fixes #622: restrict in the validation to detect nested quoted forms that share components with previous externalized objects  so that now it only accepts exactly '#1#, ''#1#, and so on ... 