### PR TITLE
Add gray-streams:stream-line-length extension

### DIFF
--- a/src/org/armedbear/lisp/boot.lisp
+++ b/src/org/armedbear/lisp/boot.lisp
@@ -111,6 +111,13 @@
 
 (export 'charpos '#:extensions)
 
+;; Redefined in pprint.lisp and gray-streams.lisp
+(defun line-length (stream)
+  (declare (ignore stream))
+  (max 0 (or *print-right-margin* 80)))
+
+(export 'line-length '#:extensions)
+
 ;; Redefined in precompiler.lisp.
 (defun precompile (name &optional definition)
   (declare (ignore name definition))

--- a/src/org/armedbear/lisp/format.lisp
+++ b/src/org/armedbear/lisp/format.lisp
@@ -1552,7 +1552,7 @@
                         ,@(expand-directive-list (pop segments))))
                 ,(expand-bind-defaults
                   ((extra 0)
-                   (line-len '(or #-abcl(sb!impl::line-length stream) 72)))
+                   (line-len '(ext:line-length stream)))
                   (format-directive-params first-semi)
                   `(setf extra-space ,extra line-len ,line-len))))
           ,@(mapcar (lambda (segment)
@@ -2798,7 +2798,7 @@
              (when (and first-semi (format-directive-colonp first-semi))
                (interpret-bind-defaults
                 ((extra 0)
-                 (len (or #-abcl(sb!impl::line-length stream) 72)))
+                 (len (ext:line-length stream)))
                 (format-directive-params first-semi)
                 (setf newline-string
                       (with-output-to-string (stream)

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -139,6 +139,7 @@
    "FUNDAMENTAL-CHARACTER-OUTPUT-STREAM"
    "STREAM-WRITE-CHAR"
    "STREAM-LINE-COLUMN"
+   "STREAM-LINE-LENGTH"
    "STREAM-START-LINE-P"
    "STREAM-WRITE-STRING"
    "STREAM-TERPRI"
@@ -308,6 +309,7 @@
 (defgeneric stream-write-char (stream character))
 (defgeneric stream-line-column (stream))
 (defgeneric stream-start-line-p (stream))
+(defgeneric stream-line-length (stream))
 (defgeneric stream-write-string (stream string &optional start end))
 (defgeneric stream-terpri (stream))
 (defmethod stream-terpri (stream)
@@ -412,6 +414,13 @@
                                   sequence &optional (start 0) end)
   (basic-write-sequence stream sequence start (or end (length sequence))
                         'signed-byte #'stream-write-byte))
+
+(defmethod stream-line-length (stream)
+  (declare (ignore stream))
+  nil)
+
+(defmethod stream-line-length ((stream xp::xp-structure))
+  (xp::line-length stream))
 
 (defun decode-read-arg (arg)
   (cond ((null arg) *standard-input*)
@@ -574,6 +583,13 @@
         nil ;(funcall *ansi-stream-column* stream)
         (stream-line-column stream))))
 
+(defun gray-line-length (stream)
+  (max 0
+       (or *print-right-margin*
+           (stream-line-length stream)
+           xp::*default-right-margin*
+           80)))
+
 (defmethod gray-stream-element-type (stream)
   (funcall *ansi-stream-element-type* stream))
 
@@ -678,6 +694,7 @@
 (setf (symbol-function 'common-lisp::file-position) #'gray-file-position)
 (setf (symbol-function 'common-lisp::file-length) #'gray-file-length)
 (setf (symbol-function 'common-lisp::listen) #'gray-listen)
+(setf (symbol-function 'ext:line-length) #'gray-line-length)
 
 (dolist (e '((common-lisp::read-char gray-read-char)
              (common-lisp::peek-char gray-peek-char)

--- a/src/org/armedbear/lisp/pprint.lisp
+++ b/src/org/armedbear/lisp/pprint.lisp
@@ -64,8 +64,12 @@
 (defvar *print-shared* nil)
 (export '(*print-shared*))
 
-(defvar *default-right-margin* 70.
+(defvar *default-right-margin* 80
   "controls default line length; must be a non-negative integer")
+
+(defun ext:line-length (stream)
+  (declare (ignore stream))
+  (max 0 (or *print-right-margin* *default-right-margin* 80)))
 
 (defvar *current-level* 0
   "current depth in logical blocks.")
@@ -290,9 +294,7 @@
 
 (defun initialize-xp (xp stream)
   (setf (base-stream xp) stream)
-  (setf (line-length xp) (max 0 (cond (*print-right-margin*)
-                                      ((output-width stream))
-                                      (t *default-right-margin*))))
+  (setf (line-length xp) (ext:line-length stream))
   (setf (line-limit xp) *print-lines*)
   (setf (line-no xp) 1)
   (setf (depth-in-blocks xp) 0)


### PR DESCRIPTION
Add support for stream-line-length. This allows streams to override `*default-line-length*`. `*print-right-margin*` still takes precedence. Currently supported by Clasp, CMUCL, Mezzano, Lispworks, and SBCL. A PR for ECL is currently open. In the case of the open source implementations this extension originally came from CMUCL.

Example of usage:

```
CL-USER(1): (require :gray-streams)
("GRAY-STREAMS")
CL-USER(2): (defclass fu (gray-streams:fundamental-character-output-stream) ())

#<STANDARD-CLASS FU {64CCBA30}>
CL-USER(3): (defmethod gray-streams:stream-write-char ((s fu) ch) (write-char ch))

#<STANDARD-METHOD GRAY-STREAMS:STREAM-WRITE-CHAR (FU T) {7EA784ED}>
CL-USER(4): (defmethod gray-streams:stream-line-length ((s fu)) 15)

#<STANDARD-METHOD GRAY-STREAMS:STREAM-LINE-LENGTH (FU) {1991B199}>
CL-USER(5): (pprint '(defun wibble (bar quux &optional zip) (format t "hello ~a ~a ~a~%" bar quux zip)))

(DEFUN WIBBLE (BAR QUUX &OPTIONAL ZIP)
  (FORMAT T "hello ~a ~a ~a~%" BAR QUUX ZIP))
CL-USER(6): (pprint '(defun wibble (bar quux &optional zip) (format t "hello ~a ~a ~a~%" bar quux zip)) (make-instance 'fu))

(DEFUN WIBBLE (BAR
               QUUX
               &OPTIONAL
               ZIP)
  (FORMAT T
          "hello ~a ~a ~a~%"
          BAR
          QUUX
          ZIP))
```