### PR TITLE
Add more support for bivalent Gray streams

### DIFF
--- a/src/org/armedbear/lisp/GrayStream.java
+++ b/src/org/armedbear/lisp/GrayStream.java
@@ -108,11 +108,28 @@ public class GrayStream
 
   public static final Symbol ELEMENT_TYPE
     = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/ELEMENT-TYPE");
+  @Override
   public LispObject getElementType() {
     Function f = checkFunction(ELEMENT_TYPE.getSymbolFunction());
     return f.execute(clos);
   }
   
+  public static final Symbol EXTERNAL_FORMAT
+    = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/EXTERNAL-FORMAT");
+  @Override
+  public LispObject getExternalFormat() {
+    Function f = checkFunction(EXTERNAL_FORMAT.getSymbolFunction());
+    return f.execute(clos);
+  }
+
+  public static final Symbol SET_EXTERNAL_FORMAT
+    = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/SET-EXTERNAL-FORMAT");
+  @Override
+  public void setExternalFormat(LispObject format) {
+    Function f = checkFunction(SET_EXTERNAL_FORMAT.getSymbolFunction());
+    f.execute(clos, format);
+  }
+
   public static final Symbol FORCE_OUTPUT
     = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/FORCE-OUTPUT");
   public void _forceOutput() {
@@ -250,18 +267,9 @@ public class GrayStream
     simple_error("unimplemented setInteractive(boolean)");
   }
 
-  public LispObject getExternalFormat() {
-    simple_error("unimplemented getExternalFormat()");
-    return null;  // unreached
-  }
-
   public String getEncoding() {
     simple_error("unimplemented getEncoding()");
     return null;  // unreached
-  }
-
-  public void setExternalFormat(LispObject format) {
-    simple_error("unimplemented setExternalFormat()");
   }
 
   public void setOpen(boolean b) {
@@ -290,6 +298,8 @@ public class GrayStream
     Autoload.autoloadFile(GrayStream.INTERACTIVE_STREAM_P, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.OPEN_STREAM_P, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.ELEMENT_TYPE, "gray-streams-java");
+    Autoload.autoloadFile(GrayStream.EXTERNAL_FORMAT, "gray-streams-java");
+    Autoload.autoloadFile(GrayStream.SET_EXTERNAL_FORMAT, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FORCE_OUTPUT, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.WRITE_STRING, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.WRITE_CHAR, "gray-streams-java");

--- a/src/org/armedbear/lisp/GrayStream.java
+++ b/src/org/armedbear/lisp/GrayStream.java
@@ -220,6 +220,13 @@ public class GrayStream
     f.execute(clos, LispInteger.getInstance(n));
   }
 
+  public static final Symbol CLEAR_INPUT
+    = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/CLEAR-INPUT");
+  public void _clearInput() {
+    Function f = checkFunction(CLEAR_INPUT.getSymbolFunction());
+    f.execute(clos);
+  }
+
   public static final Symbol FINISH_OUTPUT
     = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/FINISH-OUTPUT");
   public void _finishOutput() {
@@ -286,12 +293,7 @@ public class GrayStream
     return 0;  // unreached 
   }
 
-  public void _clearInput() {
-    // inherited implementation uses available bytes on stream
-    simple_error("unimplemented _clearInput()");
-  }
-
-// TODO figure out why we can't add these to autoloads.lisp
+  // TODO figure out why we can't add these to autoloads.lisp
   static {
     Autoload.autoloadFile(GrayStream.INPUT_STREAM_P, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.OUTPUT_STREAM_P, "gray-streams-java");
@@ -310,6 +312,7 @@ public class GrayStream
     Autoload.autoloadFile(GrayStream.STREAM_LISTEN, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.READ_BYTE, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.WRITE_BYTE, "gray-streams-java");
+    Autoload.autoloadFile(GrayStream.CLEAR_INPUT, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FINISH_OUTPUT, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FILE_POSITION, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FILE_LENGTH, "gray-streams-java");

--- a/src/org/armedbear/lisp/GrayStream.java
+++ b/src/org/armedbear/lisp/GrayStream.java
@@ -242,6 +242,13 @@ public class GrayStream
     return result.longValue();
   }
 
+  public static final Symbol SET_FILE_POSITION
+    = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/SET-FILE-POSITION");
+  public boolean _setFilePosition(LispObject arg) {
+    Function f = checkFunction(SET_FILE_POSITION.getSymbolFunction());
+    return f.execute(clos, arg).getBooleanValue();
+  }
+
   public static final Symbol FILE_LENGTH
     = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/FILE-LENGTH");
   @Override
@@ -315,6 +322,7 @@ public class GrayStream
     Autoload.autoloadFile(GrayStream.CLEAR_INPUT, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FINISH_OUTPUT, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FILE_POSITION, "gray-streams-java");
+    Autoload.autoloadFile(GrayStream.SET_FILE_POSITION, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FILE_LENGTH, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.PATHNAME, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.LINE_COLUMN, "gray-streams-java");

--- a/src/org/armedbear/lisp/GrayStream.java
+++ b/src/org/armedbear/lisp/GrayStream.java
@@ -257,6 +257,14 @@ public class GrayStream
     return f.execute(clos);
   }
 
+  public static final Symbol FILE_STRING_LENGTH
+    = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/FILE-STRING-LENGTH");
+  @Override
+  public LispObject fileStringLength(LispObject arg) {
+    Function f = checkFunction(FILE_STRING_LENGTH.getSymbolFunction());
+    return f.execute(clos, arg);
+  }
+
   public static final Symbol PATHNAME
     = PACKAGE_GRAY_STREAMS_JAVA.addExternalSymbol("JAVA/PATHNAME");
   @Override
@@ -324,6 +332,7 @@ public class GrayStream
     Autoload.autoloadFile(GrayStream.FILE_POSITION, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.SET_FILE_POSITION, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.FILE_LENGTH, "gray-streams-java");
+    Autoload.autoloadFile(GrayStream.FILE_STRING_LENGTH, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.PATHNAME, "gray-streams-java");
     Autoload.autoloadFile(GrayStream.LINE_COLUMN, "gray-streams-java");
   }

--- a/src/org/armedbear/lisp/gray-streams-java.lisp
+++ b/src/org/armedbear/lisp/gray-streams-java.lisp
@@ -28,6 +28,12 @@
 (defun java/element-type (object)
   (gray-streams::gray-stream-element-type object))
 
+(defun java/external-format (object)
+  (gray-streams::gray-stream-external-format object))
+
+(defun java/set-external-format (object new-value)
+  (setf (gray-streams::gray-stream-external-format object) new-value))
+
 (defun java/force-output (object)
   (gray-streams:stream-force-output object))
 

--- a/src/org/armedbear/lisp/gray-streams-java.lisp
+++ b/src/org/armedbear/lisp/gray-streams-java.lisp
@@ -73,6 +73,9 @@
 (defun java/file-position (object)
   (gray-streams:stream-file-position object))
 
+(defun java/set-file-position (object position)
+  (gray-streams:stream-file-position object position))
+
 (defun java/file-length (object)
   (gray-streams:stream-file-length object))
 

--- a/src/org/armedbear/lisp/gray-streams-java.lisp
+++ b/src/org/armedbear/lisp/gray-streams-java.lisp
@@ -64,6 +64,9 @@
 (defun java/write-byte (object n)
   (gray-streams:stream-read-byte object n))
 
+(defun java/clear-input (object)
+  (gray-streams:stream-clear-input object))
+
 (defun java/finish-output (object)
   (gray-streams:stream-finish-output object))
 

--- a/src/org/armedbear/lisp/gray-streams-java.lisp
+++ b/src/org/armedbear/lisp/gray-streams-java.lisp
@@ -79,6 +79,9 @@
 (defun java/file-length (object)
   (gray-streams:stream-file-length object))
 
+(defun java/file-string-length (object string)
+  (gray-streams:stream-file-string-length object string))
+
 (defun java/pathname (object)
   (gray-streams::gray-pathname object))
 

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -177,6 +177,7 @@
 (defvar *ansi-read-byte* #'read-byte)
 (defvar *ansi-write-byte* #'write-byte)
 (defvar *ansi-stream-element-type* #'cl::stream-element-type)
+(defvar *ansi-stream-external-format* #'cl::stream-external-format)
 (defvar *ansi-close* #'cl::close)
 (defvar *ansi-input-character-stream-p*
   #'(lambda (s) (and (input-stream-p s) (eql (stream-element-type s) 'character))))
@@ -212,6 +213,8 @@
 (defgeneric gray-interactive-stream-p (stream))
 (defgeneric gray-stream-element-type (stream))
 (defgeneric (setf gray-stream-element-type) (new-value stream))
+(defgeneric gray-stream-external-format (stream))
+(defgeneric (setf gray-stream-external-format) (new-value stream))
 (defgeneric gray-pathname (pathspec))
 (defgeneric gray-truename (filespec))
 
@@ -234,6 +237,9 @@
 
 (defmethod gray-streamp ((s fundamental-stream))
   s)
+
+(defmethod gray-stream-external-format ((s fundamental-stream))
+  :default)
 
 (defmethod gray-interactive-stream-p (stream)
   (declare (ignore stream))
@@ -608,6 +614,16 @@
       (funcall *ansi-stream-element-type* stream)
       (bug-or-error stream 'gray-stream-element-type)))
 
+(defmethod gray-stream-external-format (stream)
+  (if (ansi-streamp stream)
+      (funcall *ansi-stream-external-format* stream)
+      (bug-or-error stream 'gray-stream-external-format)))
+
+(defmethod (setf gray-stream-external-format) (new-value stream)
+  (if (ansi-streamp stream)
+      (sys::%set-stream-external-format stream new-value)
+      (bug-or-error stream 'gray-stream-external-format)))
+
 (defmethod gray-close (stream &key abort)
   (if (ansi-streamp stream)
       (funcall *ansi-close* stream :abort abort)
@@ -734,6 +750,8 @@
 (setf (symbol-function 'common-lisp::stream-column) #'gray-stream-column)
 (setf (symbol-function 'common-lisp::stream-element-type) #'gray-stream-element-type)
 (setf (fdefinition '(setf common-lisp::stream-element-type)) #'(setf gray-stream-element-type))
+(setf (symbol-function 'common-lisp::stream-external-format) #'gray-stream-external-format)
+(setf (fdefinition '(setf common-lisp::stream-external-format)) #'(setf gray-stream-external-format))
 (setf (symbol-function 'common-lisp::close) #'gray-close)
 (setf (symbol-function 'common-lisp::input-stream-p) #'gray-input-stream-p)
 (setf (symbol-function 'common-lisp::input-character-stream-p) #'gray-input-character-stream-p)  ;; # fb 1.01
@@ -769,6 +787,7 @@
              (common-lisp::write-byte gray-write-byte)
              (common-lisp::stream-column gray-stream-column)
              (common-lisp::stream-element-type gray-stream-element-type)
+             (common-lisp::stream-external-format gray-stream-external-format)
              (common-lisp::close gray-close)
              (common-lisp::input-stream-p gray-input-stream-p)
              (common-lisp::input-character-stream-p gray-input-character-stream-p) ;; # fb 1.01

--- a/src/org/armedbear/lisp/gray-streams.lisp
+++ b/src/org/armedbear/lisp/gray-streams.lisp
@@ -152,6 +152,7 @@
    "STREAM-WRITE-SEQUENCE"
    "STREAM-FILE-POSITION"
    "STREAM-FILE-LENGTH"
+   "STREAM-FILE-STRING-LENGTH"
    "STREAM-ELEMENT-TYPE"
    "FUNDAMENTAL-BINARY-INPUT-STREAM"
    "FUNDAMENTAL-BINARY-OUTPUT-STREAM"))
@@ -193,6 +194,7 @@
 (defvar *ansi-two-way-stream-output-stream* #'cl:two-way-stream-output-stream)
 (defvar *ansi-file-position* #'cl:file-position)
 (defvar *ansi-file-length* #'cl:file-length)
+(defvar *ansi-file-string-length* #'cl:file-string-length)
 (defvar *ansi-pathname* #'cl:pathname)
 (defvar *ansi-truename* #'cl:truename)
 
@@ -709,6 +711,18 @@
       (funcall *ansi-file-length* stream)
       (stream-file-length stream)))
 
+(defgeneric stream-file-string-length (stream object))
+
+(defmethod stream-file-string-length
+    ((stream fundamental-character-output-stream) object)
+  (declare (ignore object))
+  nil)
+
+(defun gray-file-string-length (stream object)
+  (if (ansi-streamp stream)
+      (funcall *ansi-file-string-length* stream object)
+      (stream-file-string-length stream object)))
+
 #|
 (defstruct (two-way-stream-g (:include stream))
   input-stream output-stream)
@@ -763,6 +777,7 @@
 (setf (symbol-function 'common-lisp::write-sequence) #'gray-write-sequence)
 (setf (symbol-function 'common-lisp::file-position) #'gray-file-position)
 (setf (symbol-function 'common-lisp::file-length) #'gray-file-length)
+(setf (symbol-function 'common-lisp::file-string-length) #'gray-file-string-length)
 (setf (symbol-function 'common-lisp::listen) #'gray-listen)
 (setf (symbol-function 'ext:line-length) #'gray-line-length)
 (setf (symbol-function 'common-lisp::pathname) #'gray-pathname)
@@ -798,6 +813,7 @@
              (common-lisp::write-sequence gray-write-sequence)
              (common-lisp::file-position gray-file-position)
              (common-lisp::file-length gray-file-length)
+             (common-lisp::file-string-length gray-file-string-length)
              (common-lisp::listen gray-listen)
              (common-lisp::pathname gray-pathname)
              (common-lisp::truename gray-truename)))


### PR DESCRIPTION
Add generic `STREAM-EXTERNAL-FORMAT`, `(SETF STREAM-EXTERNAL-FORMAT)` and support for implementing `CL:FILE-STRING-LENGTH`. Also add the Java side _clearInput and _setFilePosition.