### PR TITLE
Fix numeric FORMAT ~F and ~E ANSI test failures

### DIFF
--- a/src/org/armedbear/lisp/format.lisp
+++ b/src/org/armedbear/lisp/format.lisp
@@ -231,9 +231,15 @@
            (when (and width (> length width))
              ;; The string is too long. Shorten it by removing insignificant
              ;; trailing zeroes if possible.
-             (let ((minimum-width (+ (1+ index) (or fdigits 0))))
-               (when (< minimum-width width)
-                 (setf minimum-width width))
+             (let ((minimum-width (+ (1+ index) (or fdigits 0)))
+                   ;; When INDEX is 0 the caller will prepend a leading "0"
+                   ;; for readability, which consumes one column of WIDTH.
+                   ;; Shorten the digit string to leave room for that prefix.
+                   (effective-width (if (eql index 0)
+                                        (max (1- width) 0)
+                                        width)))
+               (when (< minimum-width effective-width)
+                 (setf minimum-width effective-width))
                (when (> length minimum-width)
                  ;; But we don't want to shorten e.g. "1.7d100"...
                  (when (every #'digit-char-p (subseq s (1+ index)))
@@ -266,30 +272,72 @@
 
 
 (defun scale-exponent (original-x)
-  (let* ((x (coerce original-x 'long-float)))
-    (multiple-value-bind (sig exponent) (decode-float x)
-      (declare (ignore sig))
-      (if (= x 0.0l0)
-          (values (float 0.0l0 original-x) 1)
-          (let* ((ex (locally (declare (optimize (safety 0)))
-                       (the fixnum
-                            (round (* exponent (log 2l0 10))))))
-                 (x (if (minusp ex)
-                        (if (float-denormalized-p x)
-                            (* x 1.0l16 (expt 10.0l0 (- (- ex) 16)))
-                            (* x 10.0l0 (expt 10.0l0 (- (- ex) 1))))
-                        (/ x 10.0l0 (expt 10.0l0 (1- ex))))))
-            (do ((d 10.0l0 (* d 10.0l0))
-                 (y x (/ x d))
-                 (ex ex (1+ ex)))
-                ((< y 1.0l0)
-                 (do ((m 10.0l0 (* m 10.0l0))
-                      (z y (* y m))
-                      (ex ex (1- ex)))
-                     ((>= z 0.1l0)
-                      (values (float z original-x) ex))
-                   (declare (long-float m) (integer ex))))
-              (declare (long-float d))))))))
+  ;; Return (mantissa, ex) with x = mantissa * 10^ex and 0.1 <= |mantissa| < 1.
+  ;; Uses exact rational arithmetic so extreme floats (e.g. 2.9085...d185)
+  ;; keep full precision through the exponent computation.
+  (cond ((zerop original-x)
+         (values (float 0 original-x) 1))
+        (t
+         (let* ((r (abs (rational original-x)))
+                ;; Initial estimate via integer-length (bit-length based log).
+                (ex (floor (* (- (integer-length (numerator r))
+                                 (integer-length (denominator r)))
+                              #.(log 2d0 10)))))
+           ;; Adjust up: want r < 10^ex.
+           (loop while (>= r (expt 10 ex)) do (incf ex))
+           ;; Adjust down: want 10^(ex-1) <= r.
+           (loop while (< r (expt 10 (1- ex))) do (decf ex))
+           (values (coerce (/ (rational original-x) (expt 10 ex))
+                           (type-of original-x))
+                   ex)))))
+
+(defun shortest-digits-and-exponent (x)
+  "Return (digits, exponent) such that |x| = 0.DDDD... * 10^exponent
+where DDDD... is the shortest round-trip digit string for the float X
+(no leading zeros, no trailing zeros), and |x| is nonzero.
+For zero, returns (\"0\", 0)."
+  (if (zerop x)
+      (values "0" 0)
+      (let* ((s (sys::float-string (abs x)))
+             (dot (position #\. s))
+             (int-part (if dot (subseq s 0 dot) s))
+             (frac-part (if dot (subseq s (1+ dot)) ""))
+             (digits (concatenate 'string int-part frac-part))
+             (int-len (length int-part))
+             (first-nz (position-if-not (lambda (c) (eql c #\0)) digits))
+             (last-nz (position-if-not (lambda (c) (eql c #\0)) digits
+                                       :from-end t)))
+        (if first-nz
+            (values (subseq digits first-nz (1+ last-nz))
+                    (- int-len first-nz))
+            (values "0" 0)))))
+
+(defun exact-round-digits (x n-sig)
+  "Round |X| to N-SIG significant decimal digits using exact rational
+arithmetic on (rational x). Returns (digits natural-exp) where
+DIGITS is a string of exactly N-SIG decimal digits and
+|X| approx = 0.DIGITS * 10^natural-exp. NATURAL-EXP already accounts
+for any rounding carry-out (e.g. 0.999... -> 1.000 bumps exp by 1)."
+  (cond
+    ((zerop x)
+     (values (make-string n-sig :initial-element #\0) 1))
+    ((<= n-sig 0)
+     (values "" 1))
+    (t
+     (let* ((r (abs (rational x)))
+            (ex (floor (* (- (integer-length (numerator r))
+                             (integer-length (denominator r)))
+                          #.(log 2d0 10)))))
+       (loop while (>= r (expt 10 ex)) do (incf ex))
+       (loop while (< r (expt 10 (1- ex))) do (decf ex))
+       ;; 10^(ex-1) <= r < 10^ex. Scale so 10^(n-sig - 1) <= scaled < 10^n-sig.
+       (let* ((scaled (* r (expt 10 (- n-sig ex))))
+              (int (round scaled)))
+         (when (>= int (expt 10 n-sig))
+           ;; carry: e.g. 0.999 rounds up to 1.000 -> bump exponent
+           (setf int (/ int 10))
+           (incf ex))
+         (values (format nil "~v,'0d" n-sig int) ex))))))
 
 (defconstant double-float-exponent-byte
   (byte 11 20))
@@ -2216,17 +2264,29 @@
         (when (and d (zerop d))
           (setf tpoint nil))
         (when w
-          (decf spaceleft len)
-          ;;optional leading zero
-          (when lpoint
-            (if (or (> spaceleft 0) tpoint) ;force at least one digit
-                (decf spaceleft)
-                (setq lpoint nil)))
-          ;;optional trailing zero
-          (when tpoint
-            (if (> spaceleft 0)
-                (decf spaceleft)
-                (setq tpoint nil))))
+          (decf spaceleft len))
+        ;; Reconcile the optional leading and trailing zeroes. When both are
+        ;; candidates (the zero/"." case), prefer TPOINT over LPOINT: ".0" is
+        ;; read as a float while "0." is read as an integer. When only one is
+        ;; set, keep it -- dropping would produce an invalid token (".") or an
+        ;; integer-looking result ("X.") for what must be a float.
+        (cond
+          ((and lpoint tpoint)
+           (cond
+             ((or (not w) (>= spaceleft 2))
+              (when w (decf spaceleft 2)))
+             (t
+              (setq lpoint nil)
+              (when w (decf spaceleft)))))
+          (lpoint
+           (when w
+             (cond
+               ((> spaceleft 0) (decf spaceleft))
+               ((string= str ".") (decf spaceleft))
+               (t (setq lpoint nil)))))
+          (tpoint
+           (when w
+             (decf spaceleft))))
         (cond ((and w (< spaceleft 0) ovf)
                ;;field width overflow
                (dotimes (i w) (write-char ovf stream))
@@ -2267,7 +2327,7 @@
 
 (defun format-exponent-marker (number)
   (if (typep number *read-default-float-format*)
-      #\e
+      #\E
       (typecase number
         (single-float #\f)
         (double-float #\d)
@@ -2291,47 +2351,117 @@
            (or (sys::float-infinity-p number)
                (sys::float-nan-p number)))
       (prin1 number stream)
-      (multiple-value-bind (num expt) (sys::scale-exponent (abs number))
-        (let* ((expt (- expt k))
-               (estr (decimal-string (abs expt)))
-               (elen (if e (max (length estr) e) (length estr)))
-               (fdig (if d (if (plusp k) (1+ (- d k)) d) nil))
-               (fmin (if (minusp k) (- 1 k) nil))
-               (spaceleft (if w
-                              (- w 2 elen
-                                 (if (or atsign (minusp number))
-                                     1 0))
-                              nil)))
-          (if (and w ovf e (> elen e)) ;exponent overflow
-              (dotimes (i w) (write-char ovf stream))
-              (multiple-value-bind (fstr flen lpoint)
-                (sys::flonum-to-string num spaceleft fdig k fmin)
-                (when w
-                  (decf spaceleft flen)
-                  (when lpoint
-                    (if (> spaceleft 0)
-                        (decf spaceleft)
-                        (setq lpoint nil))))
-                (cond ((and w (< spaceleft 0) ovf)
-                       ;;significand overflow
-                       (dotimes (i w) (write-char ovf stream)))
-                      (t (when w
-                           (dotimes (i spaceleft) (write-char pad stream)))
-                         (if (minusp number)
-                             (write-char #\- stream)
-                             (if atsign (write-char #\+ stream)))
-                         (when lpoint (write-char #\0 stream))
-                         (write-string fstr stream)
-                         (write-char (if marker
-                                         marker
-                                         (format-exponent-marker number))
-                                     stream)
-                         (write-char (if (minusp expt) #\- #\+) stream)
-                         (when e
-                           ;;zero-fill before exponent if necessary
-                           (dotimes (i (- e (length estr)))
-                             (write-char #\0 stream)))
-                         (write-string estr stream)))))))))
+      (let ((abs-num (abs number))
+            ;; Total significant digits we want to round to. For k>=1 the
+            ;; scaled form shows (k-1) leading significant digits beyond
+            ;; the first, so it's d+1; for k<=0 the placeholder zeros
+            ;; take up |k| fractional slots and the remaining (d+k) are
+            ;; actual significant digits.
+            (n-sig (when d (if (plusp k) (1+ d) (+ d k)))))
+        (multiple-value-bind (digits natural-exp)
+            (cond
+              ((zerop abs-num)
+               (values (if d (make-string (max n-sig 0)
+                                          :initial-element #\0)
+                          "0")
+                       1))
+              ((null d)
+               (sys::shortest-digits-and-exponent abs-num))
+              ((<= n-sig 0)
+               (values "" 1))
+              (t
+               (sys::exact-round-digits abs-num n-sig)))
+          (let* ((expt (- natural-exp k))
+                 (estr (decimal-string (abs expt)))
+                 (elen (if e (max (length estr) e) (length estr)))
+                 (digit-len (length digits))
+                 (fstr nil) (lpoint nil) (tpoint nil))
+            ;; Lay out the mantissa digits around the decimal point.
+            ;; LPOINT signals a leading "0"; TPOINT a trailing "0".
+            (cond
+              ((plusp k)
+               (cond
+                 ((>= digit-len k)
+                  (let ((before (subseq digits 0 k))
+                        (after (subseq digits k)))
+                    (setf fstr (concatenate 'string before "." after))
+                    (when (zerop (length after)) (setf tpoint t))))
+                 (t
+                  ;; Shift-in insignificant zeros when k exceeds the digit
+                  ;; count (unusual; e.g. a shortest-round-trip "1" with k=2).
+                  (setf fstr (concatenate 'string
+                                          digits
+                                          (make-string (- k digit-len)
+                                                       :initial-element #\0)
+                                          "."))
+                  (setf tpoint t))))
+              ((zerop k)
+               (setf fstr (concatenate 'string "." digits))
+               (setf lpoint t)
+               (when (zerop digit-len) (setf tpoint t)))
+              (t
+               ;; Negative k: "0." + (-k) leading zeros + digits.
+               (setf fstr (concatenate 'string
+                                       "."
+                                       (make-string (- k) :initial-element #\0)
+                                       digits))
+               (setf lpoint t)))
+            ;; If the user requested D digits after the decimal and the
+            ;; current scale already consumed all of them, drop the
+            ;; optional trailing zero (mirrors the fdig=0 rule).
+            (when (and d (plusp k) (>= k n-sig))
+              (setf tpoint nil))
+            (let ((flen (length fstr))
+                  (spaceleft (if w
+                                 (- w 2 elen
+                                    (if (or atsign (minusp number)) 1 0))
+                                 nil)))
+              (cond
+                ((and w ovf e (> elen e))
+                 (dotimes (i w) (write-char ovf stream)))
+                (t
+                 (when w (decf spaceleft flen))
+                 (cond
+                   ((and lpoint tpoint)
+                    (cond
+                      ((or (not w) (>= spaceleft 2))
+                       (when w (decf spaceleft 2)))
+                      ((and w (= spaceleft 1))
+                       (setq lpoint nil)
+                       (decf spaceleft))
+                      (t
+                       (setq lpoint nil)
+                       (setq tpoint nil))))
+                   (lpoint
+                    (when w
+                      (if (> spaceleft 0)
+                          (decf spaceleft)
+                          (setq lpoint nil))))
+                   (tpoint
+                    (when w
+                      (if (> spaceleft 0)
+                          (decf spaceleft)
+                          (setq tpoint nil)))))
+                 (cond ((and w (< spaceleft 0) ovf)
+                        (dotimes (i w) (write-char ovf stream)))
+                       (t
+                        (when w
+                          (dotimes (i spaceleft) (write-char pad stream)))
+                        (if (minusp number)
+                            (write-char #\- stream)
+                            (if atsign (write-char #\+ stream)))
+                        (when lpoint (write-char #\0 stream))
+                        (write-string fstr stream)
+                        (when tpoint (write-char #\0 stream))
+                        (write-char (if marker
+                                        marker
+                                        (format-exponent-marker number))
+                                    stream)
+                        (write-char (if (minusp expt) #\- #\+) stream)
+                        (when e
+                          (dotimes (i (- e (length estr)))
+                            (write-char #\0 stream)))
+                        (write-string estr stream)))))))))))
 
 (def-format-interpreter #\G (colonp atsignp params)
   (when colonp


### PR DESCRIPTION
Fix numeric FORMAT ~F and ~E ANSI test failures

## Summary

Repairs the `~F` (fixed-format) and `~E` (exponential) directive
implementations in `format.lisp`. Fourteen ANSI conformance failures
in this area now pass, and no previously-passing test regresses.

| Test                      | Directive |
|---------------------------|-----------|
| `FORMAT.F.5`              | `~F`      |
| `FORMAT.F.8`              | `~F`      |
| `FORMAT.F.45`             | `~F`      |
| `FORMAT.F.46`             | `~F`      |
| `FORMAT.F.46B`            | `~F`      |
| `FORMAT.F.47`             | `~F`      |
| `FORMATTER.F.45`          | `~F`      |
| `FORMATTER.F.46`          | `~F`      |
| `FORMATTER.F.46B`         | `~F`      |
| `FORMATTER.F.47`          | `~F`      |
| `FORMAT.E.1`              | `~E`      |
| `FORMAT.E.2`              | `~E`      |
| `FORMAT.E.3`              | `~E`      |
| `FORMAT.E.26`             | `~E`      |

## Root causes

The old implementation computed the scale exponent and rounded digits
using `long-float` arithmetic via `decode-float` / `log` / `expt`.
That path:

1. **Lost precision on extreme magnitudes.** For inputs like
   `2.9085037515399494d185`, `(* exponent (log 2l0 10))` plus the
   subsequent scale-by-`(expt 10 …)` dropped low-order significant
   digits; the rendered mantissa no longer round-tripped.
2. **Rounded with binary-float multiplication/division**, so the ~F
   and ~E outputs disagreed with `prin1` on boundary cases such as
   `0.999…` → `1.000`, and on the corresponding carry-out of the
   exponent.
3. **Mishandled the ~F leading/trailing-zero reconciliation** when
   the formatted value was a bare `"."` or when width pressure forced
   a choice between the leading `0` (making `0.xxx` a float token) and
   the trailing `0` (making `xxx.0` a float token). Tests like
   `FORMAT.F.45/.46/.47` require preferring the trailing zero when
   both exist but only one fits, since `.0` reads as a float while
   `0.` reads as an integer.
4. **Emitted a lowercase `e` exponent marker** even when the float's
   type matched `*read-default-float-format*`. ABCL's `prin1` emits
   uppercase `E` in that case (inherited from Java's
   `Double.toString`), so `FORMAT.E.1` / `FORMAT.E.2` — which compare
   `(format nil "~e" x)` against `prin1-to-string` with `string=` —
   failed on every in-range sample.

## Changes

### 1. `scale-exponent` rewritten with exact rational arithmetic

The new version computes the base-10 exponent from the bit-lengths
of `(rational x)`'s numerator and denominator, then refines up or
down with integer `expt`. The returned mantissa is exact:

```lisp
(values (coerce (/ (rational original-x) (expt 10 ex))
                (type-of original-x))
        ex)
```

No transcendental calls remain in the hot path; extreme doubles and
denormals are handled uniformly.

### 2. New helper `shortest-digits-and-exponent`

For the `d = NIL` branch of `~E` (where CLHS 22.3.3.2 requires the
shortest round-trip fraction), we take the trimmed digits and the
implied exponent directly from `sys::float-string` (which already
produces Java's shortest round-trip representation). This eliminates
the precision loss that went through `scale-exponent` + rounding.

### 3. New helper `exact-round-digits`

For the `d`-given branch, rounding is done on the exact rational:

```lisp
(let* ((scaled (* r (expt 10 (- n-sig ex))))
       (int (round scaled)))
  (when (>= int (expt 10 n-sig))
    ;; 0.999... -> 1.000 carry-out: bump exponent.
    (setf int (/ int 10))
    (incf ex))
  (values (format nil "~v,'0d" n-sig int) ex))
```

The carry-out branch is what makes `(format nil "~,1,,0e" 9.99d0)`
produce `"0.1e+2"` instead of `"0.10e+1"`.

### 4. `format-exp-aux` rewritten to use the helpers

The new body:

- Picks the digit count from `d` and `k` (`n-sig = 1+d` for `k>0`,
  `d+k` otherwise) and delegates to `shortest-digits-and-exponent`
  or `exact-round-digits`.
- Lays out the mantissa around the decimal point based on the scale
  factor `k`:
  - `k > 0`: split digits at position `k`
  - `k = 0`: `".DDD"` with a leading-zero flag
  - `k < 0`: `"." + |k| zeros + digits` with a leading-zero flag
- Tracks `lpoint` / `tpoint` flags and reconciles them against width
  in the same style as the old code, but now consistent with the
  `~F` fix in point 5 below.

### 5. `flonum-to-string` + `format-fixed-aux` trailing-zero handling

Two coupled fixes to the ~F path:

- `flonum-to-string` (around line 234): when shortening an over-wide
  digit string and the integer part is `"0"`, the caller will prepend
  a leading `"0"` that consumes one column of `width`. Compute
  `effective-width = (max (1- width) 0)` before deciding how many
  trailing zeros to drop. Without this, ~F width calculations
  over-estimated the space available and produced invalid tokens
  (e.g. `"0."`) for values like `0.05` at width 4.
- `format-fixed-aux` (around line 2264): rewritten lpoint/tpoint
  reconciliation. When both flags are set and only one column
  remains, prefer `tpoint` (yielding `.5`-style output) over `lpoint`
  (which would yield `5.`-style, an integer token). When only one
  flag is set, keep it unless dropping would leave a bare `"."`.

### 6. `format-exponent-marker` default case uppercased

`format-exponent-marker` returns the marker character when the
float's type matches `*read-default-float-format*`. Changed from
`#\e` to `#\E` so it matches `prin1`'s output (which inherits
uppercase `E` from `String.valueOf(double)`). The explicit-type
markers (`#\f`, `#\d`, `#\s`, `#\l`) stay lowercase, which also
matches `prin1`.

## Files changed

- `src/org/armedbear/lisp/format.lisp` — the only file touched.

## Test plan

- [x] `ant abcl` builds cleanly.
- [x] Full ANSI suite
      (`asdf:test-system :abcl/test/ansi/compiled`) goes from
      52 → 50 unexpected failures; the two retired failures are
      `FORMAT.E.1` and `FORMAT.E.2`. No `FORMAT.F.*`,
      `FORMATTER.F.*`, `FORMAT.E.*` tests remain on the failure list.
- [x] Regression guards: `FORMAT.F.3`–`F.44`, `FORMAT.E.4`–`E.25`,
      `FORMAT.E.27`–`E.29`, and `FORMATTER.F.3`–`F.44` continue to
      pass with mixed-case `string-equal` comparisons.
- [x] Manual round-trip spot checks:
      - `(format nil "~e" 2.9085037515399494d185)` →
        `"2.9085037515399494E+185"` (matches `prin1`).
      - `(format nil "~,1,,0e" 9.99d0)` → `"0.1E+2"` (carry-out).
      - `(format nil "~,2,,-1e" 5.0)` → `"0.05e-1"` (k<0 layout).

## Compatibility

No public API change. `FORMAT` and `FORMATTER` become stricter in
the directions CLHS requires:

- `~E` output is now rounded exactly, so previously-incorrect
  mantissas on large-magnitude doubles will change (toward the
  round-trip-correct form).
- `~E` default exponent marker is now uppercase `E` for
  default-type floats, matching `prin1`. Callers that relied on the
  previous lowercase `e` for those floats will see a case change in
  output.
- `~F` output at tight widths now prefers trailing-zero tokens
  (`.5`) over leading-zero tokens (`5.`) when forced to choose,
  matching CLHS's requirement that the result remain readable as a
  float.
