### PR TITLE
Have coerceToPathname use Gray stream PATHNAME generic

### DIFF
--- a/src/org/armedbear/lisp/FileStream.java
+++ b/src/org/armedbear/lisp/FileStream.java
@@ -161,6 +161,7 @@ public final class FileStream extends Stream
             racf.setEncoding(encoding);
     }
 
+    @Override
     public Pathname getPathname()
     {
         return pathname;

--- a/src/org/armedbear/lisp/GrayStream.java
+++ b/src/org/armedbear/lisp/GrayStream.java
@@ -226,6 +226,14 @@ public class GrayStream
     return f.execute(clos);
   }
 
+  public static final Symbol PATHNAME
+    = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/PATHNAME");
+  @Override
+  public Pathname getPathname() {
+    Function f = checkFunction(PATHNAME.getSymbolFunction());
+    return (Pathname)f.execute(clos);
+  }
+
   public static final Symbol LINE_COLUMN
     = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/LINE-COLUMN");
   public int getCharPos() {
@@ -295,6 +303,7 @@ public class GrayStream
     Autoload.autoloadFile(GrayStream.FINISH_OUTPUT, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FILE_POSITION, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FILE_LENGTH, "gray-streams-java");
+    Autoload.autoloadFile(GrayStream.PATHNAME, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.LINE_COLUMN, "gray-streams-java");
   }
 }

--- a/src/org/armedbear/lisp/JarStream.java
+++ b/src/org/armedbear/lisp/JarStream.java
@@ -113,6 +113,7 @@ public final class JarStream extends Stream
         super.setExternalFormat(format);
     }
 
+    @Override
     public Pathname getPathname()
     {
         return pathname;

--- a/src/org/armedbear/lisp/Lisp.java
+++ b/src/org/armedbear/lisp/Lisp.java
@@ -2143,12 +2143,10 @@ public static synchronized final void handleInterrupt()
       return (Pathname) arg;
     if (arg instanceof AbstractString)
       return (Pathname)Pathname.create(((AbstractString)arg).toString());
-    if (arg instanceof FileStream)
-      return ((FileStream)arg).getPathname();
-    if (arg instanceof JarStream)
-      return ((JarStream)arg).getPathname();
-    if (arg instanceof URLStream)
-      return ((URLStream)arg).getPathname();
+    Stream s = checkStream(arg);
+    Pathname p = s.getPathname();
+    if (p != null)
+      return p;
     type_error(arg, list(Symbol.OR,
                          Symbol.STRING,
                          Symbol.PATHNAME, Symbol.JAR_PATHNAME, Symbol.URL_PATHNAME,

--- a/src/org/armedbear/lisp/Stream.java
+++ b/src/org/armedbear/lisp/Stream.java
@@ -1821,6 +1821,11 @@ public class Stream extends StructureObject {
         return n;
     }
 
+    public Pathname getPathname()
+    {
+        return null;
+    }
+
     /** Puts a character back into the (underlying) stream
      *
      * @param n

--- a/src/org/armedbear/lisp/URLStream.java
+++ b/src/org/armedbear/lisp/URLStream.java
@@ -112,6 +112,7 @@ public final class URLStream extends Stream
         super.setExternalFormat(format);
     }
 
+    @Override
     public Pathname getPathname()
     {
         return pathname;

--- a/src/org/armedbear/lisp/gray-streams-java.lisp
+++ b/src/org/armedbear/lisp/gray-streams-java.lisp
@@ -67,6 +67,9 @@
 (defun java/file-length (object)
   (gray-streams:stream-file-length object))
 
+(defun java/pathname (object)
+  (gray-streams::gray-pathname object))
+
 (defun java/line-column (object)
   (gray-streams:stream-line-column object))
 


### PR DESCRIPTION
It appears #650 is not quite sufficient for PATHNAME. The spec states that PATHNAME-TYPE, PATHNAME-HOST, etc, should work after [close](https://novaspec.org/cl/f_close). This means that `coerceToPathname` will need to call the generic PATHNAME. To accomplish this I've added `getPathname` to the Stream class.

I've made this a draft because I haven't finished writing tests yet and I haven't verified that TRUENAME works in all cases.