### PR TITLE
contrib/jna/5.0.14

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,8 @@ Unreleased
 <https://github.com/armedbear/abcl/>
 <https://gitlab.common-lisp.net/abcl/abcl/>
 
+* [r15775] Update to jna-5.14.0 seemingly fixing problems with CFFI for at least arm64-openjdk-21
+
 * [r15774] Update to asdf-3.3.7
 
 * [r15760] (Tarn W. Burton) Add SETF for STREAM-ELEMENT-TYPE in

--- a/abcl.rdf
+++ b/abcl.rdf
@@ -20,7 +20,7 @@
   dc:identifier         <urn:abcl.org/release/1.9.3#> ;
   doap:language        "Common Lisp" ;
   dc:created           "01-JAN-2004" ;
-  dc:modified          "22-JUN-2023" ;
+  dc:modified          "11-MAR-2024" ;
   dc:version           "abcl-1.9.3" ;
   dc:release           "dev" ;
 #  dc:release           "rc-0" ;
@@ -212,6 +212,9 @@ abcl:jss
   rdf:_17  openjdk:17 ;
   rdf:_18  openjdk:18 ;
   rdf:_19  openjdk:19 ;
+  rdf:_20  openjdk:20 ;
+  rdf:_21  openjdk:21 ;
+  rdf:_22  openjdk:22 ;       
   rdfs:comment "Compatible Java runtimes" .
 
 [abcl:run _:options]
@@ -224,6 +227,8 @@ abcl:jss
     openjdk:15 "-XX:CompileThreshold=10" ;
     openjdk:16 "-XX:CompileThreshold=10" ;
     openjdk:17 "-XX:CompileThreshold=10" ;
+    openjdk:21 "-XX:CompileThreshold=10" ;
+    openjdk:20 "-XX:CompileThreshold=10" ;
     rdfs:comment "Java platform runtime options" .
 
 [abcl:build _:options]
@@ -249,7 +254,9 @@ abcl:jss
    rdf:_17  openjdk:17 ;
    rdf:_18  openjdk:18 ;
    rdf:_19  openjdk:19 ;
+   rdf:_21  openjdk:21 ;     
+   rdf:_22  openjdk:22 ;     
    rdfs:comment "Supported build platforms" .
-p
+
 
   

--- a/contrib/mvn/jna.asd
+++ b/contrib/mvn/jna.asd
@@ -2,11 +2,11 @@
 
 ;;;; Need to have jna.jar present for CFFI to work.
 (defsystem jna 
-  :version "5.13.0"
-  :long-description  "<urn:abcl.org/release/1.9.2/contrib/jna#5.12.1>"
+  :version "5.14.0"
+  :long-description  "<urn:abcl.org/release/1.9.2/contrib/jna#5.14.1>"
   :defsystem-depends-on (jss abcl-asdf)
-  :components ((:mvn "net.java.dev.jna/jna/5.13.0"
-                :alternate-uri "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.13.0.jar"
+  :components ((:mvn "net.java.dev.jna/jna/5.14.0"
+                :alternate-uri "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.14.0.jar"
                 :classname "com.sun.jna.Native")))
 
                          

--- a/contrib/mvn/jna.asd
+++ b/contrib/mvn/jna.asd
@@ -3,7 +3,7 @@
 ;;;; Need to have jna.jar present for CFFI to work.
 (defsystem jna 
   :version "5.14.0"
-  :long-description  "<urn:abcl.org/release/1.9.2/contrib/jna#5.14.1>"
+  :long-description  "<urn:abcl.org/release/1.9.2/contrib/jna#5.14.0>"
   :defsystem-depends-on (jss abcl-asdf)
   :components ((:mvn "net.java.dev.jna/jna/5.14.0"
                 :alternate-uri "https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.13.0/jna-5.14.0.jar"


### PR DESCRIPTION
Update to jna-5.0.14 fixing problems with CFFI under openjdk21 for arm64-darwin