### PR TITLE
container: use eclipse-temurin as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/openjdk:17-bullseye
+FROM docker.io/eclipse-temurin:17
 
 RUN (export DEBIAN_FRONTEND='noninteractive' && \
     apt-get update  && \


### PR DESCRIPTION
`openjdk` has been deprecated in favor of `eclipse-temurin`.

<https://hub.docker.com/_/eclipse-temurin>