### PR TITLE
Fix ANSI test failures: LABELS.37–39, LOOP.1.40–43, LOOP.8.10

### DIFF
--- a/src/org/armedbear/lisp/compiler-pass2.lisp
+++ b/src/org/armedbear/lisp/compiler-pass2.lisp
@@ -2304,6 +2304,14 @@ is registered (or not)."
   (when (eq *current-compiland* (local-function-compiland local-function))
     (aload 0)
     (return-from emit-load-local-function))
+  (let ((cached (cdr (assoc *current-compiland*
+                            (local-function-closure-cache-registers
+                             local-function)))))
+    (when cached
+      ;; A previous reference within this method already wrapped the
+      ;; closure; reuse the cached instance so #'f is EQ to #'f.
+      (aload cached)
+      (return-from emit-load-local-function)))
   (multiple-value-bind
         (class field)
       (local-function-class-and-field local-function)
@@ -2314,6 +2322,31 @@ is registered (or not)."
     (emit-invokestatic +lisp+ "makeCompiledClosure"
                        (list +lisp-object+ +closure-binding-array+)
                        +lisp-object+)))
+
+(defun emit-cache-local-function-closure (local-function)
+  "When *closure-variables* is non-null, eagerly wrap LOCAL-FUNCTION
+into a CompiledClosure and store it in a fresh JVM register associated
+with *current-compiland*.  Subsequent #'f references in this method use
+the cached instance, preserving EQ identity."
+  (when (and *closure-variables*
+             (local-function-references-needed-p local-function)
+             (not (eq *current-compiland*
+                      (local-function-compiland local-function)))
+             (not (assoc *current-compiland*
+                         (local-function-closure-cache-registers
+                          local-function))))
+    (let ((register (allocate-register nil)))
+      (multiple-value-bind (class field)
+          (local-function-class-and-field local-function)
+        (emit-getstatic class field +lisp-object+))
+      (emit-checkcast +lisp-compiled-closure+)
+      (duplicate-closure-array *current-compiland*)
+      (emit-invokestatic +lisp+ "makeCompiledClosure"
+                         (list +lisp-object+ +closure-binding-array+)
+                         +lisp-object+)
+      (astore register)
+      (push (cons *current-compiland* register)
+            (local-function-closure-cache-registers local-function)))))
 
 
 
@@ -4193,6 +4226,8 @@ given a specific common representation.")
     (dolist (local-function local-functions)
       (compile-local-function local-function))
     (dolist (local-function local-functions)
+      (emit-cache-local-function-closure local-function))
+    (dolist (local-function local-functions)
       (push local-function *local-functions*))
     (dolist (special (flet-free-specials block))
       (push special *visible-variables*))
@@ -4212,6 +4247,8 @@ given a specific common representation.")
       (push local-function *local-functions*))
     (dolist (local-function local-functions)
       (compile-local-function local-function))
+    (dolist (local-function local-functions)
+      (emit-cache-local-function-closure local-function))
     (dolist (special (labels-free-specials block))
       (push special *visible-variables*))
     (with-saved-compiler-policy
@@ -7072,17 +7109,26 @@ We need more thought here.
     ((symbolp form)
      (cond
        ((null form)
-        (emit-push-false representation)
+        (cond ((or (null representation) (eq representation :boolean))
+               (emit-push-false representation))
+              (t
+               (emit-push-nil)
+               (convert-representation nil representation)))
         (emit-move-from-stack target representation))
        ((eq form t)
-        (emit-push-true representation)
+        (cond ((or (null representation) (eq representation :boolean))
+               (emit-push-true representation))
+              (t
+               (emit-push-t)
+               (convert-representation nil representation)))
         (emit-move-from-stack target representation))
        ((keywordp form)
-        (ecase representation
-          (:boolean
-           (emit 'iconst_1))
-          ((nil)
-           (emit-load-externalized-object form)))
+        (cond ((eq representation :boolean)
+               (emit 'iconst_1))
+              (t
+               (emit-load-externalized-object form)
+               (when representation
+                 (convert-representation nil representation))))
         (emit-move-from-stack target representation))
        (t
         ;; Shouldn't happen.

--- a/src/org/armedbear/lisp/jvm.lisp
+++ b/src/org/armedbear/lisp/jvm.lisp
@@ -353,7 +353,11 @@ of the compilands being processed (p1: so far; p2: in total).")
                             ;;captured, because the function name is used in a
                             ;;(function ...) form. Obviously implies
                             ;;references-allowed-p.
-  )
+  ;; Alist mapping an enclosing compiland to a JVM register holding a
+  ;; cached closure-wrapped copy of this function. Ensures repeated
+  ;; #'f references within the same method return the same Java object,
+  ;; so #'f is EQ to #'f per ANSI.
+  (closure-cache-registers nil))
 
 (defvar *local-functions* ())
 

--- a/src/org/armedbear/lisp/loop.lisp
+++ b/src/org/armedbear/lisp/loop.lisp
@@ -1884,8 +1884,20 @@ code to be loaded.
                                 start-value
                                 limit-value))
              (setq remaining-tests t)))
-         `(() (,indexv ,step)
-           ,remaining-tests ,step-hack () () ,first-test ,step-hack)))))
+         ;; Step into a temporary and only assign the iteration variable
+         ;; after the end-test passes, so it retains its last valid value
+         ;; for the FINALLY clause (per ANSI loop.1.40-43).
+         (if (and testfn (not (eq remaining-tests t)))
+             (let ((step-tmp (gensym "LOOP-STEP-TMP-")))
+               (loop-make-var step-tmp nil indexv-type nil t)
+               `(() (,step-tmp ,step)
+                 (,testfn ,step-tmp ,endform)
+                 ,(if step-hack
+                      `(,indexv ,step-tmp ,@step-hack)
+                      `(,indexv ,step-tmp))
+                 () () ,first-test ,step-hack))
+             `(() (,indexv ,step)
+               ,remaining-tests ,step-hack () () ,first-test ,step-hack))))))
 
 ;;;; interfaces to the master sequencer
 


### PR DESCRIPTION
# Fix ANSI test failures: LABELS.37–39, LOOP.1.40–43, LOOP.8.10

## Summary

Fixes 8 ANSI Common Lisp conformance test failures across three independent root causes. All 970 tests in the LABELS / LOOP / FLET / FUNCTION categories pass after the change; no regressions observed in a 1,500+ test sample.

## Tests fixed

- `LABELS.37`, `LABELS.38`, `LABELS.39` — `(eq #'f #'f)` within a single `LABELS`/`FLET` body
- `LOOP.1.40`, `LOOP.1.41`, `LOOP.1.42`, `LOOP.1.43` — iteration variable value observed in `FINALLY`
- `LOOP.8.10` — compiler error on `T` as a form under certain representations

## Changes

### 1. `src/org/armedbear/lisp/loop.lisp` — LOOP iteration variable in FINALLY

Per ANSI 6.1.2.1.1, the arithmetic stepping iteration variable must retain its last in-range value when the termination test fails, so `FINALLY` sees the final valid value rather than the first out-of-range step.

In `loop-sequencer`, when an end-test is present the stepped value is now written into a gensym temporary first; the iteration variable is only updated after the end-test passes. When no end-test is present (or it is statically true), the original direct assignment is preserved to avoid unnecessary temporaries.

### 2. `src/org/armedbear/lisp/compiler-pass2.lisp` — `T`/`NIL`/keyword as a form

`compile-form` dispatched `T`, `NIL`, and keywords through a generic path that could produce a stack value in the wrong representation (e.g. unboxed boolean where a `LispObject` was required, or vice versa), breaking compilation of forms such as `(the (or fixnum (eql t)) t)` that LOOP can generate.

The symbol branch now handles `NIL`, `T`, and keywords explicitly: it emits the appropriate boolean or boxed constant for the requested representation and converts as needed before `emit-move-from-stack`.

### 3. `src/org/armedbear/lisp/compiler-pass2.lisp` + `jvm.lisp` — `#'f` identity for local functions

`emit-load-local-function` wrapped each `#'f` reference to a closure-carrying local function by calling `Lisp.makeCompiledClosure`, which allocates a fresh `CompiledClosure` on every call. Two `#'f` references in the same body therefore produced non-`EQ` objects, failing `(eq #'f #'f)`.

Fix: cache the closure-wrapped function once per enclosing compiland.

- `jvm.lisp`: added a `closure-cache-registers` alist slot to the `local-function` defstruct, mapping enclosing compiland → JVM local register holding the wrapped closure.
- `compiler-pass2.lisp`:
  - New `emit-cache-local-function-closure` helper: after a local function is compiled, if it needs closure wrapping, emit the `makeCompiledClosure` call once, store the result in a fresh register, and record the register in the slot.
  - `p2-flet-node` / `p2-labels-node` invoke the helper for each local function.
  - `emit-load-local-function` consults the cache first and reuses the stored register; it falls back to the original allocate-a-fresh-closure path when no cache entry exists (e.g. self-reference or non-closure cases).

This preserves the existing fast path for non-closure local functions (a direct `getstatic` of the compiled function field) while giving closure-carrying locals a stable identity within the enclosing method.

## Verification

- All 8 originally-failing target tests pass (interpreted and compiled).
- 970 tests across LABELS / LOOP / FLET / FUNCTION: 0 failures, 0 regressions.
- 559 / 560 tests across HANDLER / CATCH / BLOCK / TAGBODY / LET / DESTRUCTURING / MULTIPLE-VALUE pass; the one failure (`PPRINT-LOGICAL-BLOCK.17`) is pre-existing and unrelated to these changes.

## Files changed

- `src/org/armedbear/lisp/loop.lisp`
- `src/org/armedbear/lisp/compiler-pass2.lisp`
- `src/org/armedbear/lisp/jvm.lisp`

