### PR TITLE
Fix some Gray stream default methods

### DIFF
--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -268,6 +268,9 @@
 (defgeneric stream-read-line (stream))
 (defgeneric stream-clear-input (stream))
 
+(defmethod stream-read-char-no-hang ((stream fundamental-character-input-stream))
+  (stream-read-char stream))
+
 (defmethod stream-peek-char ((stream fundamental-character-input-stream))
   (let ((character (stream-read-char stream)))
     (unless (eq character :eof)
@@ -308,7 +311,8 @@
 (defgeneric stream-write-string (stream string &optional start end))
 (defgeneric stream-terpri (stream))
 (defmethod stream-terpri (stream)
-  (stream-write-char stream #\Newline))
+  (stream-write-char stream #\Newline)
+  nil)
 
 (defgeneric stream-fresh-line (stream))
 (defgeneric stream-finish-output (stream))


### PR DESCRIPTION
Some small tweaks.

- stream-terpri should return NIL not the newline character.
- stream-read-char-no-hang should have a default method. The implementation is not shown in the [Gray stream protocol](http://www.nhplace.com/kent/CL/Issues/stream-definition-by-user.html) example, but the existence of the default method is mentioned in the description for the generic.

