### PR TITLE
Fix gray-read-line return

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ Unreleased
 <https://github.com/armedbear/abcl/>
 <https://gitlab.common-lisp.net/abcl/abcl/>
 
+* [r15753] (Tarn W. Burton) Always return second value indicating EOF
+  in Gray stream version of CL:READ-LINE as per the ANSI
+  specification.
+
 * [r15743] (Tarn W. Burton) Add support for implementing
   CL:INTERACTIVE-STREAM-P in for Gray streams. This is done via by
   making CL:INTERACTIVE-STREAM-P a generic function when the Gray

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -490,12 +490,11 @@
     (if (ansi-streamp stream)
         (funcall *ansi-read-line* stream eof-error-p eof-value recursive-p)
         (multiple-value-bind (string eofp)
-          (stream-read-line stream)
-          (if eofp
-              (if (= (length string) 0)
-                  (report-eof stream eof-error-p eof-value)
-                  (values string t))
-              (values string nil))))))
+            (stream-read-line stream)
+          (values (if (and eofp (zerop (length string)))
+                      (report-eof stream eof-error-p eof-value)
+                      string)
+                  eofp)))))
 
 (defun gray-clear-input (&optional input-stream)
   (let ((stream (decode-read-arg input-stream)))


### PR DESCRIPTION
[READ-LINE](https://novaspec.org/cl/f_read-line) should always return a second value indicating EOF as per the spec. If `eof-error-p` is NIL then the return should be `(values eof-value T)`. I checked CCL, CLASP, ECL, CMUCL and SBCL and this is in fact what they do.