### PR TITLE
Add some more Gray extensions

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,12 @@ Unreleased
 <https://github.com/armedbear/abcl/>
 <https://gitlab.common-lisp.net/abcl/abcl/>
 
+* [r15760] (Tarn W. Burton) Add SETF for STREAM-ELEMENT-TYPE in
+  gray-streams module.
+
+* [r15759] (Tarn W. Burton) Add generic CL:PATHNAME and CL:TRUENAME in
+  gray-streams module.
+
 * [r15753] (Tarn W. Burton) Always return second value indicating EOF
   in Gray stream version of CL:READ-LINE as per the ANSI
   specification.

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -211,6 +211,7 @@
 (defgeneric gray-output-stream-p (stream))
 (defgeneric gray-interactive-stream-p (stream))
 (defgeneric gray-stream-element-type (stream))
+(defgeneric (setf gray-stream-element-type) (new-value stream))
 (defgeneric gray-pathname (pathspec))
 (defgeneric gray-truename (filespec))
 
@@ -699,6 +700,7 @@
 (setf (symbol-function 'common-lisp::write-byte) #'gray-write-byte)
 (setf (symbol-function 'common-lisp::stream-column) #'gray-stream-column)
 (setf (symbol-function 'common-lisp::stream-element-type) #'gray-stream-element-type)
+(setf (fdefinition '(setf common-lisp::stream-element-type)) #'(setf gray-stream-element-type))
 (setf (symbol-function 'common-lisp::close) #'gray-close)
 (setf (symbol-function 'common-lisp::input-stream-p) #'gray-input-stream-p)
 (setf (symbol-function 'common-lisp::input-character-stream-p) #'gray-input-character-stream-p)  ;; # fb 1.01

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -192,6 +192,8 @@
 (defvar *ansi-two-way-stream-output-stream* #'cl:two-way-stream-output-stream)
 (defvar *ansi-file-position* #'cl:file-position)
 (defvar *ansi-file-length* #'cl:file-length)
+(defvar *ansi-pathname* #'cl:pathname)
+(defvar *ansi-truename* #'cl:truename)
 
 (defun ansi-streamp (stream)
   (typep stream '(or sys::system-stream xp::xp-structure)))
@@ -209,6 +211,8 @@
 (defgeneric gray-output-stream-p (stream))
 (defgeneric gray-interactive-stream-p (stream))
 (defgeneric gray-stream-element-type (stream))
+(defgeneric gray-pathname (pathspec))
+(defgeneric gray-truename (filespec))
 
 (defmethod gray-close ((stream fundamental-stream) &key abort)
   (declare (ignore abort))
@@ -617,6 +621,12 @@
 (defmethod gray-streamp (stream)
   (funcall *ansi-streamp* stream))
 
+(defmethod gray-pathname (pathspec)
+  (funcall *ansi-pathname* pathspec))
+
+(defmethod gray-truename (pathspec)
+  (funcall *ansi-truename* pathspec))
+
 (defun gray-write-sequence (sequence stream &key (start 0) end)
   (if (ansi-streamp stream)
       (funcall *ansi-write-sequence* sequence stream :start start :end end)
@@ -702,6 +712,8 @@
 (setf (symbol-function 'common-lisp::file-length) #'gray-file-length)
 (setf (symbol-function 'common-lisp::listen) #'gray-listen)
 (setf (symbol-function 'ext:line-length) #'gray-line-length)
+(setf (symbol-function 'common-lisp::pathname) #'gray-pathname)
+(setf (symbol-function 'common-lisp::truename) #'gray-truename)
 
 (dolist (e '((common-lisp::read-char gray-read-char)
              (common-lisp::peek-char gray-peek-char)
@@ -732,7 +744,9 @@
              (common-lisp::write-sequence gray-write-sequence)
              (common-lisp::file-position gray-file-position)
              (common-lisp::file-length gray-file-length)
-             (common-lisp::listen gray-listen)))
+             (common-lisp::listen gray-listen)
+             (common-lisp::pathname gray-pathname)
+             (common-lisp::truename gray-truename)))
   (sys::put (car e) 'sys::source (cl:get (second e) 'sys::source)))
 
 #|


### PR DESCRIPTION
1. Generic versions of [TRUENAME and PATHNAME](https://github.com/yitzchak/nontrivial-gray-streams#pathname). This is an optional part of the original Gray stream proposal. 
2. [SETF STREAM-ELEMENT-TYPE](https://github.com/yitzchak/nontrivial-gray-streams#SETF-STREAM-ELEMENT-TYPE). This allows basic bivalent Gray streams. CCL already had this and I've added it to Clasp recently.

I've tested both of these in my test suite. I'll push an update to CHANGES once CI finishes just in case I have broken something else.