### PR TITLE
Properly declare global-scope script context bindings as special.

### DIFF
--- a/src/org/armedbear/lisp/scripting/lisp/abcl-script.lisp
+++ b/src/org/armedbear/lisp/scripting/lisp/abcl-script.lisp
@@ -74,8 +74,8 @@
 	   (,actual-global-bindings (generate-bindings ,global-bindings))
 	   (,actual-engine-bindings (generate-bindings ,engine-bindings)))
        (eval `(let (,@,actual-global-bindings)
+		,(generate-special-declarations ,global-bindings)
 		(let (,@,actual-engine-bindings)
-		  ,(generate-special-declarations ,global-bindings)
 		  ,(generate-special-declarations ,engine-bindings)
 		  (prog1
 		      (progn ,@,body)


### PR DESCRIPTION
With the declaration in the inner engine-scope `let`, _references to_ the bindings for global-scope vars are declared to be special, but the bindings themselves aren't; the global vars are bound lexically, which causes two problems:
1. the vars are unbound in the script, and can't be accessed; and
2. the put-bindings jcall at the end of script execution fails because the variable is unbound.

The latter occurs because the only binding of that variable is lexical, but the special-var declaration in the inner `let` has declared that all references to that var are to a dynamic binding, not a lexical binding. There is no dynamic binding, so the var is unbound and passing it as an arg signals an unbound-var error.

Solve both problems by declaring the global-scope vars as special in the `let` that creates the bindings, like we do for engine-scope vars.

For convenience, a minimal java file to reproduce the problem:
```java
import javax.script.*;

public class TestMain {
        public static void main(String[] argv) {
                ScriptEngine engine = new ScriptEngineManager().getEngineByExtension("lisp");
                try {
                        Bindings bindings = new SimpleBindings();
                        bindings.put("custom-value", new Object() { });

                        ScriptContext context = engine.getContext();
                        // ScriptContext.ENGINE_SCOPE works just fine, but
                        // ScriptContext.GLOBAL_SCOPE bail during some kind of
                        // post-script cleanup.
                        context.setBindings(bindings, ScriptContext.GLOBAL_SCOPE);

                        engine.eval("(format t \"Hiya!~%\")", context);
                } catch (ScriptException e) {
                        throw new RuntimeException(e);
                }
        }
}
```