### PR TITLE
Rework SIMPLE-VECTOR implementation using openjdk8 facilities

### DIFF
--- a/src/org/armedbear/lisp/AbstractVector.java
+++ b/src/org/armedbear/lisp/AbstractVector.java
@@ -149,7 +149,7 @@ public abstract class AbstractVector extends AbstractArray
     return index;
   }
 
-  protected void badIndex(int index, int limit)
+  protected LispObject badIndex(int index, int limit)
   {
     StringBuilder sb = new StringBuilder("Invalid array index ");
     sb.append(index);
@@ -161,12 +161,11 @@ public abstract class AbstractVector extends AbstractArray
         sb.append(limit);
         sb.append(").");
       }
-    error(new TypeError(sb.toString(),
-                         Fixnum.getInstance(index),
-                         list(Symbol.INTEGER,
-                               Fixnum.ZERO,
-                               Fixnum.getInstance(limit - 1))));
-
+    return error(new TypeError(sb.toString(),
+                               Fixnum.getInstance(index),
+                               list(Symbol.INTEGER,
+                                    Fixnum.ZERO,
+                                    Fixnum.getInstance(limit - 1))));
   }
 
   public void setFillPointer(int n)

--- a/src/org/armedbear/lisp/BasicVector.java
+++ b/src/org/armedbear/lisp/BasicVector.java
@@ -1,0 +1,93 @@
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+public class BasicVector
+  extends SimpleVector
+{
+  public enum Specialization {
+    U8, U16, U32, U64
+  }
+  Specialization specializedOn;
+
+  public BasicVector(Class type) {
+    if (type.equals(Byte.class)) {
+      specializedOn = Specialization.U8;
+    } else if (type.equals(Short.class)) {
+      specializedOn = Specialization.U16;
+    } else if (type.equals(Integer.class)) {
+      specializedOn = Specialization.U32;
+    } else if (type.equals(Long.class)) {
+      specializedOn = Specialization.U64;
+    }
+  }
+
+  public BasicVector(Class type, int capacity) {
+    this(type);
+    this.capacity = capacity;
+  }
+
+  @Override
+  public LispObject typeOf() {
+    switch (specializedOn) {
+    case U8:
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_8, new Cons(Fixnum.getInstance(capacity)));
+    case U16:
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_16, new Cons(Fixnum.getInstance(capacity)));      
+    case U32:
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_32, new Cons(Fixnum.getInstance(capacity)));      
+    case U64:
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_64, new Cons(Fixnum.getInstance(capacity)));      
+    }
+    return program_error("Unreachable");
+  }
+
+  public LispObject typep(LispObject type) {
+    if (type instanceof Cons) {
+      if (type.car().equals(Symbol.SIMPLE_VECTOR)) {
+        LispObject vectorType = type.cdr();
+        switch (specializedOn) {
+        case U8:
+          if (vectorType.equals(UNSIGNED_BYTE_8)) {
+              return T;
+            }
+          break;
+        case U16:
+          if (vectorType.equals(UNSIGNED_BYTE_16)) {
+            return T;
+          }
+          break;
+        case U32:
+          if (vectorType.equals(UNSIGNED_BYTE_32)) {
+            return T;
+          }
+          break;
+        case U64:
+          if (vectorType.equals(UNSIGNED_BYTE_64)) {
+            return T;
+          }
+          break;
+        }
+      }
+    }
+    return super.typep(type);
+  }
+
+  @Override
+  public LispObject getElementType() {
+    switch (specializedOn) {
+    case U8:
+      return UNSIGNED_BYTE_8;
+    case U16:
+      return UNSIGNED_BYTE_16;
+    case U32:
+      return UNSIGNED_BYTE_32;
+    case U64:
+      return UNSIGNED_BYTE_64;
+    }
+    return program_error("Unknown element type: " + type);
+  }
+
+
+
+}

--- a/src/org/armedbear/lisp/BasicVectorBuffer.java
+++ b/src/org/armedbear/lisp/BasicVectorBuffer.java
@@ -22,12 +22,8 @@ public final class BasicVectorBuffer<T extends Buffer>
     data = (T) ByteBuffer.allocate(capacity);
   }
 
-  // public BasicVectorBuffer(int capacity) {
-  //   this(ByteBuffer.class, capacity, false);
-  // }
-
   @Override
-  public LispObject classOf() {
+  public LispObject typeOf() {
     if (clazz.equals(ByteBuffer.class)) {
       return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_8, new Cons(Fixnum.getInstance(capacity)));
     }

--- a/src/org/armedbear/lisp/BasicVectorBuffer.java
+++ b/src/org/armedbear/lisp/BasicVectorBuffer.java
@@ -27,7 +27,7 @@ public final class BasicVectorBuffer<T extends Buffer>
     if (clazz.equals(ByteBuffer.class)) {
       return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_8, new Cons(Fixnum.getInstance(capacity)));
     }
-    return program_error("Unimplemented classOf()");
+    return program_error("Unimplemented typeOf()");
   }
 
   public LispObject getDescription() {
@@ -37,17 +37,8 @@ public final class BasicVectorBuffer<T extends Buffer>
     return new SimpleString(sb);
   }
 
-  public LispObject typep(LispObject type)
-  {
-    if (type == Symbol.SIMPLE_VECTOR)
-      return T;
-    if (type == Symbol.SIMPLE_ARRAY)
-      return T;
-    if (type == BuiltInClass.SIMPLE_VECTOR)
-      return T;
-    if (type == BuiltInClass.SIMPLE_ARRAY)
-      return T;
-    // TODO return type based on CLAZZ and capacity
+  public LispObject typep(LispObject type) {
+    // FIXME type based on CLAZZ and capacity
     if (type instanceof Cons) {
       if (type.car().equals(Symbol.SIMPLE_VECTOR)
           && type.cdr().equals(UNSIGNED_BYTE_8)) {

--- a/src/org/armedbear/lisp/BasicVectorBuffer.java
+++ b/src/org/armedbear/lisp/BasicVectorBuffer.java
@@ -1,0 +1,224 @@
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.text.MessageFormat;
+import java.util.Arrays;
+
+// A basic vector is a specialized vector that is not displaced to another
+// array, has no fill pointer, and is not expressly adjustable.
+public final class BasicVectorBuffer<T extends Buffer>
+  extends SimpleVector
+{
+  boolean directAllocation;
+  T data;
+  
+  public BasicVectorBuffer(Class<ByteBuffer> type, int capacity, boolean directAllocation) {
+    this.clazz = type;
+    this.capacity = capacity;
+    this.directAllocation = directAllocation;
+    data = (T) ByteBuffer.allocate(capacity);
+  }
+
+  // public BasicVectorBuffer(int capacity) {
+  //   this(ByteBuffer.class, capacity, false);
+  // }
+
+  @Override
+  public LispObject classOf() {
+    if (clazz.equals(ByteBuffer.class)) {
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_8, new Cons(Fixnum.getInstance(capacity)));
+    }
+    return program_error("Unimplemented classOf()");
+  }
+
+  public LispObject getDescription() {
+    StringBuffer sb = new StringBuffer("A simple vector specialized on UNSIGNED_BYTE_8 with ");
+    sb.append(capacity);
+    sb.append(" elements");
+    return new SimpleString(sb);
+  }
+
+  public LispObject typep(LispObject type)
+  {
+    if (type == Symbol.SIMPLE_VECTOR)
+      return T;
+    if (type == Symbol.SIMPLE_ARRAY)
+      return T;
+    if (type == BuiltInClass.SIMPLE_VECTOR)
+      return T;
+    if (type == BuiltInClass.SIMPLE_ARRAY)
+      return T;
+    // TODO return type based on CLAZZ and capacity
+    if (type instanceof Cons) {
+      if (type.car().equals(Symbol.SIMPLE_VECTOR)
+          && type.cdr().equals(UNSIGNED_BYTE_8)) {
+        return T;
+      }
+    }
+    return super.typep(type);
+  }
+
+  @Override
+  public LispObject getElementType() { 
+    return UNSIGNED_BYTE_8;
+    // TODO return type based on CLAZZ
+  }
+
+  @Override
+  public LispObject elt(int i) {
+    try {
+      // TODO switch on clazz
+      return coerceFromJavaByte(((ByteBuffer)data).get(i));
+    } catch (ArrayIndexOutOfBoundsException e) {
+      return badIndex(i, capacity);
+    }
+  }
+
+  @Override
+  public LispObject AREF(int i) {
+    return elt(i);
+  }
+
+  @Override
+  public void aset(int i, LispObject n) {
+    aset(i, coerceToJavaByte(n));
+  }
+
+  public void aset(int i, byte n) {
+    try {
+      ((ByteBuffer)data).put(i, n);
+    } catch (IndexOutOfBoundsException e) {
+      badIndex(i, capacity);
+    }
+  }
+
+  @Override
+  public LispObject SVREF(int i) {
+    return elt(i);
+  }
+
+  @Override
+  public void svset(int i, LispObject newValue) {
+    aset(i, newValue);
+  }
+
+  @Override
+  public LispObject subseq(int start, int end) {
+    try {
+      // TODO: switch on clazz
+      int length = start - end;
+      BasicVectorBuffer<ByteBuffer> result
+        = new BasicVectorBuffer<ByteBuffer>(ByteBuffer.class, length, this.directAllocation);
+      ((ByteBuffer)data).get(result.data.array(), start, length);
+      return result;
+    } catch (ArrayIndexOutOfBoundsException e) {
+      String m
+        = MessageFormat.format("The bounding indices {0} and {1} are bad for a sequence of length {2}.", start, end, length());
+      return type_error(m, new JavaObject(e), NIL); // Not really a type_error, as there is not one type
+    }
+  }
+
+  @Override
+  public void fill(LispObject obj) { // TODO switch on CLAZZ
+    byte b = coerceToJavaByte(obj);
+    fill(b);
+  }
+
+  public void fill(byte b) {
+    Arrays.fill(((ByteBuffer)data).array(), b);
+  }
+
+
+  // TODO AbstractVector.deleteEq() could work, as well but is it faster?
+  @Override
+  public LispObject deleteEq(LispObject item) {
+    byte b = coerceToJavaByte(item);
+    return deleteEq(b);
+  }
+
+  public LispObject deleteEq(byte b) {
+    final int limit = capacity;
+    int i = 0;
+    int j = 0;
+    ByteBuffer buffer = (ByteBuffer) data;
+    while (i < limit) {
+      byte value = buffer.get(i++);
+      if (value != b) {
+        buffer.put(j++, value);
+      }
+    }
+    if (j < limit) {
+      shrink(j);
+    }
+    return this;
+  }
+
+  //
+  // TODO check on use of AbstractVector.deleteEql()
+  //
+  
+  @Override
+  public void shrink(int n) {
+    if (n < capacity) {
+      // thunk on CLAZZ
+      BasicVectorBuffer<ByteBuffer> result
+        = new BasicVectorBuffer<ByteBuffer>(ByteBuffer.class, n, this.directAllocation);
+      ((ByteBuffer)data).get(result.data.array(), 0, n);
+      capacity = n;
+      return;
+    }
+    if (n == capacity) {
+      return;
+    }
+    error(new LispError());
+  }
+
+  @Override
+  public LispObject reverse() {
+    // thunk on CLAZZ
+    BasicVectorBuffer<ByteBuffer> result
+      = new BasicVectorBuffer<ByteBuffer>(ByteBuffer.class, capacity, this.directAllocation);
+    
+    int i, j;
+    ByteBuffer source = (ByteBuffer)data;
+    ByteBuffer destination = (ByteBuffer)result.data;
+    for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
+      destination.put(i, source.get(j));
+    }
+    return result;
+  }
+
+  @Override
+  public LispObject nreverse() {
+    int i = 0;
+    int j = capacity() - 1;
+    ByteBuffer buffer = (ByteBuffer)data;
+    while (i < j) {
+      byte temp = buffer.get(i);
+      buffer.put(i, buffer.get(j));
+      buffer.put(j, temp);
+      ++i;
+      --j;
+    }
+    return this;
+  }
+
+  public AbstractVector replace(AbstractVector source,
+                                int targetStart, int targetEnd,
+                                int sourceStart, int sourceEnd)
+  {
+    if (source instanceof BasicVectorBuffer) {
+      byte[] sourceBytes = (byte[]) ((BasicVectorBuffer)source).data.array();
+      System.arraycopy(sourceBytes, sourceStart,
+                       data.array(), targetStart,
+                       Math.min(targetEnd - targetStart, sourceEnd - sourceStart));
+      return this;
+    } else {
+      return super.replace(source, targetStart, targetEnd, sourceStart, sourceEnd);
+    }
+  }
+}
+                                                                

--- a/src/org/armedbear/lisp/BasicVectorPrimitive.java
+++ b/src/org/armedbear/lisp/BasicVectorPrimitive.java
@@ -1,0 +1,105 @@
+package org.armedbear.lisp;
+
+import static org.armedbear.lisp.Lisp.*;
+
+import java.lang.reflect.Array;
+import java.nio.Buffer;
+
+// A basic vector is a specialized vector that is not displaced to another
+// array, has no fill pointer, and is not expressly adjustable.
+public final class BasicVectorPrimitive<T> extends SimpleVector {
+  T[] data;
+  Class type;
+  
+  public BasicVectorPrimitive(Class type, int capacity) {
+    super(capacity);
+    this.type = type;
+    data = (T[]) Array.newInstance(type, capacity);
+  }
+
+  public LispObject typeOf() {
+    if (type.equals(Byte.class)) {
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_8, new Cons(Fixnum.getInstance(capacity)));
+    } else if (type.equals(Short.class)) {
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_16, new Cons(Fixnum.getInstance(capacity)));
+    } else if (type.equals(Integer.class)) {
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_32, new Cons(Fixnum.getInstance(capacity)));
+    } else if (type.equals(Long.class)) {
+      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_64, new Cons(Fixnum.getInstance(capacity)));
+    }
+    return program_error("BasicVectorPrimitive couldn't determine type.");
+  }
+
+  //public LispObject classOf()
+  
+  //  public LispObject getDescription() {
+  //    StringBuffer sb = new StringBuffer(super.getDescription().toString());
+
+  public LispObject typep(LispObject type) {
+    if (type instanceof Cons) {
+      if (type.car().equals(Symbol.SIMPLE_VECTOR)
+          && (type.cdr().equals(UNSIGNED_BYTE_8)
+              || (type.cdr().equals(UNSIGNED_BYTE_16)) 
+              || (type.cdr().equals(UNSIGNED_BYTE_32)) 
+              || (type.cdr().equals(UNSIGNED_BYTE_64)))) {
+        return T;
+      }
+    }
+    return super.typep(type);
+  }
+
+  @Override
+  public LispObject getElementType() {
+    if (type.equals(Byte.class)) {
+      return UNSIGNED_BYTE_8;
+    } else if (type.equals(Short.class)) {
+      return UNSIGNED_BYTE_16;
+    } else if (type.equals(Integer.class)) {
+      return UNSIGNED_BYTE_32;
+    } else if (type.equals(Long.class)) {
+      return UNSIGNED_BYTE_64;
+    }
+    return program_error("Unknown element type: " + type);
+  }
+
+    // do these work?
+  //  public LispObject elt(int index)
+  //  public LispObject AREF(int index)
+  //   public LispObject SVREF(int index)
+  //   public void svset(int index, LispObject newValue)
+  //   public LispObject subseq(int start, int end)
+  //  public void fill(LispObject obj) {
+
+
+  //   public LispObject deleteEq(LispObject item)
+  //   public LispObject deleteEql(LispObject item)
+
+  
+  public void shrink(int n) {
+    if (n < capacity) {
+      BasicVectorPrimitive newArray = new BasicVectorPrimitive<>(type, n);
+      System.arraycopy(data, 0, newArray.data, 0, n);
+      data = (T[])newArray.data;
+      capacity = n;
+      return;
+    }
+    if (n == capacity) {
+      return;
+    }
+    error(new LispError());
+  }
+
+  public LispObject reverse() {
+    BasicVectorPrimitive result = new BasicVectorPrimitive<>(type, capacity);
+    int i, j;
+    for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
+      result.data[i] = data[j];
+    }
+    return result;
+  }
+  //   public LispObject nreverse()
+
+  //public AbstractVector adjustArray
+  // public AbstractVector adjustArray(int newCapacity, AbstractArray displacedTo, int displacement)
+
+}

--- a/src/org/armedbear/lisp/BasicVectorPrimitive.java
+++ b/src/org/armedbear/lisp/BasicVectorPrimitive.java
@@ -12,7 +12,6 @@ public final class BasicVectorPrimitive<T> extends SimpleVector {
   Class type;
   
   public BasicVectorPrimitive(Class type, int capacity) {
-    super(capacity);
     this.type = type;
     data = (T[]) Array.newInstance(type, capacity);
   }

--- a/src/org/armedbear/lisp/BasicVectorPrimitive.java
+++ b/src/org/armedbear/lisp/BasicVectorPrimitive.java
@@ -4,78 +4,179 @@ import static org.armedbear.lisp.Lisp.*;
 
 import java.lang.reflect.Array;
 import java.nio.Buffer;
+import java.text.MessageFormat;
+import java.util.Arrays;
 
 // A basic vector is a specialized vector that is not displaced to another
 // array, has no fill pointer, and is not expressly adjustable.
-public final class BasicVectorPrimitive<T> extends SimpleVector {
-  T[] data;
-  Class type;
+public final class BasicVectorPrimitive
+  extends BasicVector
+{
+  byte[] u8;
+  short[] u16;
+  int[] u32;
+  long[] u64;
   
   public BasicVectorPrimitive(Class type, int capacity) {
-    this.type = type;
-    data = (T[]) Array.newInstance(type, capacity);
-  }
-
-  public LispObject typeOf() {
-    if (type.equals(Byte.class)) {
-      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_8, new Cons(Fixnum.getInstance(capacity)));
-    } else if (type.equals(Short.class)) {
-      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_16, new Cons(Fixnum.getInstance(capacity)));
-    } else if (type.equals(Integer.class)) {
-      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_32, new Cons(Fixnum.getInstance(capacity)));
-    } else if (type.equals(Long.class)) {
-      return list(Symbol.SIMPLE_VECTOR, UNSIGNED_BYTE_64, new Cons(Fixnum.getInstance(capacity)));
+    super(type, capacity);
+    switch (specializedOn) {
+    case U8:
+      u8 = new byte[capacity];
+    case U16:
+      u16 = new short[capacity];
+    case U32:
+      u32 = new int[capacity];
+    case U64:
+      u64 = new long[capacity];
     }
-    return program_error("BasicVectorPrimitive couldn't determine type.");
   }
 
-  //public LispObject classOf()
+  public BasicVectorPrimitive(byte[] data) {
+    super(Byte.class, data.length);
+    u8 = data;
+  }
+  public BasicVectorPrimitive(short[] data) {
+    super(Short.class, data.length);
+    u16 = data;
+  }
+  public BasicVectorPrimitive(int[] data) {
+    super(Integer.class, data.length);
+    u32 = data;
+  }
+  public BasicVectorPrimitive(long[] data) {
+    super(Long.class, data.length);
+    u64 = data;
+  }
+
   
-  //  public LispObject getDescription() {
-  //    StringBuffer sb = new StringBuffer(super.getDescription().toString());
-
-  public LispObject typep(LispObject type) {
-    if (type instanceof Cons) {
-      if (type.car().equals(Symbol.SIMPLE_VECTOR)
-          && (type.cdr().equals(getElementType()))) {
-        return T;
-      }
-    }
-    return super.typep(type);
+  @Override
+  public LispObject elt(int i) {
+    return AREF(i);
   }
 
   @Override
-  public LispObject getElementType() {
-    if (type.equals(Byte.class)) {
-      return UNSIGNED_BYTE_8;
-    } else if (type.equals(Short.class)) {
-      return UNSIGNED_BYTE_16;
-    } else if (type.equals(Integer.class)) {
-      return UNSIGNED_BYTE_32;
-    } else if (type.equals(Long.class)) {
-      return UNSIGNED_BYTE_64;
-    }
-    return program_error("Unknown element type: " + type);
+  public LispObject AREF(int i) {
+    return SVREF(i);
   }
 
-    // do these work?
-  //  public LispObject elt(int index)
-  //  public LispObject AREF(int index)
-  //   public LispObject SVREF(int index)
-  //   public void svset(int index, LispObject newValue)
-  //   public LispObject subseq(int start, int end)
-  //  public void fill(LispObject obj) {
+  @Override
+  public void aset(int i, LispObject n) {
+    svset(i, n);
+  }
 
+  public LispObject SVREF(int i) {
+    try {
+      switch (specializedOn) {
+      case U8:
+        return coerceFromJavaByte(u8[i]);
+      case U16:
+        return Fixnum.getInstance(Short.toUnsignedInt(u16[i]));
+      case U32:
+        return Fixnum.getInstance(Integer.toUnsignedLong(u32[i]));
+      case U64:
+        return LispInteger.getUnsignedInstance(u64[i]);
+      }
+    }  catch (ArrayIndexOutOfBoundsException e) {
+      return badIndex(i, capacity);
+    }
+    return program_error("Supposedly unreachable code in BasicVectorPrimitive");
+  }
 
-  //   public LispObject deleteEq(LispObject item)
+  public void svset(int i, LispObject n) {
+    try {
+      switch (specializedOn) {
+      case U8:
+        byte b = coerceToJavaByte(n);
+        u8[i] = b;
+        break;
+      case U16:
+        short s = coerceToJavaUnsignedShort(n);
+        u16[i] = s;
+        break;
+      case U32:
+        int v  = coerceToJavaUnsignedInt(n);
+        u32[i] = v;
+        break;
+      case U64:
+        //        long v = ???
+        //          ((IntBuffer)data).put(i, v);
+        program_error("Unimplemented aset on long");
+        break;
+      }
+    } catch (IndexOutOfBoundsException e) {
+      badIndex(i, capacity);
+    }
+
+  }
+  public LispObject subseq(int start, int end) {
+    try {
+      switch (specializedOn) {
+      case U8:
+        byte[] bytes = Arrays.copyOfRange(u8, start, end);
+        return new BasicVectorPrimitive(bytes);
+      case U16:
+        short[] shorts = Arrays.copyOfRange(u16, start, end);
+        return new BasicVectorPrimitive(shorts);
+      case U32:
+        int[] ints = Arrays.copyOfRange(u32, start, end);
+        return new BasicVectorPrimitive(ints);
+      case U64:
+        long[] longs = Arrays.copyOfRange(u64, start, end);
+        return new BasicVectorPrimitive(longs);
+      }
+    } catch (ArrayIndexOutOfBoundsException e) {
+      String m
+        = MessageFormat.format("The bounding indices {0} and {1} are bad for a sequence of length {2}.", start, end, length());
+      return type_error(m, new JavaObject(e), NIL); // Not really a type_error, as there is not one type
+    }
+    return program_error("Unreachable");
+  }
+
+  @Override
+  public void fill(LispObject obj) {
+    switch (specializedOn) {
+    case U8:
+      byte b = coerceToJavaByte(obj);
+      Arrays.fill(u8, b);
+      break;
+    case U16:
+      short s = coerceToJavaUnsignedShort(obj);
+      Arrays.fill(u16, s);
+      break;
+    case U32:
+      int i = coerceToJavaUnsignedInt(obj);
+      Arrays.fill(u32,i);
+      break;
+    case U64:
+      program_error("Unimplemented fill of U64");
+      break;
+    }
+  }
+
+  //   public LispObject deleteEq(LispObject item)    
   //   public LispObject deleteEql(LispObject item)
 
-  
   public void shrink(int n) {
     if (n < capacity) {
-      BasicVectorPrimitive newArray = new BasicVectorPrimitive<>(type, n);
-      System.arraycopy(data, 0, newArray.data, 0, n);
-      data = (T[])newArray.data;
+      BasicVectorPrimitive newArray = new BasicVectorPrimitive(type, n);
+      switch (specializedOn) {
+      case U8:
+        System.arraycopy(u8, 0, newArray.u8, 0, n);
+        u8 = newArray.u8;
+        break;
+      case U16:
+        System.arraycopy(u16, 0, newArray.u16, 0, n);
+        u16 = newArray.u16;
+        break;
+      case U32:
+        System.arraycopy(u32, 0, newArray.u32, 0, n);
+        u32 = newArray.u32;
+        break;
+      case U64:
+        System.arraycopy(u64, 0, newArray.u64, 0, n);
+        u64 = newArray.u64;
+        break;
+      }
       capacity = n;
       return;
     }
@@ -86,16 +187,172 @@ public final class BasicVectorPrimitive<T> extends SimpleVector {
   }
 
   public LispObject reverse() {
-    BasicVectorPrimitive result = new BasicVectorPrimitive<>(type, capacity);
+    BasicVectorPrimitive result = new BasicVectorPrimitive(type, capacity);
     int i, j;
-    for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
-      result.data[i] = data[j];
+    switch (specializedOn) {
+    case U8:
+      for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
+        result.u8[i] = u8[j];
+      }
+      break;
+    case U16:
+      for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
+        result.u16[i] = u16[j];
+      }
+      break;
+    case U32:
+      for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
+        result.u32[i] = u32[j];
+      }
+      break;
+    case U64:
+      for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
+        result.u64[i] = u64[j];
+      }
+      break;
     }
     return result;
   }
-  //   public LispObject nreverse()
+  public LispObject nreverse() {
+    int i = 0;
+    int j = capacity - 1;
+    switch (specializedOn) {
+    case U8:
+      while (i < j) {
+        byte temp = u8[i];
+        u8[i] = u8[j];
+        u8[j] = temp;
+        ++i; --j;
+      }
+      break;
+    case U16:
+      while (i < j) {
+        short temp = u16[i];
+        u16[i] = u16[j];
+        u16[j] = temp;
+        ++i; --j;
+      }
+      break;
+    case U32:
+      while (i < j) {
+        int temp = u32[i];
+        u32[i] = u32[j];
+        u32[j] = temp;
+        ++i; --j;
+      }
+      break;
+    case U64:
+      while (i < j) {
+        long temp = u64[i];
+        u64[i] = u64[j];
+        u64[j] = temp;
+        ++i; --j;
+      }
+      break;
+    }
+    return this;
+  }
 
-  //public AbstractVector adjustArray
+  @Override
+  public AbstractVector adjustArray(int newCapacity,
+                                    LispObject initialElement,
+                                    LispObject initialContents)
+  {
+    if (initialContents != null) {
+      if (initialContents.listp()) {
+        LispObject list = initialContents;
+        switch (specializedOn) {
+        case U8:
+          byte[] bytes = new byte[newCapacity];
+          for (int i = 0; i < newCapacity; i++) {
+            bytes[i] = coerceToJavaByte(list.car());
+            list = list.cdr();
+          }
+          return new BasicVectorPrimitive(bytes);
+        case U16:
+          short[] shorts = new short[newCapacity];
+          for (int i = 0; i < newCapacity; i++) {
+            shorts[i] = coerceToJavaUnsignedShort(list.car());
+            list = list.cdr();
+          }
+          return new BasicVectorPrimitive(shorts);
+        case U32:
+          int[] ints = new int[newCapacity];
+          for (int i = 0; i < newCapacity; i++) {
+            ints[i] = coerceToJavaUnsignedInt(list.car());
+            list = list.cdr();
+          }
+          return new BasicVectorPrimitive(ints);
+        case U64:
+          program_error("Unimplemented adjustment of u64 array");
+        }
+      } else if (initialContents.vectorp()) {
+        if (initialContents instanceof BasicVectorPrimitive) {
+          switch(specializedOn) {
+          case U8:
+            byte[] bytes = Arrays.copyOfRange(u8, 0, newCapacity);
+            return new BasicVectorPrimitive(bytes);
+          case U16:
+            short[] shorts = Arrays.copyOfRange(u16, 0, newCapacity);
+            return new BasicVectorPrimitive(shorts);
+          case U32:
+            int[] ints = Arrays.copyOfRange(u32, 0, newCapacity);
+            return new BasicVectorPrimitive(ints);
+          case U64:
+            long[] longs = Arrays.copyOfRange(u64, 0, newCapacity);
+            return new BasicVectorPrimitive(longs);
+          }
+        } else {
+          program_error("Unimplmented adjust array for non BasicVectorPrimitive");
+        }
+      } else {
+        type_error(initialContents, Symbol.SEQUENCE);
+      }
+    }
+    if (capacity != newCapacity) {
+      if (initialElement == null) {
+        switch(specializedOn) {
+        case U8:
+          byte[] bytes = new byte[newCapacity];
+          bytes = Arrays.copyOfRange(u8, 0, Math.min(capacity, newCapacity));
+          return new BasicVectorPrimitive(bytes);
+        case U16:
+          short[] shorts = new short[newCapacity];
+          shorts = Arrays.copyOfRange(u16, 0, Math.min(capacity, newCapacity));
+          return new BasicVectorPrimitive(shorts);
+        case U32:
+          int[] ints = new int[newCapacity];
+          ints = Arrays.copyOfRange(u32, 0, Math.min(capacity, newCapacity));
+          return new BasicVectorPrimitive(ints);
+        case U64:
+          long[] longs = new long[newCapacity];
+          longs = Arrays.copyOfRange(u64, 0, Math.min(capacity, newCapacity));
+          return new BasicVectorPrimitive(longs);
+        }
+      }
+
+      BasicVectorPrimitive result = null;
+      switch(specializedOn) {
+      case U8:
+        result = new BasicVectorPrimitive(Byte.class, newCapacity);
+        break;
+      case U16:
+        result = new BasicVectorPrimitive(Short.class, newCapacity);
+        break;
+      case U32:
+        result = new BasicVectorPrimitive(Integer.class, newCapacity);
+        break;
+      case U64:
+        result = new BasicVectorPrimitive(Long.class, newCapacity);
+        break;
+      }
+      result.fill(initialElement);
+      return result;
+    }
+
+    // No change.
+    return this;
+  }
   // public AbstractVector adjustArray(int newCapacity, AbstractArray displacedTo, int displacement)
 
 }

--- a/src/org/armedbear/lisp/BasicVectorPrimitive.java
+++ b/src/org/armedbear/lisp/BasicVectorPrimitive.java
@@ -38,10 +38,7 @@ public final class BasicVectorPrimitive<T> extends SimpleVector {
   public LispObject typep(LispObject type) {
     if (type instanceof Cons) {
       if (type.car().equals(Symbol.SIMPLE_VECTOR)
-          && (type.cdr().equals(UNSIGNED_BYTE_8)
-              || (type.cdr().equals(UNSIGNED_BYTE_16)) 
-              || (type.cdr().equals(UNSIGNED_BYTE_32)) 
-              || (type.cdr().equals(UNSIGNED_BYTE_64)))) {
+          && (type.cdr().equals(getElementType()))) {
         return T;
       }
     }

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -1673,6 +1673,9 @@ public static synchronized final void handleInterrupt()
   public static final LispObject UNSIGNED_BYTE_32 =
     list(Symbol.UNSIGNED_BYTE, Fixnum.constants[32]);
 
+  public static final LispObject UNSIGNED_BYTE_64 =
+    list(Symbol.UNSIGNED_BYTE, Fixnum.constants[64]);
+
   public static final LispObject UNSIGNED_BYTE_32_MAX_VALUE
     = Bignum.getInstance(4294967295L);
 

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -1812,6 +1812,10 @@ public static synchronized final void handleInterrupt()
           return (byte)Fixnum.getValue(obj);
   }
 
+  public static final short coerceToJavaUnsignedShort(LispObject obj) {
+    return (short) (obj.longValue() & 0xffffL);
+  }
+
   public static final int coerceToJavaUnsignedInt(LispObject obj) {
     return (int) (obj.longValue() & 0xffffffffL);
   }

--- a/src/org/armedbear/lisp/LispInteger.java
+++ b/src/org/armedbear/lisp/LispInteger.java
@@ -50,5 +50,10 @@ public class LispInteger extends LispObject implements java.io.Serializable
       return Fixnum.getInstance(i);
   }
 
-
+  public static LispInteger getUnsignedInstance(long l) {
+    if (Long.signum(l) == -1) {
+      return Bignum.getInstance(Long.toUnsignedString(l), 10); // TOOD faster with bytes arithimetic
+    }
+    return getInstance(l);
+  }
 }

--- a/src/org/armedbear/lisp/LispInteger.java
+++ b/src/org/armedbear/lisp/LispInteger.java
@@ -56,4 +56,11 @@ public class LispInteger extends LispObject implements java.io.Serializable
     }
     return getInstance(l);
   }
+
+  public static long asUnsignedLong(LispInteger i) {
+    if (i instanceof Bignum) {
+      return ((Bignum)i).value.longValue();
+    }
+    return i.longValue();
+  }
 }

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -212,7 +212,7 @@ public final class SimpleVector<T extends LispObject> extends AbstractVector
   @Override
   public LispObject subseq(int start, int end)
   {
-    SimpleVector v = new SimpleVector(clazz, end - start);
+    SimpleVector v = new SimpleVector(end - start);
     int i = start, j = 0;
     try
       {
@@ -270,7 +270,7 @@ public final class SimpleVector<T extends LispObject> extends AbstractVector
   public void shrink(int n)
   {
     if (n < capacity) {
-      SimpleVector newArray = new SimpleVector(clazz, n);
+      SimpleVector newArray = new SimpleVector(n);
       System.arraycopy(data, 0, newArray.data, 0, n);
       data = (T[])newArray.data;
       capacity = n;
@@ -283,9 +283,8 @@ public final class SimpleVector<T extends LispObject> extends AbstractVector
   }
 
   @Override
-  public LispObject reverse()
-  {
-    SimpleVector result = new SimpleVector(clazz, capacity);
+  public LispObject reverse() {
+    SimpleVector result = new SimpleVector(capacity);
     int i, j;
     for (i = 0, j = capacity - 1; i < capacity; i++, j--) { 
       result.data[i] = data[j];

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -105,7 +105,7 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
   {
     StringBuffer sb = new StringBuffer("A simple vector with ");
     sb.append(capacity);
-    sb.append(" elements");
+    sb.append(" elements.");
     return new SimpleString(sb);
   }
 
@@ -390,9 +390,7 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
             return sv.data[index];
           } catch (ArrayIndexOutOfBoundsException e) {
             int capacity = sv.capacity;
-            sv.badIndex(index, capacity);
-            // Not reached.
-            return NIL;
+            return sv.badIndex(index, capacity);
           }
         }
         return type_error(first, Symbol.SIMPLE_VECTOR);

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -160,47 +160,27 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
   @Override
   public LispObject elt(int index)
   {
-    try {
-      return (T) data[index];
-    } catch (ArrayIndexOutOfBoundsException e) {
-      badIndex(index, capacity);
-      return NIL; // Not reached.
-    }
+    return SVREF(index);
   }
 
   @Override
-  public LispObject AREF(int index)
-  {
+  public LispObject AREF(int index) {
+    return SVREF(index);
+  }
+
+  @Override
+  public void aset(int index, LispObject newValue) {
+    svset(index, newValue);
+  }
+
+  @Override
+  public LispObject SVREF(int index) {
     try {
       return data[index];
     } catch (ArrayIndexOutOfBoundsException e) {
       badIndex(index, data.length);
       return NIL; // Not reached.
     }
-  }
-
-  @Override
-  public void aset(int index, LispObject newValue)
-  {
-    try {
-      data[index] = (T) newValue;
-    } catch (ArrayIndexOutOfBoundsException e) {
-      badIndex(index, capacity);
-    }
-  }
-
-  @Override
-  public LispObject SVREF(int index)
-  {
-    try
-      {
-        return data[index];
-      }
-    catch (ArrayIndexOutOfBoundsException e)
-      {
-        badIndex(index, data.length);
-        return NIL; // Not reached.
-      }
   }
 
   @Override
@@ -381,17 +361,20 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
     {
       @Override
       public LispObject execute(LispObject first, LispObject second) {
-        if (first instanceof SimpleVector) {
-          final SimpleVector sv = (SimpleVector)first;
-          int index = Fixnum.getValue(second);
-          try {
-            return sv.data[index];
-          } catch (ArrayIndexOutOfBoundsException e) {
-            int capacity = sv.capacity;
-            return sv.badIndex(index, capacity);
+        int index = Fixnum.getValue(second);
+          if (first instanceof BasicVectorPrimitive) {
+            return ((BasicVectorPrimitive)first).SVREF(index);
           }
-        }
-        return type_error(first, Symbol.SIMPLE_VECTOR);
+          if (first instanceof SimpleVector) {
+            final SimpleVector sv = (SimpleVector)first;            
+            try {
+              return sv.data[index];
+            } catch (ArrayIndexOutOfBoundsException e) {
+              int capacity = sv.capacity;
+              return sv.badIndex(index, capacity);
+            }
+          }
+          return type_error(first, Symbol.SIMPLE_VECTOR);
       }
     };
 
@@ -401,18 +384,20 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
     {
       @Override
       public LispObject execute(LispObject first, LispObject second,
-                                LispObject third) {
+                                LispObject third)
+      {
+        int index = Fixnum.getValue(second);
+        if (first instanceof BasicVectorPrimitive) {
+          ((BasicVectorPrimitive)first).svset(index, third);
+        }
         if (first instanceof SimpleVector) {
           final SimpleVector sv = (SimpleVector)first;
-          int index = Fixnum.getValue(second);
           try {
             sv.data[index] = third;
             return third;
           } catch (ArrayIndexOutOfBoundsException e) {
             int capacity = sv.capacity;
-            sv.badIndex(index, capacity);
-            // Not reached.
-            return NIL;
+            return sv.badIndex(index, capacity);
           }
         }
         return type_error(first, Symbol.SIMPLE_VECTOR);

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -43,7 +43,7 @@ import java.text.MessageFormat;
 // "The type of a vector that is not displaced to another array, has no fill
 // pointer, is not expressly adjustable and is able to hold elements of any
 // type is a subtype of type SIMPLE-VECTOR."
-public final class SimpleVector<T extends LispObject> extends AbstractVector
+public class SimpleVector<T extends LispObject> extends AbstractVector
 {
   int capacity;
   T[] data;
@@ -305,6 +305,9 @@ public final class SimpleVector<T extends LispObject> extends AbstractVector
     return this;
   }
 
+  //
+  // TODO check logic on whether a SIMPLE-VECTOR should be adjustable
+  //
   @Override
   public AbstractVector adjustArray(int newCapacity,
                                      LispObject initialElement,

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -49,6 +49,10 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
   T[] data;
   Class clazz;
 
+  public SimpleVector() {
+    super();
+  }
+
   public SimpleVector(int capacity) {
     this(LispObject.class, capacity);
   }

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -36,7 +36,9 @@ package org.armedbear.lisp;
 import static org.armedbear.lisp.Lisp.*;
 
 import java.lang.reflect.Array;
+import java.text.MessageFormat;
 import java.util.Arrays;
+import java.text.MessageFormat;
 
 // "The type of a vector that is not displaced to another array, has no fill
 // pointer, is not expressly adjustable and is able to hold elements of any
@@ -212,23 +214,18 @@ public final class SimpleVector<T extends LispObject> extends AbstractVector
   @Override
   public LispObject subseq(int start, int end)
   {
-    SimpleVector v = new SimpleVector(end - start);
-    int i = start, j = 0;
-    try
-      {
-        while (i < end)
-          v.data[j++] = data[i++];
-        return v;
-      }
-    catch (ArrayIndexOutOfBoundsException e)
-      {
-        return error(new TypeError("Array index out of bounds: " + i + "."));
-      }
+    try {
+        T[] subseq = Arrays.copyOfRange(data, start, end);        
+        return new SimpleVector(subseq);
+    } catch (ArrayIndexOutOfBoundsException e) {
+      String m
+        = MessageFormat.format("The bounding indices {0} and {1} are bad for a sequence of length {2}.", start, end, length());
+      return type_error(m, new JavaObject(e), NIL); // Not really a type_error, as there is not one type
+    }
   }
 
   @Override
-  public void fill(LispObject obj)
-  {
+  public void fill(LispObject obj) {
     Arrays.fill(data, (T) obj);
   }
 

--- a/src/org/armedbear/lisp/SimpleVector.java
+++ b/src/org/armedbear/lisp/SimpleVector.java
@@ -47,10 +47,9 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
 {
   int capacity;
   T[] data;
-  Class clazz;
+  Class type;
 
   public SimpleVector() {
-    super();
   }
 
   public SimpleVector(int capacity) {
@@ -58,8 +57,7 @@ public class SimpleVector<T extends LispObject> extends AbstractVector
   }
 
   public SimpleVector(Class<LispObject> type, int capacity) {
-    //    data = new LispObject[capacity];
-    this.clazz = type;
+    this.type = type;
     this.capacity = capacity;
     data = (T[]) Array.newInstance(type, capacity);
     //    for (int i = capacity; i-- > 0;) {


### PR DESCRIPTION
(INCOMPLETE) Start of exploration on simplying and improving support for sequences, vectors, and arrays by using generics and functions shipped as part of openjdk8.

Goals:

1)  Simplify class structure with parametertized types

2)  Use openjdk8 methods like Arrays.fill(), sort() et. al.

3)  Reduce memory use for "oversized" buffers

4)  Optimize speed of basic operations

TODO need some benchmarks to test before/after