### PR TITLE
[BUG FIX] Incomplete TYPEP implementation for single floats.

### DIFF
--- a/src/org/armedbear/lisp/SingleFloat.java
+++ b/src/org/armedbear/lisp/SingleFloat.java
@@ -93,19 +93,23 @@ public final class SingleFloat extends LispObject
     @Override
     public LispObject typep(LispObject typeSpecifier)
     {
+        if (typeSpecifier == Symbol.SHORT_FLOAT)
+            return T;
+        if (typeSpecifier == Symbol.SINGLE_FLOAT)
+            return T;
         if (typeSpecifier == Symbol.FLOAT)
             return T;
         if (typeSpecifier == Symbol.REAL)
             return T;
         if (typeSpecifier == Symbol.NUMBER)
             return T;
-        if (typeSpecifier == Symbol.SINGLE_FLOAT)
-            return T;
-        if (typeSpecifier == Symbol.SHORT_FLOAT)
+        if (typeSpecifier == BuiltInClass.SINGLE_FLOAT)
             return T;
         if (typeSpecifier == BuiltInClass.FLOAT)
             return T;
-        if (typeSpecifier == BuiltInClass.SINGLE_FLOAT)
+        if (typeSpecifier == BuiltInClass.REAL)
+            return T;
+        if (typeSpecifier == BuiltInClass.NUMBER)
             return T;
         return super.typep(typeSpecifier);
     }


### PR DESCRIPTION
This fixes the following problems:

(typep 1.0 'number) -> T but (typep 1.0 (find-class 'number) -> NIL
(typep 1.0 'real)   -> T but (typep 1.0 (find-class 'read)   -> NIL

2026-03-05  Didier Verna  <didier@didierverna.net>

	* src/org/armedbear/lisp/SingleFloat.java (typep): Fast-check the type specifier against the REAL and NUMBER built-in classes; not only the symbols.