### PR TITLE
Use STREAMP to determine Gray stream API availability

### DIFF
--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -1950,12 +1950,8 @@ public static synchronized final void handleInterrupt()
     if (obj instanceof Stream) {
       return (Stream) obj;
     }
-    if (obj instanceof StandardObject) {
-      Function subtypep = checkFunction(Symbol.SUBTYPEP.getSymbolFunction());
-      if (subtypep.execute(obj.typeOf(), Symbol.STREAM).equals(T)) {
-        Stream result = GrayStream.findOrCreate(obj);
-        return result;
-      }
+    if (Symbol.STREAMP.getSymbolFunction().execute(obj).getBooleanValue()) {
+      return GrayStream.findOrCreate(obj);
     }
     return (Stream) // Not reached.
       type_error(obj, Symbol.STREAM);

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -194,9 +194,7 @@
 (defvar *ansi-file-length* #'cl:file-length)
 
 (defun ansi-streamp (stream)
-  (not
-   (subtypep (class-of stream)
-             'gray-streams::fundamental-stream)))
+  (typep stream '(or sys::system-stream xp::xp-structure)))
 
 (defclass fundamental-stream (standard-object stream)
   ((open-p :initform t


### PR DESCRIPTION
Using `(typep obj 'stream)` effectively makes the generic function STREAMP not very useful since all streams need to subclass STREAM, which always returns T for STREAMP. This is an optional part of the Gray stream protocol. Some implementations enforce the requirement that streams must subclass STREAM, i.e. CMUCL, SBCL and CLISP. On the other hand Clasp, ECL, MKCL, Mezzano and CCL all implement the generic STREAMP and don't require that Gray streams subclass STREAM.